### PR TITLE
Removed double quotes from "backstore_max_unmap_lba_count" lrbd property

### DIFF
--- a/xml/deployment_iscsi.xml
+++ b/xml/deployment_iscsi.xml
@@ -787,7 +787,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>"backstore_max_unmap_lba_count":</term>
+     <term>backstore_max_unmap_lba_count:</term>
      <listitem>
       <para>
        Maximum number of LBA for UNMAP.


### PR DESCRIPTION
This PR removes double quotes from "backstore_max_unmap_lba_count" property for consistency with other lrbd properties in this documentation.

Signed-off-by: Ricardo Marques <rimarques@suse.com>