### PR TITLE
Removed duplicated "tpg_login_timeout" property on lrbd example

### DIFF
--- a/xml/deployment_iscsi.xml
+++ b/xml/deployment_iscsi.xml
@@ -859,7 +859,6 @@
 {
     "host": "igw1",
     "target": "iqn.2003-01.org.linux-iscsi.generic.x86:sn.abcdefghijk",
-    "tpg_login_timeout": "10",
     "tpg_default_cmdsn_depth": "64",
     "tpg_default_erl": "0",
     "tpg_login_timeout": "10",


### PR DESCRIPTION
This PR removes a duplicated "tpg_login_timeout" property on lrbd example. This fix has already been applied on [lrbd wiki page](https://github.com/SUSE/lrbd/wiki/Home/_history) (see revision a33e24e)

Signed-off-by: Ricardo Marques <rimarques@suse.com>