### PR TITLE
Added bluestore_ prefix to compression, BSC#1053247

### DIFF
--- a/xml/admin_operating_pools.xml
+++ b/xml/admin_operating_pools.xml
@@ -846,8 +846,8 @@ created pool pool1 snap snapshot1</screen>
    <para>
     Data compression for a pool can be enabled with:
    </para>
-<screen>&prompt.root;<command>ceph</command> osd pool set <replaceable>POOL_NAME</replaceable> compression_algorithm snappy
-&prompt.root;<command>ceph</command> osd pool set <replaceable>POOL_NAME</replaceable> compression_mode aggressive</screen>
+<screen>&prompt.root;<command>ceph</command> osd pool set <replaceable>POOL_NAME</replaceable> bluestore_compression_algorithm snappy
+&prompt.root;<command>ceph</command> osd pool set <replaceable>POOL_NAME</replaceable> bluestore_compression_mode aggressive</screen>
    <para>
     Replace <replaceable>POOL_NAME</replaceable> with the pool for which to
     enable compression.
@@ -861,7 +861,7 @@ created pool pool1 snap snapshot1</screen>
    </para>
    <variablelist>
     <varlistentry>
-     <term>compression_algorithm</term>
+     <term>bluestore_compression_algorithm</term>
      <listitem>
       <para>
        Values: <literal>none</literal>, <literal>zstd</literal>, <literal>snappy</literal>,
@@ -902,7 +902,7 @@ created pool pool1 snap snapshot1</screen>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>compression_mode</term>
+     <term>bluestore_compression_mode</term>
      <listitem>
       <para>
        Value: {<literal>none</literal>, <literal>aggressive</literal>,
@@ -918,7 +918,9 @@ created pool pool1 snap snapshot1</screen>
        <listitem>
         <para>
          <literal>passive</literal>: compress if hinted
-         <literal>COMPRESSIBLE</literal>
+         <literal>COMPRESSIBLE</literal>. For information about how to set
+         the flag, see
+         <link xlink:href="http://docs.ceph.com/docs/doc-12.2.0-major-changes/rados/api/librados/#rados_set_alloc_hint"/>.
         </para>
        </listitem>
        <listitem>
@@ -936,7 +938,7 @@ created pool pool1 snap snapshot1</screen>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>compression_required_ratio</term>
+     <term>bluestore_compression_required_ratio</term>
      <listitem>
       <para>
        Value: Double, Ratio = SIZE_COMPRESSED / SIZE_ORIGINAL. Default:
@@ -949,7 +951,7 @@ created pool pool1 snap snapshot1</screen>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>compression_max_blob_size</term>
+     <term>bluestore_compression_min_blob_size</term>
      <listitem>
       <para>
        Value: Unsigned Integer, size in bytes. Default: <literal>0</literal>
@@ -960,13 +962,57 @@ created pool pool1 snap snapshot1</screen>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>compression_min_blob_size</term>
+     <term>bluestore_compression_max_blob_size</term>
      <listitem>
       <para>
        Value: Unsigned Integer, size in bytes. Default: <literal>0</literal>
       </para>
       <para>
        Maximum size of objects that are compressed.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>bluestore_compression_min_blob_size_ssd</term>
+     <listitem>
+      <para>
+       Value: Unsigned Integer, size in bytes. Default: <literal>8K</literal>
+      </para>
+      <para>
+       Minimum size of objects that are compressed and stored on solid-state drive.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>bluestore_compression_max_blob_size_ssd</term>
+     <listitem>
+      <para>
+       Value: Unsigned Integer, size in bytes. Default: <literal>64K</literal>
+      </para>
+      <para>
+       Maximum size of objects that are compressed and stored on solid-state drive.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>bluestore_compression_min_blob_size_hdd</term>
+     <listitem>
+      <para>
+       Value: Unsigned Integer, size in bytes. Default: <literal>128K</literal>
+      </para>
+      <para>
+       Minimum size of objects that are compressed and stored on hard disk drives.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>bluestore_compression_max_blob_size_hdd</term>
+     <listitem>
+      <para>
+       Value: Unsigned Integer, size in bytes. Default: <literal>512K</literal>
+      </para>
+      <para>
+       Maximum size of objects that are compressed and stored on hard disk drives.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Only bluestore_* parameters are currently documented. Avoid confusion with other compression settings, precedence, etc.