### PR TITLE
Move tcmu-runner service status check to installation section

### DIFF
--- a/xml/deployment_iscsi.xml
+++ b/xml/deployment_iscsi.xml
@@ -916,6 +916,16 @@
     with the 'non-fb' version of the <systemitem>targetcli</systemitem>
     package.
    </para>
+   <para>
+    Confirm that the <systemitem>tcmu-runner</systemitem> &systemd; service is
+    running:
+   </para>
+<screen>&prompt.root;systemctl enable tcmu-runner
+tcmu-gw:~ # systemctl status tcmu-runner
+● tcmu-runner.service - LIO Userspace-passthrough daemon
+  Loaded: loaded (/usr/lib/systemd/system/tcmu-runner.service; static; vendor
+  preset: disabled)
+    Active: active (running) since ...</screen>
   </sect2>
 
   <sect2 xml:id="iscsi.tcmu.depl">
@@ -980,16 +990,6 @@ Created LUN 0-&gt;0 mapping in node ACL iqn.1998-01.com.vmware:esxi-872c4888</sc
 Global pref auto_save_on_exit=true
 Last 10 configs saved in /etc/target/backup.
 Configuration saved to /etc/target/saveconfig.json</screen>
-   <para>
-    Confirm that the <systemitem>tcmu-runner</systemitem> &systemd; service is
-    running:
-   </para>
-<screen>&prompt.root;systemctl enable tcmu-runner
-tcmu-gw:~ # systemctl status tcmu-runner
-● tcmu-runner.service - LIO Userspace-passthrough daemon
-  Loaded: loaded (/usr/lib/systemd/system/tcmu-runner.service; static; vendor
-  preset: disabled)
-    Active: active (running) since ...</screen>
   </sect2>
 
   <sect2 xml:id="iscsi.tcmu.use">


### PR DESCRIPTION
If the tcmu-runner service is not running, the first step described on "**9.5.2 Configuration and Deployment**" will fail because tcmu-runner RBD handler requires this service to be running.

For this reason, this PR moves the service status check from the bottom of the section "**9.5.2 Configuration and Deployment**" to the bottom of "**9.5.1 Installation**" section.

Signed-off-by: Ricardo Marques <rimarques@suse.com>