### PR TITLE
Change Removing OSD

### DIFF
--- a/xml/admin_saltcluster.xml
+++ b/xml/admin_saltcluster.xml
@@ -312,7 +312,7 @@ role-rgw/cluster/rgw1*.sls</screen>
   <para>
    A &osd; can be removed from the cluster by running the following command:
   </para>
-<screen>&prompt.smaster;salt-run disengage.safety
+<screen>&prompt.smaster;<command>salt-run</command> disengage.safety
 &prompt.smaster;<command>salt-run</command> remove.osd <replaceable>OSD_ID</replaceable></screen>
 
 <para>

--- a/xml/admin_saltcluster.xml
+++ b/xml/admin_saltcluster.xml
@@ -316,7 +316,9 @@ role-rgw/cluster/rgw1*.sls</screen>
 &prompt.smaster;<command>salt-run</command> remove.osd <replaceable>OSD_ID</replaceable></screen>
 
 <para>
- OSD_ID has to be the number of OSD, not using the term <literal>osd</literal> itself.
+ <replaceable>OSD_ID</replaceable> has to be the number of the OSD without
+ the term <literal>osd</literal>. For example, from <literal>osd.3</literal>
+ only use the digit <literal>3</literal>.
 </para>
 
 


### PR DESCRIPTION
* To remove an OSD, DeepSea safety has to be disengaged
* The remove needs the OSD_ID in digits without the leading "osd."