### PR TITLE
Clarify cross protocol access warning, fate#326335

### DIFF
--- a/xml/deployment_cifs.xml
+++ b/xml/deployment_cifs.xml
@@ -26,11 +26,12 @@
   shares can be used with Windows* clients.
  </para>
  <warning>
-  <title>Do Not Export a File System via NFS and SAMBA Simultaneously</title>
+  <title>Cross Protocol Access</title>
   <para>
-   If you export the same file system via NFS and SAMBA at the same time, you
-   risk data corruption on the exported file system as the cross protocol file
-   locking is not implemented.
+   Native &cephfs; and NFS clients are not restricted by file locks obtained
+   via Samba, and vice-versa. Applications that rely on cross protocol file
+   locking may experience data corruption if &cephfs; backed Samba share paths
+   are accessed via other means.
   </para>
  </warning>
  <sect1 xml:id="sec.ses.cifs.example">

--- a/xml/deployment_ganesha.xml
+++ b/xml/deployment_ganesha.xml
@@ -26,11 +26,12 @@
   or &cephfs;.
  </para>
  <warning>
-  <title>Do Not Export a File System via NFS and SAMBA Simultaneously</title>
+  <title>Cross Protocol Access</title>
   <para>
-   If you export the same file system via NFS and SAMBA at the same time, you
-   risk data corruption on the exported file system as the cross protocol file
-   locking is not implemented.
+   Native &cephfs; and NFS clients are not restricted by file locks obtained
+   via Samba, and vice-versa. Applications that rely on cross protocol file
+   locking may experience data corruption if &cephfs; backed Samba share paths
+   are accessed via other means.
   </para>
  </warning>
  <sect1 xml:id="sec.as.ganesha.preparation">


### PR DESCRIPTION
- "Samba" instead of "SAMBA".
- The warning applies to native CephFS clients as well as Samba and NFS.

Signed-off-by: David Disseldorp <ddiss@suse.de>