### PR TITLE
Typo when accepting salt-key

### DIFF
--- a/xml/admin_saltcluster.xml
+++ b/xml/admin_saltcluster.xml
@@ -95,7 +95,7 @@
     <para>
      On the &smaster;, accept the salt key of the new node:
     </para>
-<screen>&prompt.smaster;salt-key --a <replaceable>NEW_NODE_KEY</replaceable></screen>
+<screen>&prompt.smaster;salt-key --accept <replaceable>NEW_NODE_KEY</replaceable></screen>
    </step>
    <step>
     <para>


### PR DESCRIPTION
When accepting keys with salt-key it is either `salt-key -a` or `salt-key --accept`
The document said `salt-key --a` and that throws a `salt-key: error: ambiguous option: --a`

I do think the long options are better suitable for documentation.