### PR TITLE
RBD 'exclusive-lock' and 'stripingv2' are supported by iSCSI

### DIFF
--- a/xml/admin_rbd.xml
+++ b/xml/admin_rbd.xml
@@ -1379,8 +1379,7 @@ rbd_default_features = layering,fast-diff
    <title>Features not Supported by &iscsi;</title>
    <para>
     RBD images with the following features will not be supported by &iscsi;:
-    <option>deep-flatten</option>, <option>striping</option>,
-    <option>exclusive-lock</option>, <option>object-map</option>,
+    <option>deep-flatten</option>, <option>object-map</option>,
     <option>journaling</option>, <option>fast-diff</option>
    </para>
   </note>


### PR DESCRIPTION
Signed-off-by: Ricardo Marques <rimarques@suse.com>