### PR TITLE
Remove GPT partition table step

### DIFF
--- a/xml/admin_install_salt.xml
+++ b/xml/admin_install_salt.xml
@@ -648,15 +648,7 @@ done</screen>
      </step>
      <step>
       <para>
-       Create a new GPT partition table:
-      </para>
-<screen>
-&prompt.root;sgdisk -Z --clear -g /dev/sdX
-</screen>
-     </step>
-     <step>
-      <para>
-       Verify the result with:
+       Verify drive is empty (with no GPT structures) using:
       </para>
 <screen>
 &prompt.root;parted -s /dev/sdX print free


### PR DESCRIPTION
Disks with GPT partition tables cannot be used with ceph-volume.