### PR TITLE
Prometheus Alertmanager SNMP trap receiver docu

### DIFF
--- a/xml/admin_operating_monitor.xml
+++ b/xml/admin_operating_monitor.xml
@@ -2893,6 +2893,11 @@ url: <replaceable>STRING</replaceable>
         Telegram bot (https://github.com/inCaller/prometheus_bot)
        </para>
       </listitem>
+      <listitem>
+       <para>
+        SNMP trap (https://github.com/SUSE/prometheus-webhook-snmp)
+       </para>
+      </listitem>
      </itemizedlist>
     </example>
     <example>
@@ -3058,6 +3063,40 @@ ALERTS{alertname="<replaceable>ALERT_NAME</replaceable>", alertstate="pending|fi
       </listitem>
      </itemizedlist>
     </sect4>
+   </sect3>
+   <sect3>
+    <title>SNMP Trap Receiver</title>
+    <para>
+     If you want to get notified about &prometheus; alerts via SNMP traps,
+     then you can install the &prometheus; Alertmanager SNMP trap receiver
+     via &deepsea;. To do so you need to enable it in the Pillar under the
+     <option>monitoring:alertmanager_receiver_snmp:enabled</option> key.
+     The configuration of the receiver must be set under the
+     <option>monitoring:alertmanager_receiver_snmp:config</option> key.
+     &deepsea; Stage 2 or the <command>salt <replaceable>SALT_MASTER</replaceable>
+     state.apply ceph.monitoring.alertmanager</command> command will install
+     and configure the receiver in the appropriate location.
+    </para>
+    <example>
+     <title>SNMP Trap Configuration</title>
+<screen>
+monitoring:
+  alertmanager:
+    receiver:
+      snmp:
+        enabled: True
+        config:
+          host: localhost
+          port: 9099
+          snmp_host: snmp.foo-bar.com
+          snmp_community: private
+          metrics: True
+</screen>
+     <para>
+      Refer to the receiver manual at <link xlink:href="https://github.com/SUSE/prometheus-webhook-snmp#global-configuration-file" />.
+      for more details about the configuration options.
+     </para>
+    </example>
    </sect3>
   </sect2>
  </sect1>


### PR DESCRIPTION
Add documentation how to use install and configure the Prometheus Alertmanager SNMP trap receiver (https://github.com/SUSE/prometheus-webhook-snmp).

Signed-off-by: Volker Theile <vtheile@suse.com>