### PR TITLE
Remove /dev from disk device names

### DIFF
--- a/xml/admin_ceph_tips.xml
+++ b/xml/admin_ceph_tips.xml
@@ -1013,7 +1013,7 @@ disk_led:
   <note>
   <title>Device naming</title>
   <para>
-   The device name used in the salt-run command must match the name
+   The device name used in the <command>salt-run</command> command needs to match the name
    recognized by salt. The following command can be used to display
    these names:
   </para>

--- a/xml/admin_ceph_tips.xml
+++ b/xml/admin_ceph_tips.xml
@@ -1010,6 +1010,17 @@ disk_led:
 &prompt.root;salt-run disk_led.device srv16.ceph sdd fault on
 &prompt.root;salt-run disk_led.device srv16.ceph sdd fault off</screen>
 
+  <note>
+  <title>Device naming</title>
+  <para>
+   The device name used in the salt-run command must match the name
+   recognized by salt. The following command can be used to display
+   these names:
+  </para>
+<screen>&prompt.smaster;salt '<replaceable>minion_name</replaceable>' grains.get disks
+</screen>
+  </note>
+
   <para>
    In many environments, the <filename>/srv/pillar/ceph/disk_led.sls</filename>
    configuration will require changes in order to adjust the LED lights for

--- a/xml/admin_ceph_tips.xml
+++ b/xml/admin_ceph_tips.xml
@@ -1005,10 +1005,10 @@ disk_led:
    run the following:
   </para>
 
-<screen>&prompt.root;salt-run disk_led.device srv16.ceph /dev/sdd ident on
-&prompt.root;salt-run disk_led.device srv16.ceph /dev/sdd ident off
-&prompt.root;salt-run disk_led.device srv16.ceph /dev/sdd fault on
-&prompt.root;salt-run disk_led.device srv16.ceph /dev/sdd fault off</screen>
+<screen>&prompt.root;salt-run disk_led.device srv16.ceph sdd ident on
+&prompt.root;salt-run disk_led.device srv16.ceph sdd ident off
+&prompt.root;salt-run disk_led.device srv16.ceph sdd fault on
+&prompt.root;salt-run disk_led.device srv16.ceph sdd fault off</screen>
 
   <para>
    In many environments, the <filename>/srv/pillar/ceph/disk_led.sls</filename>


### PR DESCRIPTION
As per the discussion on ses-users, /dev/sdd should be changed to just sdd.