### PR TITLE
samba: don't document NT4 domain joins

### DIFF
--- a/xml/deployment_cifs.xml
+++ b/xml/deployment_cifs.xml
@@ -814,14 +814,6 @@ Enter administrator's password: <replaceable>PASSWORD</replaceable>
 Using short domain name -- <replaceable>DOMAIN</replaceable>
 Joined 'example-host' to dns domain 'DOMAIN.example.com'
 </screen>
-   <para>
-    To join the host to an NT4 domain, run:
-   </para>
-<screen>
-&prompt.root;net rpc join -U administrator
-Enter administrator's password: <replaceable>PASSWORD</replaceable>
-Joined domain DOMAIN.
-</screen>
   </sect2>
 
   <sect2 xml:id="cephfs.ad.nss">


### PR DESCRIPTION
NT4 style domains are ancient. Only AD domain joins should be covered.

Signed-off-by: David Disseldorp <ddiss@suse.de>