### PR TITLE
Adding telemetry module docs (BSC#1150907)

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -1594,6 +1594,11 @@ role-storage/cluster/*.sls
     </para>
 <screen>&prompt.smaster;salt-run state.orch ceph.restart.rgw.force</screen>
    </step>
+   <step>
+     <para>Before you continue, we strongly recommend enabling the Ceph
+       telemetry module. For more information, see <xref linkend="mgr-modules-telemetry"/>
+       for information and instructions.</para>
+   </step>
   </procedure>
  </sect1>
  <sect1 xml:id="upgrade-drive-groups">

--- a/xml/admin_install_salt.xml
+++ b/xml/admin_install_salt.xml
@@ -898,6 +898,11 @@ alternative_defaults:
      Depending on the setup, the command may run for several minutes.
     </para>
    </step>
+   <step>
+     <para>Before you continue, we strongly recommend enabling the Ceph
+       telemetry module. For more information, see <xref linkend="mgr-modules-telemetry"/>
+       for information and instructions.</para>
+   </step>
   </procedure>
  </sect1>
  <sect1 xml:id="deepsea-cli">

--- a/xml/manager_modules.xml
+++ b/xml/manager_modules.xml
@@ -185,4 +185,68 @@
    </tip>
   </sect2>
  </sect1>
+ <sect1 xml:id="mgr-modules-telemetry">
+  <title>Telemetry Module</title>
+  <para>
+    The telemetry plugin sends anonymous data about the cluster, in which it
+    is running, back to the Ceph project.</para>
+  <para>
+    This (opt-in) component contains counters and statistics on how the cluster has been
+    deployed, the version of Ceph, the distribition of the hosts and other
+    parameters which help the project to gain a better understanding of the
+    way Ceph is used. It does not contain any sensitive data like pool names,
+    object names, object contents or hostnames.</para>
+  <para>The purpose of the telemetry module is to provide an automated feedback
+    loop for the developers to help quantify adoption rates, tracking, or
+    pointing out things that need to be better explained or validated during
+    configuration to prevent undesirable outcomes.</para>
+  <note>
+    <para>
+      The Telemetry Module requires the mgr nodes to have the ability to push
+      data over HTTPS to the upstream servers. Ensure your corporate firewalls
+      permit this action.
+    </para>
+  </note>
+  <para>If you would like to read more, or see some of the early findings
+    of using this tool, we recommend reading <link xlink:href="https://ceph.io/community/the-first-telemetry-results-are-in/"/>.
+  </para>
+  <procedure>
+    <step>
+      <para>
+        To enable the telemetry module:
+      </para>
+      <screen>ceph mgr module enable telemetry</screen>
+      <note>
+        <para>
+          This command only enables you to view your data locally. This
+          command does not share your data with the Ceph community.
+        </para>
+      </note>
+    </step>
+    <step>
+      <para>To allow the telemetry module to start sharing data:</para>
+      <screen>ceph telemetry on</screen>
+    </step>
+    <step>
+      <para>To disable telemetry data sharing:</para>
+      <screen>ceph telemetry off</screen>
+    </step>
+    <step>
+      <para>To generate a JSON report that can be printed:</para>
+      <screen>ceph telemetry show</screen>
+    </step>
+    <step>
+      <para>To add a contact and description to the report:</para>
+      <screen>ceph config set mgr mgr/telemetry/contact ‘John Doe <literal>john.doe@example.com</literal>’
+        ceph config set mgr mgr/telemetry/description ‘My first Ceph cluster’</screen>
+    </step>
+    <step>
+      <para>The module compiles and sends a new report every 24 hours by default.
+      To adjust this interval:</para>
+      <screen>ceph config set mgr mgr/telemetry/interval HOURS</screen>
+    </step>
+  </procedure>
+  <para>For more information on the telemetry modules, see
+    <link xlink:href="https://docs.ceph.com/docs/master/mgr/telemetry/"/>.</para>
+ </sect1>
 </chapter>

--- a/xml/manager_modules.xml
+++ b/xml/manager_modules.xml
@@ -192,9 +192,9 @@
     is running, back to the Ceph project.</para>
   <para>
     This (opt-in) component contains counters and statistics on how the cluster has been
-    deployed, the version of Ceph, the distribition of the hosts and other
+    deployed, the version of &ceph;, the distribition of the hosts and other
     parameters which help the project to gain a better understanding of the
-    way Ceph is used. It does not contain any sensitive data like pool names,
+    way &ceph; is used. It does not contain any sensitive data like pool names,
     object names, object contents or hostnames.</para>
   <para>The purpose of the telemetry module is to provide an automated feedback
     loop for the developers to help quantify adoption rates, tracking, or
@@ -202,51 +202,51 @@
     configuration to prevent undesirable outcomes.</para>
   <note>
     <para>
-      The Telemetry Module requires the mgr nodes to have the ability to push
+      The Telemetry Module requires the &mgr; nodes to have the ability to push
       data over HTTPS to the upstream servers. Ensure your corporate firewalls
       permit this action.
     </para>
   </note>
-  <para>If you would like to read more, or see some of the early findings
+  <!-- <para>If you would like to read more, or see some of the early findings
     of using this tool, we recommend reading <link xlink:href="https://ceph.io/community/the-first-telemetry-results-are-in/"/>.
-  </para>
+  </para> -->
   <procedure>
     <step>
       <para>
         To enable the telemetry module:
       </para>
-      <screen>ceph mgr module enable telemetry</screen>
+      <screen>&prompt.cephuser;ceph mgr module enable telemetry</screen>
       <note>
         <para>
           This command only enables you to view your data locally. This
-          command does not share your data with the Ceph community.
+          command does not share your data with the &ceph; community.
         </para>
       </note>
     </step>
     <step>
       <para>To allow the telemetry module to start sharing data:</para>
-      <screen>ceph telemetry on</screen>
+      <screen>&prompt.cephuser;ceph telemetry on</screen>
     </step>
     <step>
       <para>To disable telemetry data sharing:</para>
-      <screen>ceph telemetry off</screen>
+      <screen>&prompt.cephuser;ceph telemetry off</screen>
     </step>
     <step>
       <para>To generate a JSON report that can be printed:</para>
-      <screen>ceph telemetry show</screen>
+      <screen>&prompt.cephuser;ceph telemetry show</screen>
     </step>
     <step>
       <para>To add a contact and description to the report:</para>
-      <screen>ceph config set mgr mgr/telemetry/contact ‘John Doe <literal>john.doe@example.com</literal>’
+      <screen>&prompt.cephuser;ceph config set mgr mgr/telemetry/contact ‘John Doe <literal>john.doe@example.com</literal>’
         ceph config set mgr mgr/telemetry/description ‘My first Ceph cluster’</screen>
     </step>
     <step>
       <para>The module compiles and sends a new report every 24 hours by default.
       To adjust this interval:</para>
-      <screen>ceph config set mgr mgr/telemetry/interval HOURS</screen>
+      <screen>&prompt.cephuser;ceph config set mgr mgr/telemetry/interval HOURS</screen>
     </step>
   </procedure>
-  <para>For more information on the telemetry modules, see
-    <link xlink:href="https://docs.ceph.com/docs/master/mgr/telemetry/"/>.</para>
+ <!-- <para>For more information on the telemetry modules, see
+    <link xlink:href="https://docs.ceph.com/docs/master/mgr/telemetry/"/>.</para> -->
  </sect1>
 </chapter>


### PR DESCRIPTION
Adding telemetry module docs. Tim Serong (bug reporter)
wanted the docs in the mgr modules section and linked
to the appropriate deploy and upgrade sections.

Backport: SES6