### PR TITLE
Removing Red Hat from copyright and licensing

### DIFF
--- a/xml/copyright_suse_storage_cc.xml
+++ b/xml/copyright_suse_storage_cc.xml
@@ -29,19 +29,15 @@
 <?dbtimestamp format="Y"?>
   &suse; LLC
  </para>
- <para>
+<!-- <para>
   Copyright &copy; 2016, RedHat, Inc, and contributors.
-<!-- Licensed under Creative Commons BY-SA. -->
- </para>
+ </para> -->
  <para>
-  The text of and illustrations in this document are licensed under a Creative
-  Commons Attribution-Share Alike 4.0 International ("CC-BY-SA"). An
-  explanation of CC-BY-SA is available at
+  Except where otherwise noted, this document is licensed under Creative
+  Commons Attribution-Share Alike 4.0 International ("CC-BY-SA"):
   <link xlink:href="http://creativecommons.org/licenses/by-sa/4.0/legalcode"/>.
-  In accordance with CC-BY-SA, if you distribute this document or an adaptation
-  of it, you must provide the URL for the original version.
  </para>
- <para>
+<!-- <para>
   Red Hat, Red Hat Enterprise Linux, the Shadowman logo, JBoss, MetaMatrix,
   Fedora, the Infinity Logo, and RHCE are trademarks of Red Hat, Inc.,
   registered in the United States and other countries. Linux&reg; is the
@@ -50,7 +46,7 @@
   affiliates. XFS&reg; is a trademark of Silicon Graphics International Corp.
   or its subsidiaries in the United States and/or other countries. All other
   trademarks are the property of their respective owners.
- </para>
+ </para> -->
  <para>
   For &suse; trademarks, see
   <link xlink:href="http://www.suse.com/company/legal/"/>. All other


### PR DESCRIPTION
Ensuring documents are only licensed under CC-BY-SA-4.0 and copyright is attributed to SUSE. Previously, copyright was attributed to both Red Hat and SUSE. This also removes the Red Hat license. CC-BY... is the appropriate license used for Ceph upstream.