### PR TITLE
Adding a note to clarify salt-minion fingerprint (BSC#1154346)

### DIFF
--- a/xml/admin_install_salt.xml
+++ b/xml/admin_install_salt.xml
@@ -570,6 +570,12 @@ FAIL_ON_WARNING: False
      Verify each &sminion;'s fingerprint and accept all salt keys on the
      &smaster; if the fingerprints match.
     </para>
+    <note>
+      <para>If the &sminion; fingerprint comes back empty, make sure the &sminion;
+        has a &smaster; configuration and it can communicate with the
+        &smaster;.
+      </para>
+    </note>
     <para>
      View each minion's fingerprint:
     </para>


### PR DESCRIPTION
salt-call --local key.finger only works if the local salt-minion
can talk to a salt master. This note during step 10 clarifies
this.