### PR TITLE
Added salt minion command for btrfs sub-volume creation (BSC#1154435)

### DIFF
--- a/xml/admin_install_salt.xml
+++ b/xml/admin_install_salt.xml
@@ -773,8 +773,17 @@ alternative_defaults:
      before &deepsea; stages. To migrate existing directories or for more
      details, see <xref linkend="storage-tips-ceph-btrfs-subvol"/>.
     </para>
-<screen>&prompt.smaster;salt '<replaceable>MON_NODES</replaceable>' state.apply ceph.subvolume</screen>
-   </step>
+    <para>Apply the following commands to each of the &salt; minions:</para>
+<screen>&prompt.smaster;salt 'MONITOR_NODES' saltutil.sync_all
+&prompt.smaster;salt 'MONITOR_NODES' state.apply ceph.subvolume
+</screen>
+    <note>
+      <para>The &ceph;.subvolume command creates <filename>/var/lib/ceph</filename>
+      as a <filename>@/var/lib/ceph</filename> Btrfs subvolume.
+      </para>
+    </note>
+    <para>The new subvolume is now mounted and <literal>/etc/fstab</literal> is updated.</para>
+  </step>
    <step>
     <para>
      Prepare your cluster. Refer to <xref linkend="deepsea-stage-description"/>


### PR DESCRIPTION
Prior to running DeepSea stage 0, you need to apply the
commands to each of the salt minions that will become ceph
monitors. This PR adds both commands to step 3.