### PR TITLE
Add "run discovery stage command" instruction (BSC#1154437)

### DIFF
--- a/xml/admin_install_salt.xml
+++ b/xml/admin_install_salt.xml
@@ -802,6 +802,7 @@ alternative_defaults:
      <filename>/srv/pillar/ceph/proposals</filename>. The data are stored in
      the YAML format in *.sls or *.yml files.
     </para>
+    <para>Run the following command to trigger the discovery stage:</para>
 <screen>&prompt.smaster;salt-run state.orch ceph.stage.1</screen>
     <para>
      or


### PR DESCRIPTION
The initial step 5 did not clarify that you are required to run
the following commands to initiate the discovery phase. This
addition syncs the instructions with step 7, and makes it clear
to the user they have to run these commands.