### PR TITLE
Adds grafana and prometheus chapter (BSC#1134623)

### DIFF
--- a/xml/admin_prometheus_grafana.xml
+++ b/xml/admin_prometheus_grafana.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="prometheus-grafana">
+<!-- ============================================================== -->
+ <title>&prometheus; and &grafana;</title>
+ <info>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:editurl>https://github.com/SUSE/doc-ses/edit/maintenance/ses5.5/xml/</dm:editurl>
+   <dm:maintainer>tbazant@suse.com</dm:maintainer>
+   <dm:status>editing</dm:status>
+   <dm:deadline/>
+   <dm:priority/>
+   <dm:translation>yes</dm:translation>
+   <dm:languages/>
+   <dm:release>SES 5</dm:release>
+  </dm:docmanager>
+ </info>
+ <sect1 xml:id="new-roles">
+  <title>New Roles</title>
+  <para>
+    &deepsea; uses the &prometheus; and &grafana; roles and deploys the
+    monitoring stack accordingly. This allows for multiple &prometheus;
+    instances for an HA setup. The &prometheus; role also includes the <literal>alertmanager</literal>.
+  </para>
+  <para>
+    There is also code to remove &prometheus; and &grafana; from nodes that do not
+    have the respective roles. If you have a &prometheus; or &grafana; installation
+    that is managed outside of &deepsea; on &deepsea; minions, make sure to add
+    <literal>rescind-[prometheus|grafana|alertmanager]: default-nop</literal> to
+    your pillar, otherwise &deepsea; removes your installation.
+  </para>
+</sect1>
+
+<sect1 xml:id="pillar-variables">
+ <title>Pillar variables</title>
+ <para>
+   The default pillar is available to all nodes by default. Either alter the
+   global configuration in <filename>/srv/pillar/ceph/stack/global.yml</filename> or alter
+   <filename>/srv/pillar/ceph/stack/CLUSTER-NAME/minions/HOST</filename> if a
+   specific minion configuration needs to be altered.
+ </para>
+ <para> The following is an example of the default pillar:</para>
+<screen>
+  monitoring:
+    alertmanager:
+      config: salt://path/to/config
+      additional_flags: ''
+    grafana:
+      ssl_cert: False # not present by default
+      ssl_key: False # not present by default
+    prometheus:
+      additional_flags: ''
+      alert_relabel_config: []
+      rule_files: []
+      scrape_interval:
+        ceph: 10
+        node_exporter: 10
+        prometheus: 10
+        grafana: 10
+      relabel_config:
+        alertmanager: []
+        ceph: []
+        node_exporter: []
+        prometheus: []
+        grafana: []
+      metric_relabel_config:
+        ceph: []
+        node_exporter: []
+        prometheus: []
+        grafana: []
+      target_partition:
+        ceph: '1/1'
+        node_exporter: '1/1'
+        prometheus: '1/1'
+        grafana: '1/1'
+</screen>
+
+ <sect2 xml:id="prometheus">
+  <title>&prometheus;</title>
+  <variablelist>
+    <varlistentry>
+      <term><filename>scrape_interval</filename></term>
+      <listitem>
+        <para>
+          Changes the scrape interval for various scrape target groups
+          (these groups map to exporters that provide data).
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term><filename>target_partition</filename></term>
+      <listitem>
+        <para>
+          For when multiple &prometheus; instances are deployed and you want
+          partition scrape targets and have some instances scrape only part
+          of all exporter instances (currently this is only implemented for
+          <literal>node_exporter</literal> targets).</para>
+        <para>For example, if there are two &prometheus; instances, the
+          available <literal>node_exporter</literal> target should be
+          divided between them.</para>
+        <para>Configure the pillar so that the instance sees
+          <literal>monitoring:prometheus:target_partition:node_exporter:'1/2'</literal> and
+          the other sees <literal>monitoring:prometheus:target_partition:node_exporter:'2/2'</literal>.</para>
+        <para>A &prometheus; instance seeing 0/X in its pillar will remove all
+          scrape targets of that kind.</para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+</sect2>
+
+  <sect2 xml:id="grafana">
+   <title>&grafana;</title>
+   <variablelist>
+     <varlistentry>
+       <term><filename>config</filename></term>
+       <listitem>
+         <para>
+           As the alertmanager configuration contains only user specific configuration,
+           the user needs to provide a alertmanager config in the pillar.
+           The location of the file is in salt's <filename>salt:// file</filename>
+           server url. For example, <filename>srv/salt/ceph/monitoring/alertmanager/files/myconfig.yml</filename>
+           translates to <filename>salt://ceph/monitoring/alertmanager/files/myconfig.yml</filename>
+           as the pillar content. &deepsea; uses this file to deploy.</para>
+         <para>
+           If the pillar variable is not set, &deepsea; only ensures that
+           there is a file. That can either be the default config file installed
+           by the rpm or a user managed file.
+         </para>
+       </listitem>
+     </varlistentry>
+     <varlistentry>
+       <term><filename>additional_flags</filename></term>
+       <listitem>
+         <para>
+           &deepsea; creates the needed <literal>--cluster.peer</literal> flags for a highly
+           available alertmanager setup (if more then one node has the &prometheus;
+           role). If you want to pass additional flags
+           (see <literal>prometheus-alertmanager --help</literal> for available flags), list them
+           as a spaces-separated string in this pillar variable.
+         </para>
+       </listitem>
+     </varlistentry>
+   </variablelist>
+ </sect2>
+</sect1>
+</chapter>

--- a/xml/book_storage_admin.xml
+++ b/xml/book_storage_admin.xml
@@ -53,6 +53,7 @@
  <part xml:id="part-gui">
   <title>Managing Cluster with GUI Tools</title>
   <xi:include href="admin_gui_oa.xml" parse="xml"/>
+  <xi:include href="admin_prometheus_grafana.xml" parse="xml"/>
  </part>
  <part xml:id="part-virt">
   <title>Integration with Virtualization Tools</title>


### PR DESCRIPTION
Currently, the admin guide is missing a section about
the monitoring tools - prometheus and grafana. This commit
adds a section under Part IV and contains information from
the DeepSea wiki: https://github.com/SUSE/DeepSea/wiki/New-Monitoring