### PR TITLE
Remove the <part> around Glossary; revert its title (BSC#1154581)

### DIFF
--- a/xml/book_storage_admin.xml
+++ b/xml/book_storage_admin.xml
@@ -67,9 +67,9 @@
   <xi:include href="admin_ceph_troubleshooting.xml" parse="xml"/>
  </part>
  
- <xi:include href="ses_glossary.xml" parse="xml"/>
  <xi:include href="app_stage1_custom.xml" parse="xml"/>
  <xi:include href="app_alerting.xml" parse="xml"/>
  <xi:include href="maintenance_updates_admin.xml" parse="xml"/>
+ <xi:include href="ses_glossary.xml" parse="xml"/>
  <xi:include href="admin_docupdates.xml" parse="xml"/>
 </book>

--- a/xml/book_storage_admin.xml
+++ b/xml/book_storage_admin.xml
@@ -66,11 +66,8 @@
   <xi:include href="admin_ceph_faqs.xml" parse="xml"/>
   <xi:include href="admin_ceph_troubleshooting.xml" parse="xml"/>
  </part>
- <part xml:id="admin-glossary">
-  <title>Glossary</title>
-  <xi:include href="ses_glossary.xml" parse="xml"/>
- </part>
  
+ <xi:include href="ses_glossary.xml" parse="xml"/>
  <xi:include href="app_stage1_custom.xml" parse="xml"/>
  <xi:include href="app_alerting.xml" parse="xml"/>
  <xi:include href="maintenance_updates_admin.xml" parse="xml"/>

--- a/xml/book_storage_deployment.xml
+++ b/xml/book_storage_deployment.xml
@@ -53,11 +53,7 @@
  </part>
  
  <xi:include href="maintenance_updates_deploy.xml" parse="xml"/>
+ <xi:include href="ses_glossary.xml" parse="xml"/>
  
- <part xml:id="deployment-glossary">
-  <title>Glossary</title>
-  <xi:include href="ses_glossary.xml" parse="xml"/>
- </part>
-
  <xi:include href="deployment_docupdates.xml" parse="xml"/>
 </book>

--- a/xml/ses_glossary.xml
+++ b/xml/ses_glossary.xml
@@ -7,7 +7,7 @@
 <!-- Converted by suse-upgrade version 1.1 -->
 <glossary xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0">
 <!-- === CEPH ====================================================== -->
- <title>Terms Used in this Manual</title>
+ <title>Glossary</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:editurl>https://github.com/SUSE/doc-ses/edit/master/xml/</dm:editurl>


### PR DESCRIPTION
As per the title
Removed the <part>...</part>
Change the title within the glossary itself to "Glossary" -- previously I had changed this to "Terms Used in this Manual" so that the Contents pages did not say:

  Glossary:
   ...  Glossary