### PR TITLE
Added min_size for EC pools (BSC#1153481)

### DIFF
--- a/xml/admin_ceph_erasure.xml
+++ b/xml/admin_ceph_erasure.xml
@@ -154,9 +154,10 @@ ABCDEFGHI</screen>
     <listitem>
      <para>
       the number of data chunks, that is the number of chunks into which the
-      original object is divided. For example if <literal>k = 2</literal> a
+      original object is divided. For example, if <literal>k = 2</literal> a
       10KB object will be divided into <literal>k</literal> objects of 5KB
       each.
+      The default <literal>min_size</literal> on erasure pools is <literal>k + 1</literal>.
      </para>
     </listitem>
    </varlistentry>

--- a/xml/admin_ceph_erasure.xml
+++ b/xml/admin_ceph_erasure.xml
@@ -157,7 +157,7 @@ ABCDEFGHI</screen>
       original object is divided. For example, if <literal>k = 2</literal> a
       10KB object will be divided into <literal>k</literal> objects of 5KB
       each.
-      The default <literal>min_size</literal> on erasure pools is <literal>k + 1</literal>.
+      The default <literal>min_size</literal> on erasure coded pools is <literal>k + 1</literal>.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
The default for min_size on EC pools is k+1.
As changed here: https://github.com/ceph/ceph/pull/8008