### PR TITLE
Updating throttling command for nautilus (BSC#1154602)

### DIFF
--- a/xml/manager_modules.xml
+++ b/xml/manager_modules.xml
@@ -122,10 +122,10 @@
     <para>
      During the process of balancing, the balancer module throttles PG
      movements so that only a configurable fraction of PGs is moved. The
-     default is 5% and you can adjust the fraction to for example 9% by running
+     default is 5% and you can adjust the fraction, to 9% for example, by running
      the following command:
     </para>
-<screen>&prompt.cephuser;ceph config set mgr mgr/balancer/max_misplaced .09</screen>
+<screen>&prompt.cephuser;ceph config set mgr target_max_misplaced_ratio .09</screen>
    </tip>
    <para>
     To create and execute a balancing plan, follow these steps:
@@ -139,7 +139,7 @@
     </step>
     <step>
      <para>
-      Have the balancer create a plan called for example 'great_plan':
+      Create a plan. For example, 'great_plan':
      </para>
 <screen>&prompt.cephuser;ceph balancer optimize great_plan</screen>
     </step>


### PR DESCRIPTION
Updating the tip section "Movable Fraction of Placement Groups (PGs)"
as the command displayed was based on the upstream doc for
mimic. This corrects that command to the nautilus command.