### PR TITLE
Removing "bytes" confusion from '5G' example (BSC#1153582)

### DIFF
--- a/xml/admin_install_salt.xml
+++ b/xml/admin_install_salt.xml
@@ -1493,8 +1493,8 @@ drive_group_default_name:
     drive_spec: <replaceable>DEVICE_SPECIFICATION</replaceable>
   wal_devices:
     drive_spec: <replaceable>DEVICE_SPECIFICATION</replaceable>
-  block_wal_size: '5G'  # (optional)
-  block_db_size: '5G'   # (optional)
+  block_wal_size: '5G'  # (optional, unit suffixes permitted)
+  block_db_size: '5G'   # (optional, unit suffixes permitted)
   osds_per_device: 1   # number of osd daemons per device
   format:              # 'bluestore' or 'filestore' (defaults to 'bluestore')
   encryption:           # 'True' or 'False' (defaults to 'False')

--- a/xml/admin_install_salt.xml
+++ b/xml/admin_install_salt.xml
@@ -1493,8 +1493,8 @@ drive_group_default_name:
     drive_spec: <replaceable>DEVICE_SPECIFICATION</replaceable>
   wal_devices:
     drive_spec: <replaceable>DEVICE_SPECIFICATION</replaceable>
-  block_wal_size: '5G'  # in bytes, you can use shortcuts; optional
-  block_db_size: '5G'   # in bytes, you can use shortcuts; optional
+  block_wal_size: '5G'  # (optional)
+  block_db_size: '5G'   # (optional)
   osds_per_device: 1   # number of osd daemons per device
   format:              # 'bluestore' or 'filestore' (defaults to 'bluestore')
   encryption:           # 'True' or 'False' (defaults to 'False')


### PR DESCRIPTION
The original example confused the reader by mentioning "bytes".
5G is not bytes, and the recommendation follows the example
upstream. See: https://github.com/SUSE/DeepSea/wiki/Drive-Groups#specification