### PR TITLE
Backporting BSC #1135168 fix to SES 5.5

### DIFF
--- a/xml/deployment_cephfs.xml
+++ b/xml/deployment_cephfs.xml
@@ -48,7 +48,7 @@
     <para>
      A minimum of one &mds;. SUSE recommends to deploy several nodes with the
      MDS role. Only one will be 'active' and the rest will be 'passive'.
-     Remember to mention all the MDS nodes in the <command>mount</command>
+     Remember to mention all the MON nodes in the <command>mount</command>
      command when mounting the &cephfs; from a client.
     </para>
    </listitem>


### PR DESCRIPTION
Change "MDS nodes" to "MON nodes" in 11.1  Supported CephFS Scenarios and Guidance §