### PR TITLE
Adding documented support for multiple active MDS daemons (BSC#1154562)

### DIFF
--- a/xml/deployment_cephfs.xml
+++ b/xml/deployment_cephfs.xml
@@ -77,7 +77,7 @@
    </listitem>
    <listitem>
      <para>
-       A minimum of one metadata Server. We recommend to deploying several
+       A minimum of one &mds;. We recommend deploying several
        nodes within the MDS role. By default additional MDS daemons start
        as <literal>standby</literal> daemons, acting as backups for the active MDS.
        Multiple active MDS daemons are also supported

--- a/xml/deployment_cephfs.xml
+++ b/xml/deployment_cephfs.xml
@@ -78,7 +78,7 @@
    <listitem>
      <para>
        A minimum of one &mds;. We recommend deploying several
-       nodes within the MDS role. By default additional MDS daemons start
+       nodes with the MDS role. By default additional MDS daemons start
        as <literal>standby</literal> daemons, acting as backups for the active MDS.
        Multiple active MDS daemons are also supported
        (refer to section <xref linkend="ceph-cephfs-multimds"/>).

--- a/xml/deployment_cephfs.xml
+++ b/xml/deployment_cephfs.xml
@@ -75,6 +75,15 @@
      only be added while the file system is unmounted.
     </para>
    </listitem>
+   <listitem>
+     <para>
+       A minimum of one metadata Server. We recommend to deploying several
+       nodes within the MDS role. By default additional MDS daemons start
+       as <literal>standby</literal> daemons, acting as backups for the active MDS.
+       Multiple active MDS daemons are also supported
+       (refer to section <xref linkend="ceph-cephfs-multimds"/>).
+     </para>
+   </listitem>
   </itemizedlist>
  </sect1>
  <sect1 xml:id="ceph-cephfs-mds">
@@ -813,6 +822,7 @@ e5: 1/1/1 up</screen>
     where <replaceable>rank</replaceable> is the number of an active MDS daemon
     of a file system instance, ranging from 0 to <option>max_mds</option>-1.
    </para>
+   <para>We recommend at least one MDS is left as a standby daemon.</para>
   </sect2>
 
   <sect2 xml:id="ceph-cephfs-multimds-updates">


### PR DESCRIPTION
As of SES5, we support multiple active MDS in CephFS. This
documentation ensures that is up-to-date.

Backport: SES5