### PR TITLE
Adding filestore to bluestore upgrade content (BSC#1141175)

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -1402,7 +1402,7 @@ data:
   <title>OSD Migration to &bluestore;</title>
   <para>
    OSD &bluestore; is a new back end for the OSD daemons. It is the default
-   option since &productname; &productnumber;. Compared to FileStore, which
+   option since &productname; 5. Compared to &filestore;, which
    stores objects as files in an XFS file system, &bluestore; can deliver
    increased performance because it stores objects directly on the underlying
    block device. &bluestore; also enables other features, such as built-in
@@ -1412,20 +1412,20 @@ data:
    Specifically for &bluestore;, an OSD has a 'wal' (Write Ahead Log) device
    and a 'db' (RocksDB database) device. The RocksDB database holds the
    metadata for a &bluestore; OSD. These two devices will reside on the same
-   device as an OSD by default, but either can be placed on faster/different
-   media.
+   device as an OSD by default, but either can be placed on different, for
+   example faster, media.
   </para>
   <para>
-   In SES5, both FileStore and &bluestore; are supported and it is possible
-   for FileStore and &bluestore; OSDs to co-exist in a single cluster. During
-   the SUSE Enterprise Storage upgrade procedure, FileStore OSDs are not
+   In &productname; 5, both &filestore; and &bluestore; are supported and it is possible
+   for &filestore; and &bluestore; OSDs to co-exist in a single cluster. During
+   the &productname; upgrade procedure, &filestore; OSDs are not
    automatically converted to &bluestore;. Be aware that the
    &bluestore;-specific features will not be available on OSDs that have not
    been migrated to &bluestore;.
   </para>
   <para>
-   Before converting to &bluestore;, the OSDs need to be running &productname;
-   &productnumber;. The conversion is a slow process as all data gets
+   Before converting to &bluestore;, the OSDs need to be running &productname; 5.
+   The conversion is a slow process as all data gets
    re-written twice. Though the migration process can take a long time to
    complete, there is no cluster outage and all clients can continue accessing
    the cluster during this period. However, do expect lower performance for
@@ -1433,7 +1433,7 @@ data:
    backfilling of cluster data.
   </para>
   <para>
-   Use the following procedure to migrate FileStore OSDs to &bluestore;:
+   Use the following procedure to migrate &filestore; OSDs to &bluestore;:
   </para>
   <tip>
    <title>Turn Off Safety Measures</title>
@@ -1451,17 +1451,18 @@ data:
  </screen>
    <para>You can also choose to rebuild each node individually. For example:</para>
  <screen>
-   &prompt.smaster; salt-run rebuild.node data1.ceph
+&prompt.smaster; salt-run rebuild.node data1.ceph
  </screen>
-   <para>The rebuild is not idempotent. To address the complication of shared
-     devices, the first step of a rebuild is to remove all the OSDs on a node.
-     If one OSD fails to convert, rerunning the rebuild will destroy the
-     already converted Bluestore OSDs. Depending on the failure and the
-     amount of progress, for example we recommend running:</para>
- <screen>
-   &prompt.smaster; salt-run disks.deploy target=data1.ceph
- </screen>
-  </tip>
+   <para>The <literal>rebuild.node</literal> always removes and recreates
+     all OSDs on the node.</para>
+     <important>
+       <para>If one OSD fails to convert, re-running the rebuild destroys the
+         already converted &bluestore; OSDs. If this happens, run:</para>
+         <screen>
+           &prompt.smaster; salt-run disks.deploy <replaceable>TARGET</replaceable>
+         </screen>
+       </important>
+ </tip>
   <procedure>
    <step>
     <para>

--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -1406,7 +1406,7 @@ data:
    stores objects as files in an XFS file system, &bluestore; can deliver
    increased performance because it stores objects directly on the underlying
    block device. &bluestore; also enables other features, such as built-in
-   compression and EC overwrites, that are unavailable with FileStore.
+   compression and EC overwrites, that are unavailable with &filestore.
   </para>
   <para>
    Specifically for &bluestore;, an OSD has a 'wal' (Write Ahead Log) device
@@ -1475,7 +1475,7 @@ data:
      <filename>policy.cfg</filename>, finds any hardware profile using the
      original data structure, and converts it to the new data structure. The
      result is a new hardware profile named
-     'migrated-<replaceable>original_name</replaceable>'.
+     'migrated-<replaceable>ORIGINAL_NAME</replaceable>'.
      <filename>policy.cfg</filename> is updated as well.
     </para>
     <para>

--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -1397,6 +1397,146 @@ data:
    </step>
   </procedure>
  </sect1>
+
+ <sect1 xml:id="filestore2bluestore">
+  <title>OSD Migration to &bluestore;</title>
+  <para>
+   OSD &bluestore; is a new back end for the OSD daemons. It is the default
+   option since &productname; &productnumber;. Compared to FileStore, which
+   stores objects as files in an XFS file system, &bluestore; can deliver
+   increased performance because it stores objects directly on the underlying
+   block device. &bluestore; also enables other features, such as built-in
+   compression and EC overwrites, that are unavailable with FileStore.
+  </para>
+  <para>
+   Specifically for &bluestore;, an OSD has a 'wal' (Write Ahead Log) device
+   and a 'db' (RocksDB database) device. The RocksDB database holds the
+   metadata for a &bluestore; OSD. These two devices will reside on the same
+   device as an OSD by default, but either can be placed on faster/different
+   media.
+  </para>
+  <para>
+   In SES5, both FileStore and &bluestore; are supported and it is possible
+   for FileStore and &bluestore; OSDs to co-exist in a single cluster. During
+   the SUSE Enterprise Storage upgrade procedure, FileStore OSDs are not
+   automatically converted to &bluestore;. Be aware that the
+   &bluestore;-specific features will not be available on OSDs that have not
+   been migrated to &bluestore;.
+  </para>
+  <para>
+   Before converting to &bluestore;, the OSDs need to be running &productname;
+   &productnumber;. The conversion is a slow process as all data gets
+   re-written twice. Though the migration process can take a long time to
+   complete, there is no cluster outage and all clients can continue accessing
+   the cluster during this period. However, do expect lower performance for
+   the duration of the migration. This is caused by rebalancing and
+   backfilling of cluster data.
+  </para>
+  <para>
+   Use the following procedure to migrate FileStore OSDs to &bluestore;:
+  </para>
+  <tip>
+   <title>Turn Off Safety Measures</title>
+   <para>
+    &salt; commands needed for running the migration are blocked by safety
+    measures. In order to turn these precautions off, run the following
+    command:
+   </para>
+ <screen>
+ &prompt.smaster;salt-run disengage.safety
+ </screen>
+   <para>Rebuild the nodes before continuing:</para>
+ <screen>
+ &prompt.smaster; salt-run rebuild.node <replaceable>TARGET</replaceable>
+ </screen>
+   <para>You can also choose to rebuild each node individually. For example:</para>
+ <screen>
+   &prompt.smaster; salt-run rebuild.node data1.ceph
+ </screen>
+   <para>The rebuild is not idempotent. To address the complication of shared
+     devices, the first step of a rebuild is to remove all the OSDs on a node.
+     If one OSD fails to convert, rerunning the rebuild will destroy the
+     already converted Bluestore OSDs. Depending on the failure and the
+     amount of progress, for example we recommend running:</para>
+ <screen>
+   &prompt.smaster; salt-run disks.deploy target=data1.ceph
+ </screen>
+  </tip>
+  <procedure>
+   <step>
+    <para>
+     Migrate hardware profiles:
+    </para>
+ <screen>&prompt.smaster;salt-run state.orch ceph.migrate.policy</screen>
+    <para>
+     This runner migrates any hardware profiles currently in use by the
+     <filename>policy.cfg</filename> file. It processes
+     <filename>policy.cfg</filename>, finds any hardware profile using the
+     original data structure, and converts it to the new data structure. The
+     result is a new hardware profile named
+     'migrated-<replaceable>original_name</replaceable>'.
+     <filename>policy.cfg</filename> is updated as well.
+    </para>
+    <para>
+     If the original configuration had separate journals, the &bluestore;
+     configuration will use the same device for the 'wal' and 'db' for that
+     OSD.
+    </para>
+   </step>
+   <step>
+    <para>
+     &deepsea; migrates OSDs by setting their weight to 0 which 'vacuums' the
+     data until the OSD is empty. You can either migrate OSDs one by one, or
+     all OSDs at once. In either case, when the OSD is empty, the
+     orchestration removes it and then re-creates it with the new
+     configuration.
+    </para>
+    <tip>
+     <title>Recommended Method</title>
+     <para>
+      Use <command>ceph.migrate.nodes</command> if you have a large number of
+      physical storage nodes or almost no data. If one node represents less
+      than 10% of your capacity, then the
+      <command>ceph.migrate.nodes</command> may be marginally faster moving
+      all the data from those OSDs in parallel.
+     </para>
+     <para>
+      If you are not sure about which method to use, or the site has few
+      storage nodes (for example each node has more than 10% of the cluster
+      data), then select <command>ceph.migrate.osds</command>.
+     </para>
+    </tip>
+    <substeps>
+     <step>
+      <para>
+       To migrate OSDs one at a time, run:
+      </para>
+ <screen>&prompt.smaster;salt-run state.orch ceph.migrate.osds</screen>
+     </step>
+     <step>
+      <para>
+       To migrate all OSDs on each node in parallel, run:
+      </para>
+ <screen>&prompt.smaster;salt-run state.orch ceph.migrate.nodes</screen>
+     </step>
+    </substeps>
+    <tip>
+     <para>
+      As the orchestration gives no feedback about the migration progress, use
+     </para>
+ <screen>&prompt.cephuser;ceph osd tree</screen>
+     <para>
+      to see which OSDs have a weight of zero periodically.
+     </para>
+    </tip>
+   </step>
+  </procedure>
+  <para>
+   After the migration to &bluestore;, the object count will remain the same
+   and disk usage will be nearly the same.
+  </para>
+</sect1>
+
  <sect1 xml:id="upgrade-appnodes-order">
   <title>Upgrade Application Nodes</title>
 

--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -1406,7 +1406,7 @@ data:
    stores objects as files in an XFS file system, &bluestore; can deliver
    increased performance because it stores objects directly on the underlying
    block device. &bluestore; also enables other features, such as built-in
-   compression and EC overwrites, that are unavailable with &filestore.
+   compression and EC overwrites, that are unavailable with &filestore;.
   </para>
   <para>
    Specifically for &bluestore;, an OSD has a 'wal' (Write Ahead Log) device
@@ -1457,81 +1457,13 @@ data:
      all OSDs on the node.</para>
      <important>
        <para>If one OSD fails to convert, re-running the rebuild destroys the
-         already converted &bluestore; OSDs. If this happens, run:</para>
+         already converted &bluestore; OSDs. Instead of re-running the rebuild,
+         you can run:</para>
          <screen>
            &prompt.smaster; salt-run disks.deploy <replaceable>TARGET</replaceable>
          </screen>
        </important>
  </tip>
-  <procedure>
-   <step>
-    <para>
-     Migrate hardware profiles:
-    </para>
- <screen>&prompt.smaster;salt-run state.orch ceph.migrate.policy</screen>
-    <para>
-     This runner migrates any hardware profiles currently in use by the
-     <filename>policy.cfg</filename> file. It processes
-     <filename>policy.cfg</filename>, finds any hardware profile using the
-     original data structure, and converts it to the new data structure. The
-     result is a new hardware profile named
-     'migrated-<replaceable>ORIGINAL_NAME</replaceable>'.
-     <filename>policy.cfg</filename> is updated as well.
-    </para>
-    <para>
-     If the original configuration had separate journals, the &bluestore;
-     configuration will use the same device for the 'wal' and 'db' for that
-     OSD.
-    </para>
-   </step>
-   <step>
-    <para>
-     &deepsea; migrates OSDs by setting their weight to 0 which 'vacuums' the
-     data until the OSD is empty. You can either migrate OSDs one by one, or
-     all OSDs at once. In either case, when the OSD is empty, the
-     orchestration removes it and then re-creates it with the new
-     configuration.
-    </para>
-    <tip>
-     <title>Recommended Method</title>
-     <para>
-      Use <command>ceph.migrate.nodes</command> if you have a large number of
-      physical storage nodes or almost no data. If one node represents less
-      than 10% of your capacity, then the
-      <command>ceph.migrate.nodes</command> may be marginally faster moving
-      all the data from those OSDs in parallel.
-     </para>
-     <para>
-      If you are not sure about which method to use, or the site has few
-      storage nodes (for example each node has more than 10% of the cluster
-      data), then select <command>ceph.migrate.osds</command>.
-     </para>
-    </tip>
-    <substeps>
-     <step>
-      <para>
-       To migrate OSDs one at a time, run:
-      </para>
- <screen>&prompt.smaster;salt-run state.orch ceph.migrate.osds</screen>
-     </step>
-     <step>
-      <para>
-       To migrate all OSDs on each node in parallel, run:
-      </para>
- <screen>&prompt.smaster;salt-run state.orch ceph.migrate.nodes</screen>
-     </step>
-    </substeps>
-    <tip>
-     <para>
-      As the orchestration gives no feedback about the migration progress, use
-     </para>
- <screen>&prompt.cephuser;ceph osd tree</screen>
-     <para>
-      to see which OSDs have a weight of zero periodically.
-     </para>
-    </tip>
-   </step>
-  </procedure>
   <para>
    After the migration to &bluestore;, the object count will remain the same
    and disk usage will be nearly the same.


### PR DESCRIPTION
Bluestore is the default for SES 5.x and 6, however for customers
performing any upgrade path, they may not have completed this
requirement when upgrading from SES 4 to SES 5. This PR
includes the content from SES 5.5 docs.