### PR TITLE
Remove section numbering in Ceph updates chapter (bsc#1151881)

### DIFF
--- a/xml/maintenance_updates_admin.xml
+++ b/xml/maintenance_updates_admin.xml
@@ -123,7 +123,7 @@
     been changed from <literal>firefly</literal> to <literal>hammer</literal>, which means the cluster will issue
     a health warning if your CRUSH tunables are older than 'hammer'. There is
     generally a small (but non-zero) amount of data that will move around by
-    making the switch to 'hammer' tunables.
+    making the switch to <literal>hammer</literal> tunables.
    </para>
    <para>
     If possible, we recommend that you set the oldest allowed client to

--- a/xml/maintenance_updates_admin.xml
+++ b/xml/maintenance_updates_admin.xml
@@ -120,7 +120,7 @@
   <listitem>
    <para>
     The default value for <option>mon_crush_min_required_version</option> has
-    been changed from 'firefly' to 'hammer', which means the cluster will issue
+    been changed from <literal>firefly</literal> to <literal>hammer</literal>, which means the cluster will issue
     a health warning if your CRUSH tunables are older than 'hammer'. There is
     generally a small (but non-zero) amount of data that will move around by
     making the switch to 'hammer' tunables.

--- a/xml/maintenance_updates_admin.xml
+++ b/xml/maintenance_updates_admin.xml
@@ -6,7 +6,7 @@
 ]>
 <appendix xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
- xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="maintenance-updates-admin">
+ xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="maintenance-updates-deploy">
  <title>&ceph; Maintenance Updates Based on Upstream '&cephname;' Point Releases</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -33,139 +33,126 @@
   point release that has been&mdash;or is planned to be&mdash;included in the
   product.
  </para>
- <sect1>
-  <title>&cephname; 14.2.4 Point Release</title>
-
-  <para>
-   This point release fixes a serious regression that found its way into the
-   14.2.3 point release. This regression did not affect &productname; customers
-   because we did not ship a version based on 14.2.3.
-  </para>
- </sect1>
- <sect1>
-  <title>&cephname; 14.2.3 Point Release</title>
-
-  <itemizedlist>
-   <listitem>
-    <para>
-     Fixed a denial of service vulnerability where an unauthenticated client of
-     &cogw; could trigger a crash from an uncaught exception.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     &cephname;-based librbd clients can now open images on Jewel clusters.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     The &ogw; <option>num_rados_handles</option> has been removed. If you were
-     using a value of <option>num_rados_handles</option> greater than 1,
-     multiply your current <option>objecter_inflight_ops</option> and
-     <option>objecter_inflight_op_bytes</option> parameters by the old
-     <option>num_rados_handles</option> to get the same throttle behavior.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     The secure mode of Messenger v2 protocol is no longer experimental with
-     this release. This mode is now the preferred mode of connection for
-     monitors.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     <option>osd_deep_scrub_large_omap_object_key_threshold</option> has been
-     lowered to detect an object with large number of omap keys more easily.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     The &dashboard; now supports silencing &prometheus; notifications.
-    </para>
-   </listitem>
-  </itemizedlist>
- </sect1>
- <sect1>
-  <title>&cephname; 14.2.2 Point Release</title>
-
-  <itemizedlist>
-   <listitem>
-    <para>
-     The <literal>no{up,down,in,out}</literal> related commands have been
-     revamped. There are now two ways to set the
-     <literal>no{up,down,in,out}</literal> flags: the old <command>ceph osd
-     [un]set <replaceable>FLAG</replaceable></command> command, which sets
-     cluster-wide flags; and the new <command>ceph osd [un]set-group
-     <replaceable>FLAGS</replaceable> <replaceable>WHO</replaceable></command>
-     command, which sets flags in batch at the granularity of any crush node,
-     or device class.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     <command>radosgw-admin</command> introduces two subcommands that allow the
-     managing of expire-stale objects that might be left behind after a bucket
-     reshard in earlier versions of &ogw;. One subcommand lists such objects
-     and the other deletes them.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Earlier &cephname; releases (14.2.1 and 14.2.0) have an issue where
-     deploying a single new &cephname; &bluestore; OSD on an upgraded cluster
-     (i.e. one that was originally deployed pre-&cephname;) breaks the pool
-     utilization statistics reported by <command>ceph df</command>. Until all
-     OSDs have been reprovisioned or updated (via <command>ceph-bluestore-tool
-     repair</command>), the pool statistics will show values that are lower
-     than the true value. This is resolved in 14.2.2, such that the cluster
-     only switches to using the more accurate per-pool stats after
-     <emphasis>all</emphasis> OSDs are 14.2.2 or later, are &blockstore;, and
-     have been updated via the repair function if they were created prior to
-     &cephname;.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     The default value for <option>mon_crush_min_required_version</option> has
-     been changed from 'firefly' to 'hammer', which means the cluster will
-     issue a health warning if your CRUSH tunables are older than 'hammer'.
-     There is generally a small (but non-zero) amount of data that will move
-     around by making the switch to 'hammer' tunables.
-    </para>
-    <para>
-     If possible, we recommend that you set the oldest allowed client to
-     'hammer' or later. To display what the current oldest allowed client is,
-     run:
-    </para>
+ <bridgehead renderas="sect1">&cephname; 14.2.4 Point Release</bridgehead>
+ <para>
+  This point release fixes a serious regression that found its way into the
+  14.2.3 point release. This regression did not affect &productname; customers
+  because we did not ship a version based on 14.2.3.
+ </para>
+ <bridgehead renderas="sect1">&cephname; 14.2.3 Point Release</bridgehead>
+ <itemizedlist>
+  <listitem>
+   <para>
+    Fixed a denial of service vulnerability where an unauthenticated client of
+    &cogw; could trigger a crash from an uncaught exception.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    &cephname;-based librbd clients can now open images on Jewel clusters.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    The &ogw; <option>num_rados_handles</option> has been removed. If you were
+    using a value of <option>num_rados_handles</option> greater than 1,
+    multiply your current <option>objecter_inflight_ops</option> and
+    <option>objecter_inflight_op_bytes</option> parameters by the old
+    <option>num_rados_handles</option> to get the same throttle behavior.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    The secure mode of Messenger v2 protocol is no longer experimental with
+    this release. This mode is now the preferred mode of connection for
+    monitors.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    <option>osd_deep_scrub_large_omap_object_key_threshold</option> has been
+    lowered to detect an object with large number of omap keys more easily.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    The &dashboard; now supports silencing &prometheus; notifications.
+   </para>
+  </listitem>
+ </itemizedlist>
+ <bridgehead renderas="sect1">&cephname; 14.2.2 Point Release</bridgehead>
+ <itemizedlist>
+  <listitem>
+   <para>
+    The <literal>no{up,down,in,out}</literal> related commands have been
+    revamped. There are now two ways to set the
+    <literal>no{up,down,in,out}</literal> flags: the old <command>ceph osd
+    [un]set <replaceable>FLAG</replaceable></command> command, which sets
+    cluster-wide flags; and the new <command>ceph osd [un]set-group
+    <replaceable>FLAGS</replaceable> <replaceable>WHO</replaceable></command>
+    command, which sets flags in batch at the granularity of any crush node, or
+    device class.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    <command>radosgw-admin</command> introduces two subcommands that allow the
+    managing of expire-stale objects that might be left behind after a bucket
+    reshard in earlier versions of &ogw;. One subcommand lists such objects and
+    the other deletes them.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    Earlier &cephname; releases (14.2.1 and 14.2.0) have an issue where
+    deploying a single new &cephname; &bluestore; OSD on an upgraded cluster
+    (i.e. one that was originally deployed pre-&cephname;) breaks the pool
+    utilization statistics reported by <command>ceph df</command>. Until all
+    OSDs have been reprovisioned or updated (via <command>ceph-bluestore-tool
+    repair</command>), the pool statistics will show values that are lower than
+    the true value. This is resolved in 14.2.2, such that the cluster only
+    switches to using the more accurate per-pool stats after
+    <emphasis>all</emphasis> OSDs are 14.2.2 or later, are &blockstore;, and
+    have been updated via the repair function if they were created prior to
+    &cephname;.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    The default value for <option>mon_crush_min_required_version</option> has
+    been changed from 'firefly' to 'hammer', which means the cluster will issue
+    a health warning if your CRUSH tunables are older than 'hammer'. There is
+    generally a small (but non-zero) amount of data that will move around by
+    making the switch to 'hammer' tunables.
+   </para>
+   <para>
+    If possible, we recommend that you set the oldest allowed client to
+    'hammer' or later. To display what the current oldest allowed client is,
+    run:
+   </para>
 <screen>&prompt.cephuser;ceph osd dump | grep min_compat_client</screen>
-    <para>
-     If the current value is older than 'hammer', you can tell whether it is
-     safe to make this change by verifying that there are no clients older than
-     'hammer' currently connected to the cluster:
-    </para>
+   <para>
+    If the current value is older than 'hammer', you can tell whether it is
+    safe to make this change by verifying that there are no clients older than
+    'hammer' currently connected to the cluster:
+   </para>
 <screen>&prompt.cephuser;ceph features</screen>
-    <para>
-     The newer 'straw2' CRUSH bucket type was introduced in 'hammer', If you
-     verify that all clients are 'hammer' or newer, it allows new features only
-     supported for 'straw2' buckets to be used, including the 'crush-compat'
-     mode for the Balancer (<xref linkend="mgr-modules-balancer" />).
-    </para>
-   </listitem>
-  </itemizedlist>
-
-  <para>
-   Find detailed information about the patch at
-   <link xlink:href="https://download.suse.com/Download?buildid=D38A7mekBz4~"/>
-  </para>
- </sect1>
- <sect1>
-  <title>&cephname; 14.2.1 Point Release</title>
-
-  <para>
-   This was the first point release following the original &cephname; release
-   (14.2.0). The original ('General Availability' or 'GA') version of
-   &productname; &productnumber; was based on this point release.
-  </para>
- </sect1>
+   <para>
+    The newer 'straw2' CRUSH bucket type was introduced in 'hammer', If you
+    verify that all clients are 'hammer' or newer, it allows new features only
+    supported for 'straw2' buckets to be used, including the 'crush-compat'
+    mode for the Balancer (<xref linkend="mgr-modules-balancer" />).
+   </para>
+  </listitem>
+ </itemizedlist>
+ <para>
+  Find detailed information about the patch at
+  <link xlink:href="https://download.suse.com/Download?buildid=D38A7mekBz4~"/>
+ </para>
+ <bridgehead renderas="sect1">&cephname; 14.2.1 Point Release</bridgehead>
+ <para>
+  This was the first point release following the original &cephname; release
+  (14.2.0). The original ('General Availability' or 'GA') version of
+  &productname; &productnumber; was based on this point release.
+ </para>
 </appendix>

--- a/xml/maintenance_updates_admin.xml
+++ b/xml/maintenance_updates_admin.xml
@@ -138,7 +138,7 @@
    </para>
 <screen>&prompt.cephuser;ceph features</screen>
    <para>
-    The newer 'straw2' CRUSH bucket type was introduced in 'hammer', If you
+    The newer 'straw2' CRUSH bucket type was introduced in 'hammer'. If you
     verify that all clients are 'hammer' or newer, it allows new features only
     supported for 'straw2' buckets to be used, including the 'crush-compat'
     mode for the Balancer (<xref linkend="mgr-modules-balancer" />).

--- a/xml/maintenance_updates_admin.xml
+++ b/xml/maintenance_updates_admin.xml
@@ -132,7 +132,7 @@
    </para>
 <screen>&prompt.cephuser;ceph osd dump | grep min_compat_client</screen>
    <para>
-    If the current value is older than 'hammer', you can tell whether it is
+    If the current value is older than 'hammer', run the following command to determine whether it is
     safe to make this change by verifying that there are no clients older than
     'hammer' currently connected to the cluster:
    </para>

--- a/xml/maintenance_updates_admin.xml
+++ b/xml/maintenance_updates_admin.xml
@@ -6,7 +6,7 @@
 ]>
 <appendix xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
- xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="maintenance-updates-deploy">
+ xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="maintenance-updates-admin">
  <title>&ceph; Maintenance Updates Based on Upstream '&cephname;' Point Releases</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/maintenance_updates_admin.xml
+++ b/xml/maintenance_updates_admin.xml
@@ -22,7 +22,7 @@
  </info>
  <para>
   Several key packages in &productname; &productnumber; are based on the
-  '&cephname;' release series of &ceph;. When the &ceph; project
+  &cephname; release series of &ceph;. When the &ceph; project
   (<link xlink:href="https://github.com/ceph/ceph"/>) publishes new point
   releases in the &cephname; series. &productname; &productnumber; is updated
   to ensure that the product benefits from the latest upstream bugfixes and
@@ -86,12 +86,16 @@
    <para>
     The <literal>no{up,down,in,out}</literal> related commands have been
     revamped. There are now two ways to set the
-    <literal>no{up,down,in,out}</literal> flags: the old <command>ceph osd
-    [un]set <replaceable>FLAG</replaceable></command> command, which sets
-    cluster-wide flags; and the new <command>ceph osd [un]set-group
-    <replaceable>FLAGS</replaceable> <replaceable>WHO</replaceable></command>
-    command, which sets flags in batch at the granularity of any crush node, or
-    device class.
+    <literal>no{up,down,in,out}</literal> flags: the old command
+   </para>
+<screen>ceph osd [un]set <replaceable>FLAG</replaceable></screen>
+   <para>
+    which sets cluster-wide flags; and the new command
+   </para>
+<screen>ceph osd [un]set-group <replaceable>FLAGS</replaceable> <replaceable>WHO</replaceable></screen>
+   <para>
+    which sets flags in batch at the granularity of any crush node, or device
+    class.
    </para>
   </listitem>
   <listitem>
@@ -120,28 +124,30 @@
   <listitem>
    <para>
     The default value for <option>mon_crush_min_required_version</option> has
-    been changed from <literal>firefly</literal> to <literal>hammer</literal>, which means the cluster will issue
-    a health warning if your CRUSH tunables are older than 'hammer'. There is
-    generally a small (but non-zero) amount of data that will move around by
-    making the switch to <literal>hammer</literal> tunables.
+    been changed from <literal>firefly</literal> to <literal>hammer</literal>,
+    which means the cluster will issue a health warning if your CRUSH tunables
+    are older than Hammer. There is generally a small (but non-zero) amount of
+    data that will move around by making the switch to Hammer tunables.
    </para>
    <para>
     If possible, we recommend that you set the oldest allowed client to
-    'hammer' or later. To display what the current oldest allowed client is,
-    run:
+    <literal>hammer</literal> or later. To display what the current oldest
+    allowed client is, run:
    </para>
 <screen>&prompt.cephuser;ceph osd dump | grep min_compat_client</screen>
    <para>
-    If the current value is older than 'hammer', run the following command to determine whether it is
-    safe to make this change by verifying that there are no clients older than
-    'hammer' currently connected to the cluster:
+    If the current value is older than <literal>hammer</literal>, run the
+    following command to determine whether it is safe to make this change by
+    verifying that there are no clients older than Hammer currently connected
+    to the cluster:
    </para>
 <screen>&prompt.cephuser;ceph features</screen>
    <para>
-    The newer 'straw2' CRUSH bucket type was introduced in 'hammer'. If you
-    verify that all clients are 'hammer' or newer, it allows new features only
-    supported for 'straw2' buckets to be used, including the 'crush-compat'
-    mode for the Balancer (<xref linkend="mgr-modules-balancer" />).
+    The newer <literal>straw2</literal> CRUSH bucket type was introduced in
+    Hammer. If you verify that all clients are Hammer or newer, it allows new
+    features only supported for <literal>straw2</literal> buckets to be used,
+    including the <literal>crush-compat</literal> mode for the Balancer
+    (<xref linkend="mgr-modules-balancer" />).
    </para>
   </listitem>
  </itemizedlist>

--- a/xml/maintenance_updates_deploy.xml
+++ b/xml/maintenance_updates_deploy.xml
@@ -33,139 +33,126 @@
   point release that has been&mdash;or is planned to be&mdash;included in the
   product.
  </para>
- <sect1>
-  <title>&cephname; 14.2.4 Point Release</title>
-
-  <para>
-   This point release fixes a serious regression that found its way into the
-   14.2.3 point release. This regression did not affect &productname; customers
-   because we did not ship a version based on 14.2.3.
-  </para>
- </sect1>
- <sect1>
-  <title>&cephname; 14.2.3 Point Release</title>
-
-  <itemizedlist>
-   <listitem>
-    <para>
-     Fixed a denial of service vulnerability where an unauthenticated client of
-     &cogw; could trigger a crash from an uncaught exception.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     &cephname;-based librbd clients can now open images on Jewel clusters.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     The &ogw; <option>num_rados_handles</option> has been removed. If you were
-     using a value of <option>num_rados_handles</option> greater than 1,
-     multiply your current <option>objecter_inflight_ops</option> and
-     <option>objecter_inflight_op_bytes</option> parameters by the old
-     <option>num_rados_handles</option> to get the same throttle behavior.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     The secure mode of Messenger v2 protocol is no longer experimental with
-     this release. This mode is now the preferred mode of connection for
-     monitors.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     <option>osd_deep_scrub_large_omap_object_key_threshold</option> has been
-     lowered to detect an object with large number of omap keys more easily.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     The &dashboard; now supports silencing &prometheus; notifications.
-    </para>
-   </listitem>
-  </itemizedlist>
- </sect1>
- <sect1>
-  <title>&cephname; 14.2.2 Point Release</title>
-
-  <itemizedlist>
-   <listitem>
-    <para>
-     The <literal>no{up,down,in,out}</literal> related commands have been
-     revamped. There are now two ways to set the
-     <literal>no{up,down,in,out}</literal> flags: the old <command>ceph osd
-     [un]set <replaceable>FLAG</replaceable></command> command, which sets
-     cluster-wide flags; and the new <command>ceph osd [un]set-group
-     <replaceable>FLAGS</replaceable> <replaceable>WHO</replaceable></command>
-     command, which sets flags in batch at the granularity of any crush node,
-     or device class.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     <command>radosgw-admin</command> introduces two subcommands that allow the
-     managing of expire-stale objects that might be left behind after a bucket
-     reshard in earlier versions of &ogw;. One subcommand lists such objects
-     and the other deletes them.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Earlier &cephname; releases (14.2.1 and 14.2.0) have an issue where
-     deploying a single new &cephname; &bluestore; OSD on an upgraded cluster
-     (i.e. one that was originally deployed pre-&cephname;) breaks the pool
-     utilization statistics reported by <command>ceph df</command>. Until all
-     OSDs have been reprovisioned or updated (via <command>ceph-bluestore-tool
-     repair</command>), the pool statistics will show values that are lower
-     than the true value. This is resolved in 14.2.2, such that the cluster
-     only switches to using the more accurate per-pool stats after
-     <emphasis>all</emphasis> OSDs are 14.2.2 or later, are &blockstore;, and
-     have been updated via the repair function if they were created prior to
-     &cephname;.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     The default value for <option>mon_crush_min_required_version</option> has
-     been changed from 'firefly' to 'hammer', which means the cluster will
-     issue a health warning if your CRUSH tunables are older than 'hammer'.
-     There is generally a small (but non-zero) amount of data that will move
-     around by making the switch to 'hammer' tunables.
-    </para>
-    <para>
-     If possible, we recommend that you set the oldest allowed client to
-     'hammer' or later. To display what the current oldest allowed client is,
-     run:
-    </para>
+ <bridgehead renderas="sect1">&cephname; 14.2.4 Point Release</bridgehead>
+ <para>
+  This point release fixes a serious regression that found its way into the
+  14.2.3 point release. This regression did not affect &productname; customers
+  because we did not ship a version based on 14.2.3.
+ </para>
+ <bridgehead renderas="sect1">&cephname; 14.2.3 Point Release</bridgehead>
+ <itemizedlist>
+  <listitem>
+   <para>
+    Fixed a denial of service vulnerability where an unauthenticated client of
+    &cogw; could trigger a crash from an uncaught exception.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    &cephname;-based librbd clients can now open images on Jewel clusters.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    The &ogw; <option>num_rados_handles</option> has been removed. If you were
+    using a value of <option>num_rados_handles</option> greater than 1,
+    multiply your current <option>objecter_inflight_ops</option> and
+    <option>objecter_inflight_op_bytes</option> parameters by the old
+    <option>num_rados_handles</option> to get the same throttle behavior.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    The secure mode of Messenger v2 protocol is no longer experimental with
+    this release. This mode is now the preferred mode of connection for
+    monitors.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    <option>osd_deep_scrub_large_omap_object_key_threshold</option> has been
+    lowered to detect an object with large number of omap keys more easily.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    The &dashboard; now supports silencing &prometheus; notifications.
+   </para>
+  </listitem>
+ </itemizedlist>
+ <bridgehead renderas="sect1">&cephname; 14.2.2 Point Release</bridgehead>
+ <itemizedlist>
+  <listitem>
+   <para>
+    The <literal>no{up,down,in,out}</literal> related commands have been
+    revamped. There are now two ways to set the
+    <literal>no{up,down,in,out}</literal> flags: the old <command>ceph osd
+    [un]set <replaceable>FLAG</replaceable></command> command, which sets
+    cluster-wide flags; and the new <command>ceph osd [un]set-group
+    <replaceable>FLAGS</replaceable> <replaceable>WHO</replaceable></command>
+    command, which sets flags in batch at the granularity of any crush node, or
+    device class.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    <command>radosgw-admin</command> introduces two subcommands that allow the
+    managing of expire-stale objects that might be left behind after a bucket
+    reshard in earlier versions of &ogw;. One subcommand lists such objects and
+    the other deletes them.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    Earlier &cephname; releases (14.2.1 and 14.2.0) have an issue where
+    deploying a single new &cephname; &bluestore; OSD on an upgraded cluster
+    (i.e. one that was originally deployed pre-&cephname;) breaks the pool
+    utilization statistics reported by <command>ceph df</command>. Until all
+    OSDs have been reprovisioned or updated (via <command>ceph-bluestore-tool
+    repair</command>), the pool statistics will show values that are lower than
+    the true value. This is resolved in 14.2.2, such that the cluster only
+    switches to using the more accurate per-pool stats after
+    <emphasis>all</emphasis> OSDs are 14.2.2 or later, are &blockstore;, and
+    have been updated via the repair function if they were created prior to
+    &cephname;.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    The default value for <option>mon_crush_min_required_version</option> has
+    been changed from 'firefly' to 'hammer', which means the cluster will issue
+    a health warning if your CRUSH tunables are older than 'hammer'. There is
+    generally a small (but non-zero) amount of data that will move around by
+    making the switch to 'hammer' tunables.
+   </para>
+   <para>
+    If possible, we recommend that you set the oldest allowed client to
+    'hammer' or later. To display what the current oldest allowed client is,
+    run:
+   </para>
 <screen>&prompt.cephuser;ceph osd dump | grep min_compat_client</screen>
-    <para>
-     If the current value is older than 'hammer', you can tell whether it is
-     safe to make this change by verifying that there are no clients older than
-     'hammer' currently connected to the cluster:
-    </para>
+   <para>
+    If the current value is older than 'hammer', you can tell whether it is
+    safe to make this change by verifying that there are no clients older than
+    'hammer' currently connected to the cluster:
+   </para>
 <screen>&prompt.cephuser;ceph features</screen>
-    <para>
-     The newer 'straw2' CRUSH bucket type was introduced in 'hammer', If you
-     verify that all clients are 'hammer' or newer, it allows new features only
-     supported for 'straw2' buckets to be used, including the 'crush-compat'
-     mode for the Balancer (<xref linkend="mgr-modules-balancer" />).
-    </para>
-   </listitem>
-  </itemizedlist>
-
-  <para>
-   Find detailed information about the patch at
-   <link xlink:href="https://download.suse.com/Download?buildid=D38A7mekBz4~"/>
-  </para>
- </sect1>
- <sect1>
-  <title>&cephname; 14.2.1 Point Release</title>
-
-  <para>
-   This was the first point release following the original &cephname; release
-   (14.2.0). The original ('General Availability' or 'GA') version of
-   &productname; &productnumber; was based on this point release.
-  </para>
- </sect1>
+   <para>
+    The newer 'straw2' CRUSH bucket type was introduced in 'hammer', If you
+    verify that all clients are 'hammer' or newer, it allows new features only
+    supported for 'straw2' buckets to be used, including the 'crush-compat'
+    mode for the Balancer (<xref linkend="mgr-modules-balancer" />).
+   </para>
+  </listitem>
+ </itemizedlist>
+ <para>
+  Find detailed information about the patch at
+  <link xlink:href="https://download.suse.com/Download?buildid=D38A7mekBz4~"/>
+ </para>
+ <bridgehead renderas="sect1">&cephname; 14.2.1 Point Release</bridgehead>
+ <para>
+  This was the first point release following the original &cephname; release
+  (14.2.0). The original ('General Availability' or 'GA') version of
+  &productname; &productnumber; was based on this point release.
+ </para>
 </appendix>


### PR DESCRIPTION
Replaced &lt;sect1>'s with &lt;bridgehead>'s so that the section numbers are not numbered.
The numbering caused confusion with the ceph version numbers in the titles because one went up whil the other down