### PR TITLE
Adding new intro chap for Arm architecture (BSC#1154813)

### DIFF
--- a/xml/deployment_hwrecommend.xml
+++ b/xml/deployment_hwrecommend.xml
@@ -23,6 +23,21 @@
   basis. If several processes are located on the same machine, the CPU, RAM,
   disk and network requirements need to be added up.
  </para>
+
+ <sect1 xml:id="multi-architecture">
+  <title>Multiple Architecture Confiurations</title>
+  <para>
+    &productname; supports both &x86; and &amd64; architectures.
+    When considering each architecture, it is important to note that
+    from a cores per OSD, frequency, and RAM perspective, there is no real
+    difference between CPU architectures for sizing.
+  </para>
+  <para>
+    However, it is worth noting that erasure code performance on a lower
+    powered &amd64; CPU could be less performant than on an
+    Intel Xeon or higher-end &amd64; CPU.</para>
+</sect1>
+
  <sect1 xml:id="ses-bp-minimum-cluster">
   <title>Minimum Cluster Configuration</title>
 

--- a/xml/deployment_hwrecommend.xml
+++ b/xml/deployment_hwrecommend.xml
@@ -27,15 +27,15 @@
  <sect1 xml:id="multi-architecture">
   <title>Multiple Architecture Confiurations</title>
   <para>
-    &productname; supports both &x86; and &amd64; architectures.
+    &productname; supports both &x86; and ARM architectures.
     When considering each architecture, it is important to note that
     from a cores per OSD, frequency, and RAM perspective, there is no real
     difference between CPU architectures for sizing.
   </para>
   <para>
-    However, it is worth noting that erasure code performance on a lower
-    powered &amd64; CPU could be less performant than on an
-    Intel Xeon or higher-end &amd64; CPU.</para>
+    Like with smaller &x86; processors (non-server), lower-performance
+    ARM cores may not provide an optimal experience, especially when
+    used for erasure coded pools.</para>
 </sect1>
 
  <sect1 xml:id="ses-bp-minimum-cluster">

--- a/xml/deployment_hwrecommend.xml
+++ b/xml/deployment_hwrecommend.xml
@@ -25,16 +25,16 @@
  </para>
 
  <sect1 xml:id="multi-architecture">
-  <title>Multiple Architecture Confiurations</title>
+  <title>Multiple Architecture Configurations</title>
   <para>
-    &productname; supports both &x86; and ARM architectures.
+    &productname; supports both &x86; and &arm; architectures.
     When considering each architecture, it is important to note that
     from a cores per OSD, frequency, and RAM perspective, there is no real
     difference between CPU architectures for sizing.
   </para>
   <para>
     Like with smaller &x86; processors (non-server), lower-performance
-    ARM cores may not provide an optimal experience, especially when
+    &arm;-based cores may not provide an optimal experience, especially when
     used for erasure coded pools.</para>
 </sect1>
 

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -276,6 +276,8 @@
 
 <!ENTITY x86           "x86">
 <!ENTITY amd64         "AMD64">
+<!ENTITY arm           "Arm">
+<!ENTITY arm64         "&arm;&nbsp;&aarch64;">
 <!ENTITY s390          "S/390">
 <!ENTITY zseries       "System z">
 <!ENTITY ipf           "Itanium">

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -277,6 +277,7 @@
 <!ENTITY x86           "x86">
 <!ENTITY amd64         "AMD64">
 <!ENTITY arm           "Arm">
+<!ENTITY aarch64       "AArch64">
 <!ENTITY arm64         "&arm;&nbsp;&aarch64;">
 <!ENTITY s390          "S/390">
 <!ENTITY zseries       "System z">


### PR DESCRIPTION
SES has supported ARM architecture since SES 4. Going forward
we want to ensure this is documented for customers. There is
no major difference between the two architectures (x86 and ARM)
but it is important to have documented.