### PR TITLE
Document OGW archive sync module zone (jsc#ses 380)

### DIFF
--- a/xml/admin_ceph_gateway.xml
+++ b/xml/admin_ceph_gateway.xml
@@ -1546,6 +1546,16 @@ GET /<replaceable>BUCKET</replaceable>?mdsearch
     </variablelist>
    </sect3>
   </sect2>
+
+  <sect2 xml:id="archive-sync-module">
+   <title>Archive Synchronization Module</title>
+   <para>
+    The <emphasis>archive module</emphasis> utilizes the versioning feature of
+    S3 objects in &ogw;. You can configure an <emphasis>archive zone</emphasis>
+    that captures the different versions of S3 objects as they occur over time
+    in other zones.
+   </para>
+  </sect2>
  </sect1>
  <sect1 xml:id="ceph-rgw-ldap">
   <title>LDAP Authentication</title>

--- a/xml/admin_ceph_gateway.xml
+++ b/xml/admin_ceph_gateway.xml
@@ -1550,11 +1550,12 @@ GET /<replaceable>BUCKET</replaceable>?mdsearch
   <sect2 xml:id="archive-sync-module">
    <title>Archive Synchronization Module</title>
    <para>
-    The <emphasis>archive module</emphasis> utilizes the versioning feature of
-    S3 objects in &ogw;. You can configure an <emphasis>archive zone</emphasis>
-    that captures the different versions of S3 objects as they occur over time
-    in other zones. The history of versions that the archive zone keeps can
-    only be eliminated via gateways associated with the archive zone.
+    The <emphasis>archive sync module</emphasis> utilizes the versioning
+    feature of S3 objects in &ogw;. You can configure an <emphasis>archive
+    zone</emphasis> that captures the different versions of S3 objects as they
+    occur over time in other zones. The history of versions that the archive
+    zone keeps can only be eliminated via gateways associated with the archive
+    zone.
    </para>
    <para>
     With such architecture, several non-versioned zones can mirror their data
@@ -1577,16 +1578,20 @@ GET /<replaceable>BUCKET</replaceable>?mdsearch
       multisite gateways.
      </para>
      <para>
-      To use the archive module, you need to create a new zone whose tier type
-      is set to <literal>archive</literal>:
+      Refer to <xref linkend="ceph-rgw-sync"/> for details on configuring
+      synchronization modules.
      </para>
+    </tip>
+    <para>
+     To use the archive module, you need to create a new zone whose tier type
+     is set to <literal>archive</literal>:
+    </para>
 <screen>
 &prompt.cephuser;radosgw-admin zone create --rgw-zonegroup=<replaceable>ZONE_GROUP_NAME</replaceable> \
  --rgw-zone=<replaceable>OGW_ZONE_NAME</replaceable> \
  --endpoints=<replaceable>http://OGW_ENDPOINT1_URL[,http://OGW_ENDPOINT2_URL,...]</replaceable>
  --tier-type=archive
 </screen>
-    </tip>
    </sect3>
   </sect2>
  </sect1>

--- a/xml/admin_ceph_gateway.xml
+++ b/xml/admin_ceph_gateway.xml
@@ -1553,8 +1553,41 @@ GET /<replaceable>BUCKET</replaceable>?mdsearch
     The <emphasis>archive module</emphasis> utilizes the versioning feature of
     S3 objects in &ogw;. You can configure an <emphasis>archive zone</emphasis>
     that captures the different versions of S3 objects as they occur over time
-    in other zones.
+    in other zones. The history of versions that the archive zone keeps can
+    only be eliminated via gateways associated with the archive zone.
    </para>
+   <para>
+    With such architecture, several non-versioned zones can mirror their data
+    and metadata via their zone gateways providing high availability to the end
+    users, while the archive zone captures all the data updates to consolidate
+    them as versions of S3 objects.
+   </para>
+   <para>
+    By including the archive zone in a multi-zone configuration, you gain the
+    flexibility of an S3 object history in one zone while saving the space that
+    the replicas of the versioned S3 objects would consume in the remaining
+    zones.
+   </para>
+   <sect3 xml:id="archive-sync-module-configuration">
+    <title>Configuration</title>
+    <tip>
+     <title>More Information</title>
+     <para>
+      Refer to <xref linkend="ceph-rgw-fed"/> for details on configuring
+      multisite gateways.
+     </para>
+     <para>
+      To use the archive module, you need to create a new zone whose tier type
+      is set to <literal>archive</literal>:
+     </para>
+<screen>
+&prompt.cephuser;radosgw-admin zone create --rgw-zonegroup=<replaceable>ZONE_GROUP_NAME</replaceable> \
+ --rgw-zone=<replaceable>OGW_ZONE_NAME</replaceable> \
+ --endpoints=<replaceable>http://OGW_ENDPOINT1_URL[,http://OGW_ENDPOINT2_URL,...]</replaceable>
+ --tier-type=archive
+</screen>
+    </tip>
+   </sect3>
   </sect2>
  </sect1>
  <sect1 xml:id="ceph-rgw-ldap">

--- a/xml/admin_docupdates.xml
+++ b/xml/admin_docupdates.xml
@@ -48,6 +48,12 @@
    <title>General Updates</title>
    <listitem>
     <para>
+     Added <xref linkend="archive-sync-module"/>
+     (<link xlink:href="https://jira.suse.com/browse/SES-380"/>).
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      Added <xref linkend="dash-rbd-mirror"/>
      (<link xlink:href="https://jira.suse.com/browse/SES-235"/>).
     </para>

--- a/xml/ses_glossary.xml
+++ b/xml/ses_glossary.xml
@@ -36,6 +36,14 @@
      A point which aggregates other nodes into a hierarchy of physical
      locations.
     </para>
+    <important>
+     <title>Do Not Mix with S3 Buckets</title>
+     <para>
+      S3 <emphasis>buckets</emphasis> or <emphasis>containers</emphasis>
+      represent different terms meaning <emphasis>folders</emphasis> for
+      storing objects.
+     </para>
+    </important>
    </glossdef>
   </glossentry>
   <glossentry><glossterm>CRUSH, &crushmap;</glossterm>
@@ -131,7 +139,7 @@
     </para>
    </glossdef>
   </glossentry>
-  <glossentry><glossterm>archive module</glossterm>
+  <glossentry><glossterm>archive sync module</glossterm>
    <glossdef>
     <para>
      Module that enables creating an &ogw; zone for keeping the history of S3

--- a/xml/ses_glossary.xml
+++ b/xml/ses_glossary.xml
@@ -122,21 +122,22 @@
    </glossdef>
   </glossentry>
  </glossdiv>
- <title>&ogw; Specific Terms</title>
- <glossentry><glossterm>&ogw;</glossterm>
-  <glossdef>
-   <para>
-    The S3/Swift gateway component for &ceph; Object Store.
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry><glossterm>archive module</glossterm>
-  <glossdef>
-   <para>
-    Module that enables creating an &ogw; zone for keeping the history of S3
-    object versions.
-   </para>
-  </glossdef>
- </glossentry>
- <glossdiv></glossdiv>
+ <glossdiv>
+  <title>&ogw; Specific Terms</title>
+  <glossentry><glossterm>&ogw;</glossterm>
+   <glossdef>
+    <para>
+     The S3/Swift gateway component for &ceph; Object Store.
+    </para>
+   </glossdef>
+  </glossentry>
+  <glossentry><glossterm>archive module</glossterm>
+   <glossdef>
+    <para>
+     Module that enables creating an &ogw; zone for keeping the history of S3
+     object versions.
+    </para>
+   </glossdef>
+  </glossentry>
+ </glossdiv>
 </glossary>

--- a/xml/ses_glossary.xml
+++ b/xml/ses_glossary.xml
@@ -22,8 +22,7 @@
  </info>
  <glossdiv>
   <title>General</title>
-  <glossentry>
-   <glossterm>Admin node</glossterm>
+  <glossentry><glossterm>Admin node</glossterm>
    <glossdef>
     <para>
      The node from which you run the <command>ceph-deploy</command> utility to
@@ -31,8 +30,7 @@
     </para>
    </glossdef>
   </glossentry>
-  <glossentry>
-   <glossterm>Bucket</glossterm>
+  <glossentry><glossterm>Bucket</glossterm>
    <glossdef>
     <para>
      A point which aggregates other nodes into a hierarchy of physical
@@ -40,20 +38,18 @@
     </para>
    </glossdef>
   </glossentry>
-  <glossentry>
-   <glossterm>CRUSH, &crushmap;</glossterm>
+  <glossentry><glossterm>CRUSH, &crushmap;</glossterm>
    <glossdef>
     <para>
      <emphasis>Controlled Replication Under Scalable Hashing</emphasis>: An
-     algorithm that determines how to store and retrieve data by computing
-     data storage locations. CRUSH requires a map of the cluster to
-     pseudo-randomly store and retrieve data in OSDs with a uniform
-     distribution of data across the cluster.
+     algorithm that determines how to store and retrieve data by computing data
+     storage locations. CRUSH requires a map of the cluster to pseudo-randomly
+     store and retrieve data in OSDs with a uniform distribution of data across
+     the cluster.
     </para>
    </glossdef>
   </glossentry>
-  <glossentry>
-   <glossterm>Monitor node, MON</glossterm>
+  <glossentry><glossterm>Monitor node, MON</glossterm>
    <glossdef>
     <para>
      A cluster node that maintains maps of cluster state, including the monitor
@@ -61,20 +57,18 @@
     </para>
    </glossdef>
   </glossentry>
-  <glossentry>
-   <glossterm>OSD</glossterm>
+  <glossentry><glossterm>OSD</glossterm>
    <glossdef>
     <para>
      Depending on context, <emphasis>Object Storage Device</emphasis> or
-     <emphasis>Object Storage Daemon</emphasis>. The <command>ceph-osd</command>
-     daemon is the component of &ceph; that is responsible for storing objects
-     on a local file system and providing access to them over the network.
+     <emphasis>Object Storage Daemon</emphasis>. The
+     <command>ceph-osd</command> daemon is the component of &ceph; that is
+     responsible for storing objects on a local file system and providing
+     access to them over the network.
     </para>
    </glossdef>
   </glossentry>
-
-  <glossentry>
-   <glossterm>OSD node</glossterm>
+  <glossentry><glossterm>OSD node</glossterm>
    <glossdef>
     <para>
      A cluster node that stores data, handles data replication, recovery,
@@ -83,16 +77,14 @@
     </para>
    </glossdef>
   </glossentry>
-  <glossentry>
-   <glossterm>Node</glossterm>
+  <glossentry><glossterm>Node</glossterm>
    <glossdef>
     <para>
      Any single machine or server in a Ceph cluster.
     </para>
    </glossdef>
   </glossentry>
-  <glossentry>
-   <glossterm>PG</glossterm>
+  <glossentry><glossterm>PG</glossterm>
    <glossdef>
     <para>
      Placement Group: a sub-division of a <emphasis>pool</emphasis>, used for
@@ -100,17 +92,14 @@
     </para>
    </glossdef>
   </glossentry>
-  
-  <glossentry>
-   <glossterm>Pool</glossterm>
+  <glossentry><glossterm>Pool</glossterm>
    <glossdef>
     <para>
      Logical partitions for storing objects such as disk images.
     </para>
    </glossdef>
   </glossentry>
-  <glossentry>
-   <glossterm>Rule Set</glossterm>
+  <glossentry><glossterm>Rule Set</glossterm>
    <glossdef>
     <para>
      Rules to determine data placement for a pool.
@@ -132,12 +121,22 @@
     </para>
    </glossdef>
   </glossentry>
-  <glossentry><glossterm>&rgw;</glossterm>
-   <glossdef>
-    <para>
-     The S3/Swift gateway component for &ceph; Object Store.
-    </para>
-   </glossdef>
-  </glossentry>
  </glossdiv>
+ <title>&ogw; Specific Terms</title>
+ <glossentry><glossterm>&ogw;</glossterm>
+  <glossdef>
+   <para>
+    The S3/Swift gateway component for &ceph; Object Store.
+   </para>
+  </glossdef>
+ </glossentry>
+ <glossentry><glossterm>archive module</glossterm>
+  <glossdef>
+   <para>
+    Module that enables creating an &ogw; zone for keeping the history of S3
+    object versions.
+   </para>
+  </glossdef>
+ </glossentry>
+ <glossdiv></glossdiv>
 </glossary>


### PR DESCRIPTION
Archive sync modul enables creating a new OGW zone for collecting history of OGW objects' versions.

- Created a new section describing what archive modul is and how to create its zone.
- updated docupdates section
- extended glossary for 1 term