### PR TITLE
Adding SUSE recommendation for erasure coded pools (BSC#1153481)

### DIFF
--- a/xml/admin_ceph_erasure.xml
+++ b/xml/admin_ceph_erasure.xml
@@ -158,6 +158,8 @@ ABCDEFGHI</screen>
       10KB object will be divided into <literal>k</literal> objects of 5KB
       each.
       The default <literal>min_size</literal> on erasure coded pools is <literal>k + 1</literal>.
+      However, we recommend <literal>min_size</literal> to be <literal>k + 2</literal> or
+      more to prevent loss of writes and data.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
The original pull request https://github.com/SUSE/doc-ses/pull/111/files
updated with the default min_size for EC pools.
This PR includes the recommended size from SUSE.