### PR TITLE
Fixed minor formatting issues in ntp to chrony migration section

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -311,7 +311,8 @@ mds standby for name = mds.456-another-mds
    the time synchronization daemon on each cluster node. You can migrate to
    <systemitem>chronyd</systemitem> either
    <emphasis role="bold">before</emphasis> the cluster, or upgrade the cluster
-   and migrate to <systemitem class="daemon">chronyd</systemitem> afterwards.
+   and migrate to <systemitem class="daemon">chronyd</systemitem>
+   <emphasis role="bold">afterward</emphasis>.
   </para>
 
   <procedure>
@@ -334,14 +335,14 @@ mds standby for name = mds.456-another-mds
     <para>
      Disable and stop the <systemitem class="daemon">ntpd</systemitem> service:
     </para>
-<screen>&prompt.smaster;systemctl disable ntpd.service &amp;&amp;systemctl stop ntpd.service</screen>
+<screen>&prompt.smaster;systemctl disable ntpd.service &amp;&amp; systemctl stop ntpd.service</screen>
    </step>
    <step>
     <para>
      Start and enable the <systemitem class="daemon">chronyd</systemitem>
      service:
     </para>
-<screen>&prompt.smaster;systemctl start chronyd.service &amp;&amp;systemctl enable chronyd.service</screen>
+<screen>&prompt.smaster;systemctl start chronyd.service &amp;&amp; systemctl enable chronyd.service</screen>
    </step>
    <step>
     <para>
@@ -396,14 +397,14 @@ mds standby for name = mds.456-another-mds
     <para>
      Disable and stop the <systemitem class="daemon">ntpd</systemitem> service:
     </para>
-<screen>&prompt.smaster;systemctl disable ntpd.service &amp;&amp;systemctl stop ntpd.service</screen>
+<screen>&prompt.smaster;systemctl disable ntpd.service &amp;&amp; systemctl stop ntpd.service</screen>
    </step>
    <step>
     <para>
      Start and enable the <systemitem class="daemon">chronyd</systemitem>
      service:
     </para>
-<screen>&prompt.smaster;systemctl start chronyd.service &amp;&amp;systemctl enable chronyd.service</screen>
+<screen>&prompt.smaster;systemctl start chronyd.service &amp;&amp; systemctl enable chronyd.service</screen>
    </step>
    <step>
     <para>


### PR DESCRIPTION
Found several text formatting flaws in the ntp to chrony migration section.
This PR fixes them.