### PR TITLE
Add instruction for how to increase prometheus data store (BSC#1123032)

### DIFF
--- a/xml/admin_gui_oa.xml
+++ b/xml/admin_gui_oa.xml
@@ -360,7 +360,44 @@ RGW_API_SECRET_KEY="lJzPbZYZTv8FzmJS5eiiZPHxlT2LMGOMW8ZAeOAq"</screen>
     original scale, double-click the chart.
    </para>
   </tip>
+  <para>Within openATTIC there are options to display graphs for longer than
+    15 days. However, by default prometheus only stores history for 15 days.
+    This can be adjusted in <filename>/etc/systemd/system/multi-user.target.wants/prometheus.service</filename>.</para>
+  <procedure>
+    <step>
+      <para>
+        Open <filename>/etc/systemd/system/multi-user.target.wants/prometheus.service</filename>.
+      </para>
+    </step>
+    <step>
+      <para>
+        This file should reference the following:
+      </para>
+      <screen>
+        EnvironmentFile=-/etc/sysconfig/prometheus
+        ExecStart=/usr/bin/prometheus $ARGS
+      </screen>
+      <para>If not does not, add the above two lines and include
+        the following:</para>
+      <screen>
+        ARGS="--storage.tsdb.retention=90d" \
+              --log.level=warn"
+      </screen>
+      <tip>
+        <para>Ensure <literal>ARGS</literal> is a multiline bash string.
+        This enables prometheus to store up to 90 days of data.</para>
+        <para>If you want other time options, the format is as follows:
+          xxh, xxd, xxw, xxy (hours, days, weeks, years).</para>
+      </tip>
+    </step>
+    <step>
+      <para>
+        Restart the prometheus service.
+      </para>
+    </step>
+  </procedure>
  </sect1>
+
  <sect1 xml:id="ceph-oa-webui-ceph">
   <title>&ceph; Related Tasks</title>
 

--- a/xml/admin_gui_oa.xml
+++ b/xml/admin_gui_oa.xml
@@ -387,7 +387,9 @@ RGW_API_SECRET_KEY="lJzPbZYZTv8FzmJS5eiiZPHxlT2LMGOMW8ZAeOAq"</screen>
         <para>Ensure <literal>ARGS</literal> is a multiline bash string.
         This enables &prometheus; to store up to 90 days of data.</para>
         <para>If you want other time options, the format is as follows:
-          xxh, xxd, xxw, xxy (hours, days, weeks, years).</para>
+          <replaceable>number</replaceable> X <replaceable>time multiplier</replaceable>
+          (where <replaceable>time multiplier</replaceable> can be h[ours], d[ays], w[eeks],
+          y[ears]).</para>
       </tip>
     </step>
     <step>

--- a/xml/admin_gui_oa.xml
+++ b/xml/admin_gui_oa.xml
@@ -360,9 +360,9 @@ RGW_API_SECRET_KEY="lJzPbZYZTv8FzmJS5eiiZPHxlT2LMGOMW8ZAeOAq"</screen>
     original scale, double-click the chart.
    </para>
   </tip>
-  <para>Within openATTIC there are options to display graphs for longer than
-    15 days. However, by default prometheus only stores history for 15 days.
-    This can be adjusted in <filename>/etc/systemd/system/multi-user.target.wants/prometheus.service</filename>.</para>
+  <para>Within &oa; there are options to display graphs for longer than
+    15 days. However, by default &prometheus; only stores history for 15 days.
+    You can adjust this behavior in <filename>/etc/systemd/system/multi-user.target.wants/prometheus.service</filename>.</para>
   <procedure>
     <step>
       <para>
@@ -385,14 +385,14 @@ RGW_API_SECRET_KEY="lJzPbZYZTv8FzmJS5eiiZPHxlT2LMGOMW8ZAeOAq"</screen>
       </screen>
       <tip>
         <para>Ensure <literal>ARGS</literal> is a multiline bash string.
-        This enables prometheus to store up to 90 days of data.</para>
+        This enables &prometheus; to store up to 90 days of data.</para>
         <para>If you want other time options, the format is as follows:
           xxh, xxd, xxw, xxy (hours, days, weeks, years).</para>
       </tip>
     </step>
     <step>
       <para>
-        Restart the prometheus service.
+        Restart the &prometheus; service.
       </para>
     </step>
   </procedure>


### PR DESCRIPTION
By default prometheus only stores 15 days. These instructions
allow the user to alter this env.