### PR TITLE
Added a tip on monitoring cluster nodes' status during upgrade (bsc#1154568)

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -766,6 +766,7 @@ mds standby for name = mds.456-another-mds
    installer DVD</emphasis>, or using the <emphasis>distribution migration
    system</emphasis>.
   </para>
+
   <para>
    After upgrading each node, we recommend running
    <command>rpmconfigcheck</command> to check for any updated configuration
@@ -1088,6 +1089,31 @@ preserve:
     </para>
    </listitem>
   </itemizedlist>
+
+  <tip>
+   <title>Status of Cluster Nodes</title>
+   <para>
+    After the &adm; is upgraded, you can run the <command>salt-run
+    upgrade.status</command> command to view useful information about cluster
+    nodes. The command lists the &ceph; and OS versions of all nodes, and
+    recommends the order in which to upgrade any nodes that are still running
+    old versions.
+   </para>
+<screen>&prompt.smaster;salt-run upgrade.status
+The newest installed software versions are:
+  ceph: ceph version 14.2.1-468-g994fd9e0cc (994fd9e0ccc50c2f3a55a3b7a3d4e0ba74786d50) nautilus (stable)
+  os: SUSE Linux Enterprise Server 15 SP1
+
+Nodes running these software versions:
+  admin.ceph (assigned roles: master)
+  mon2.ceph (assigned roles: admin, mon, mgr)
+
+Nodes running older software versions must be upgraded in the following order:
+   1: mon1.ceph (assigned roles: admin, mon, mgr)
+   2: mon3.ceph (assigned roles: admin, mon, mgr)
+   3: data1.ceph (assigned roles: storage)
+[...]</screen>
+  </tip>
  </sect1>
  <sect1 xml:id="upgrade-mons">
   <title>Upgrade &mon;/&mgr; Nodes</title>
@@ -1423,21 +1449,6 @@ data:
   usage:   31 GiB used, 566 GiB / 597 GiB avail
   pgs:     1024 active+clean
 </screen>
-    <tip>
-     <title>Check for the Version of Cluster Components/Nodes</title>
-     <para>
-      When you need to find out the versions of individual cluster components
-      and nodes&mdash;for example to find out if all your nodes are actually on
-      the same patch level after the upgrade&mdash;you can run
-     </para>
-<screen>&prompt.smaster;salt-run status.report</screen>
-     <para>
-      The command goes through the connected &sminion;s and scans for the
-      version numbers of &ceph;, &salt;, and &sls;, and gives you a report
-      displaying the version that the majority of nodes have and showing nodes
-      whose version is different from the majority.
-     </para>
-    </tip>
    </step>
    <step>
     <para>

--- a/xml/deployment_docupdates.xml
+++ b/xml/deployment_docupdates.xml
@@ -74,6 +74,13 @@
    <title>Bugfixes</title>
    <listitem>
     <para>
+     Added a tip on monitoring cluster nodes' status during upgrade in
+     <xref linkend="upgrade-adm"/>
+     (<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=1154568"/>).
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      Added <xref linkend="upgrade-one-node-auto"/>
      (<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=1154438"/>).
     </para>


### PR DESCRIPTION
After admin node is upgraded, you can watch all cluster nodes' status. The `upgrade.status`
 runner replaces the old `status.report`