### PR TITLE
Made network recommendations more specific (bsc#1156631)

### DIFF
--- a/xml/deployment_docupdates.xml
+++ b/xml/deployment_docupdates.xml
@@ -74,6 +74,13 @@
    <title>Bugfixes</title>
    <listitem>
     <para>
+     Made the network recommendations synchronized and more specific in
+     <xref linkend="ceph-install-ceph-deploy-network"/>
+     (<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=1156631"/>).
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      Added <xref linkend="upgrade-one-node-auto"/>
      (<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=1154438"/>).
     </para>

--- a/xml/deployment_hwrecommend.xml
+++ b/xml/deployment_hwrecommend.xml
@@ -375,12 +375,11 @@
   <title>Network Recommendations</title>
 
   <para>
-   For the &ceph; cluster network environment, we recommend either two bonded
-   10 GbE network interfaces, or one 25 GbE network interface. The network
-   interfaces should be split into a public client part, and a trusted internal
-   part using VLANs. Use the 802.3ad bonding mode to provide maximum bandwidth
-   and resiliency. Find more details about configuring bonded network
-   interfaces in
+   For the &ceph; cluster network environment, we recommend two bonded 25 GbE
+   network interfaces. The network interfaces should be split into a public
+   client part, and a trusted internal part using VLANs. Use the 802.3ad
+   bonding mode to provide maximum bandwidth and resiliency. Find more details
+   about configuring bonded network interfaces in
    <link xlink:href="https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-network.html#sec-network-iface-bonding"/>
   </para>
 

--- a/xml/deployment_hwrecommend.xml
+++ b/xml/deployment_hwrecommend.xml
@@ -375,11 +375,12 @@
   <title>Network Recommendations</title>
 
   <para>
-   The network environment where you intend to run &ceph; should ideally be a
-   bonded set of at least two network interfaces that is logically split into a
-   public part and a trusted internal part using VLANs. The bonding mode is
-   recommended to be 802.3ad if possible to provide maximum bandwidth and
-   resiliency.
+   For the &ceph; cluster network environment, we recommend a bonded set of at
+   least two separate 25 GbE network interfaces. The networks interfaces should
+   be split into a public client part, and a trusted internal part using VLANs.
+   Use the 802.3ad bonding mode to provide maximum bandwidth and resiliency.
+   Find more details about configuring bonded network interfaces in
+   <link xlink:href="https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-network.html#sec-network-iface-bonding"/>
   </para>
 
   <para>

--- a/xml/deployment_hwrecommend.xml
+++ b/xml/deployment_hwrecommend.xml
@@ -376,7 +376,7 @@
 
   <para>
    For the &ceph; cluster network environment, we recommend either two bonded
-   10GbE network interfaces, or one 25 GbE network interfaces. The network
+   10 GbE network interfaces, or one 25 GbE network interface. The network
    interfaces should be split into a public client part, and a trusted internal
    part using VLANs. Use the 802.3ad bonding mode to provide maximum bandwidth
    and resiliency. Find more details about configuring bonded network

--- a/xml/deployment_hwrecommend.xml
+++ b/xml/deployment_hwrecommend.xml
@@ -375,11 +375,12 @@
   <title>Network Recommendations</title>
 
   <para>
-   For the &ceph; cluster network environment, we recommend a bonded set of at
-   least two separate 25 GbE network interfaces. The networks interfaces should
-   be split into a public client part, and a trusted internal part using VLANs.
-   Use the 802.3ad bonding mode to provide maximum bandwidth and resiliency.
-   Find more details about configuring bonded network interfaces in
+   For the &ceph; cluster network environment, we recommend either two bonded
+   10GbE network interfaces, or one 25 GbE network interfaces. The network
+   interfaces should be split into a public client part, and a trusted internal
+   part using VLANs. Use the 802.3ad bonding mode to provide maximum bandwidth
+   and resiliency. Find more details about configuring bonded network
+   interfaces in
    <link xlink:href="https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-network.html#sec-network-iface-bonding"/>
   </para>
 


### PR DESCRIPTION
The general paragraph about network recommendations was a bit vague and did not refer
to a SLE section which explains how to set bonding devices. This PR amends that.