### PR TITLE
Broken link to the NFS chapter of the SLES15-SP1 admin guide

### DIFF
--- a/xml/admin_nfsganesha.xml
+++ b/xml/admin_nfsganesha.xml
@@ -24,7 +24,7 @@
  </info>
  <para>
   &ganesha; is an NFS server (refer to
-  <link xlink:href="https://www.suse.com/documentation/sles-15/book_sle_admin/data/cha_nfs.html">Sharing
+  <link xlink:href="https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-nfs.html">Sharing
   File Systems with NFS</link> ) that runs in a user address space instead of
   as part of the operating system kernel. With &ganesha;, you can plug in your
   own storage mechanism&mdash;such as &ceph;&mdash;and access it from any NFS


### PR DESCRIPTION
this updates the link to the current correct URI.