### PR TITLE
Updating the "ceph mds set" command (BSC#1157885)

### DIFF
--- a/xml/admin_ceph_cephfs.xml
+++ b/xml/admin_ceph_cephfs.xml
@@ -238,7 +238,7 @@
     [...]
     mds: cephfs-1/1/1 up  {0=node2=up:active}, 1 up:standby
     [...]
-&prompt.cephuser;<command>ceph</command> mds set max_mds 2
+&prompt.cephuser;<command>ceph</command> fs set cephfs max_mds 2
 &prompt.cephuser;<command>ceph</command> status
   [...]
   services:
@@ -283,7 +283,7 @@
     [...]
     mds: cephfs-2/2/2 up  {0=node2=up:active,1=node1=up:active}
     [...]
-&prompt.cephuser;<command>ceph</command> mds set max_mds 1
+&prompt.cephuser;<command>ceph</command> fs set cephfs max_mds 1
 &prompt.cephuser;<command>ceph</command> status
   [...]
   services:


### PR DESCRIPTION
The "ceph mds set" does not exist in SES6, updates the
commit to "ceph fs set cephfs"