### PR TITLE
Added release notes for Ceph 14.2.5 (bsc#1158944)

### DIFF
--- a/xml/admin_docupdates.xml
+++ b/xml/admin_docupdates.xml
@@ -45,7 +45,12 @@
   <title>Maintenance update of &productname; 6 documentation</title>
 
   <itemizedlist mark="bullet" spacing="normal">
-   <title>General Updates</title>
+   <listitem>
+    <para>
+     Added a list of new features for &ceph; 14.2.5 in the '&ceph; Maintenance
+     Updates Based on Upstream '&cephname;' Point Releases' appendix.
+    </para>
+   </listitem>
    <listitem>
     <para>
      Added <xref linkend="archive-sync-module"/>
@@ -64,10 +69,6 @@
      (<link xlink:href="https://jira.suse.com/browse/SES-269"/>).
     </para>
    </listitem>
-  </itemizedlist>
-
-  <itemizedlist mark="bullet" spacing="normal">
-   <title>Bugfixes</title>
    <listitem>
     <para>
      Added <filename>/etc/ceph</filename> to the list of backup content in

--- a/xml/ceph_maintenance_updates.xml
+++ b/xml/ceph_maintenance_updates.xml
@@ -33,6 +33,257 @@
   point release that has been&mdash;or is planned to be&mdash;included in the
   product.
  </para>
+ <bridgehead renderas="sect1">&cephname; 14.2.5 Point Release</bridgehead>
+ <itemizedlist>
+  <listitem>
+   <para>
+    <emphasis role="bold">Health warnings will be issued if daemons have
+    recently crashed.</emphasis> &ceph; will now issue health warnings if
+    daemons have recently crashed. &ceph; has been collecting crash reports
+    since the initial Nautilus release, but the health alerts are new. To view
+    new crashes (or all crashes, if you have just upgraded), run:
+   </para>
+<screen>&prompt.cephuser;ceph crash ls-new</screen>
+   <para>
+    To acknowledge a particular crash (or all crashes) and silence the health
+    warning, run:
+   </para>
+<screen>
+&prompt.cephuser;ceph crash archive <replaceable>CRASH-ID</replaceable>
+&prompt.cephuser;ceph crash archive-all
+</screen>
+  </listitem>
+  <listitem>
+   <para>
+    <emphasis role="bold"><option>pg_num</option> must be a power of two,
+    otherwise HEALTH_WARN is reported.</emphasis> &ceph; will now issue a
+    health warning if a &rados; pool has a <option>pg_num</option> value that
+    is not a power of two. You can fix this by adjusting the pool to a nearby
+    power of two:
+   </para>
+<screen>
+&prompt.cephuser;ceph osd pool set <replaceable>POOL-NAME</replaceable> pg_num <replaceable>NEW-PG-NUM</replaceable>
+</screen>
+   <para>
+    Alternatively, you can silenced the warning with:
+   </para>
+<screen>
+&prompt.cephuser;ceph config set global mon_warn_on_pool_pg_num_not_power_of_two false
+</screen>
+  </listitem>
+  <listitem>
+   <para>
+    <emphasis role="bold">Pool size needs to be > 1, otherwise HEALTH_WARN is
+    reported.</emphasis> &ceph; will issue a health warning if a &rados;
+    pool’s size is set to 1 or, in other words, if the pool is configured
+    with no redundancy. &ceph; will stop issuing the warning if the pool size
+    is set to the minimum recommended value:
+   </para>
+<screen>
+&prompt.cephuser;ceph osd pool set <replaceable>POOL-NAME</replaceable> size <replaceable>NUM-REPLICAS</replaceable>
+</screen>
+   <para>
+    You can silence the warning with:
+   </para>
+<screen>
+&prompt.cephuser;ceph config set global mon_warn_on_pool_no_redundancy false
+</screen>
+  </listitem>
+  <listitem>
+   <para>
+    <emphasis role="bold">Health warning is reported if average OSD heartbeat
+    ping time exceeds threshold.</emphasis> A health warning is now generated
+    if the average OSD heartbeat ping time exceeds a configurable threshold for
+    any of the intervals computed. The OSD computes 1 minute, 5 minute and 15
+    minute intervals with average, minimum, and maximum values.
+   </para>
+   <para>
+    A new configuration option, <option>mon_warn_on_slow_ping_ratio</option>,
+    specifies a percentage of <option>osd_heartbeat_grace</option> to determine
+    the threshold. A value of zero disables the warning.
+   </para>
+   <para>
+    A new configuration option, <option>mon_warn_on_slow_ping_time</option>,
+    specified in milliseconds, overrides the computed value and causes a
+    warning when OSD heartbeat pings take longer than the specified amount.
+   </para>
+   <para>
+    A new command <command>ceph daemon
+    mgr.<replaceable>MGR-NUMBER</replaceable> dump_osd_network
+    <replaceable>THRESHOLD</replaceable></command> lists all connections with a
+    ping time longer than the specified threshold or value determined by the
+    configuration options, for the average for any of the 3 intervals.
+   </para>
+   <para>
+    A new command <command>ceph daemon osd.# dump_osd_network
+    <replaceable>THRESHOLD</replaceable></command> will do the same as the
+    previous one but only including heartbeats initiated by the specified OSD.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    <emphasis role="bold">Changes in the telemetry MGR module.</emphasis>
+   </para>
+   <para>
+    A new 'device' channel (enabled by default) will report anonymized hard
+    disk and SSD health metrics to telemetry.ceph.com in order to build and
+    improve device failure prediction algorithms.
+   </para>
+   <para>
+    Telemetry reports information about &cephfs; file systems, including:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+      how many MDS daemons (in total and per file system)
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      which features are (or have been) enabled
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      how many data pools
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      approximate file system age (year + month of creation)
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      how many files, bytes, and snapshots
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      how much metadata is being cached
+     </para>
+    </listitem>
+   </itemizedlist>
+   <para>
+    Other miscellaneous information:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+      which &ceph; release the monitors are running
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      whether msgr v1 or v2 addresses are used for the monitors
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      whether IPv4 or IPv6 addresses are used for the monitors
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      whether &rados; cache tiering is enabled (and which mode)
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      whether pools are replicated or erasure coded, and which erasure code
+      profile plug-in and parameters are in use
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      how many hosts are in the cluster, and how many hosts have each type of
+      daemon
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      whether a separate OSD cluster network is being used
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      how many RBD pools and images are in the cluster, and how many pools have
+      RBD mirroring enabled
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      how many RGW daemons, zones, and zonegroups are present; which RGW
+      frontends are in use
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      aggregate stats about the &crushmap;, such as which algorithms are used,
+      how big buckets are, how many rules are defined, and what tunables are in
+      use
+     </para>
+    </listitem>
+   </itemizedlist>
+   <para>
+    If you had telemetry enabled before 14.2.5, you will need to re-opt-in
+    with:
+   </para>
+<screen>&prompt.cephuser;ceph telemetry on</screen>
+   <para>
+    If you are not comfortable sharing device metrics, you can disable that
+    channel first before re-opting-in:
+   </para>
+<screen>
+&prompt.cephuser;ceph config set mgr mgr/telemetry/channel_device false
+&prompt.cephuser;ceph telemetry on
+</screen>
+   <para>
+    You can view exactly what information will be reported first with:
+   </para>
+<screen>
+&prompt.cephuser;ceph telemetry show        # see everything
+&prompt.cephuser;ceph telemetry show device # just the device info
+&prompt.cephuser;ceph telemetry show basic  # basic cluster info
+</screen>
+  </listitem>
+  <listitem>
+   <para>
+    <emphasis role="bold">New OSD daemon command
+    <command>dump_recovery_reservations</command></emphasis>. It reveals the
+    recovery locks held (in_progress) and waiting in priority queues. Usage:
+   </para>
+<screen>
+&prompt.cephuser;ceph daemon osd.<replaceable>ID</replaceable> dump_recovery_reservations
+</screen>
+  </listitem>
+  <listitem>
+   <para>
+    <emphasis role="bold">New OSD daemon command
+    <command>dump_scrub_reservations</command>. </emphasis> It reveals the
+    scrub reservations that are held for local (primary) and remote (replica)
+    PGs. Usage:
+   </para>
+<screen>
+&prompt.cephuser;ceph daemon osd.<replaceable>ID</replaceable> dump_scrub_reservations
+</screen>
+  </listitem>
+  <listitem>
+   <para>
+    <emphasis role="bold">RGW now supports S3 Object Lock set of
+    APIs.</emphasis> RGW now supports S3 Object Lock set of APIs allowing for a
+    WORM model for storing objects. 6 new APIs have been added put/get bucket
+    object lock, put/get object retention, put/get object legal hold.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    <emphasis role="bold"> RGW now supports List Objects V2.</emphasis> RGW now
+    supports List Objects V2 as specified at
+    <link xlink:href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html"/>.
+   </para>
+  </listitem>
+ </itemizedlist>
  <bridgehead renderas="sect1">&cephname; 14.2.4 Point Release</bridgehead>
  <para>
   This point release fixes a serious regression that found its way into the

--- a/xml/ceph_maintenance_updates.xml
+++ b/xml/ceph_maintenance_updates.xml
@@ -37,7 +37,7 @@
  <itemizedlist>
   <listitem>
    <para>
-    <emphasis role="bold">Health warnings will be issued if daemons have
+    <emphasis role="bold">Health warnings are now issued if daemons have
     recently crashed.</emphasis> &ceph; will now issue health warnings if
     daemons have recently crashed. &ceph; has been collecting crash reports
     since the initial Nautilus release, but the health alerts are new. To view
@@ -56,7 +56,7 @@
   <listitem>
    <para>
     <emphasis role="bold"><option>pg_num</option> must be a power of two,
-    otherwise HEALTH_WARN is reported.</emphasis> &ceph; will now issue a
+    otherwise <literal>HEALTH_WARN</literal> is reported.</emphasis> &ceph; will now issue a
     health warning if a &rados; pool has a <option>pg_num</option> value that
     is not a power of two. You can fix this by adjusting the pool to a nearby
     power of two:
@@ -65,7 +65,7 @@
 &prompt.cephuser;ceph osd pool set <replaceable>POOL-NAME</replaceable> pg_num <replaceable>NEW-PG-NUM</replaceable>
 </screen>
    <para>
-    Alternatively, you can silenced the warning with:
+    Alternatively, you can silence the warning with:
    </para>
 <screen>
 &prompt.cephuser;ceph config set global mon_warn_on_pool_pg_num_not_power_of_two false
@@ -73,9 +73,9 @@
   </listitem>
   <listitem>
    <para>
-    <emphasis role="bold">Pool size needs to be > 1, otherwise HEALTH_WARN is
+    <emphasis role="bold">Pool size needs to be greater than 1 otherwise <literal>HEALTH_WARN</literal> is
     reported.</emphasis> &ceph; will issue a health warning if a &rados;
-    pool’s size is set to 1 or, in other words, if the pool is configured
+    pool’s size is set to 1 or if the pool is configured
     with no redundancy. &ceph; will stop issuing the warning if the pool size
     is set to the minimum recommended value:
    </para>
@@ -92,7 +92,7 @@
   <listitem>
    <para>
     <emphasis role="bold">Health warning is reported if average OSD heartbeat
-    ping time exceeds threshold.</emphasis> A health warning is now generated
+    ping time exceeds the threshold.</emphasis> A health warning is now generated
     if the average OSD heartbeat ping time exceeds a configurable threshold for
     any of the intervals computed. The OSD computes 1 minute, 5 minute and 15
     minute intervals with average, minimum, and maximum values.
@@ -126,7 +126,7 @@
    </para>
    <para>
     A new 'device' channel (enabled by default) will report anonymized hard
-    disk and SSD health metrics to telemetry.ceph.com in order to build and
+    disk and SSD health metrics to <literal>telemetry.ceph.com</literal> in order to build and
     improve device failure prediction algorithms.
    </para>
    <para>
@@ -135,32 +135,32 @@
    <itemizedlist>
     <listitem>
      <para>
-      how many MDS daemons (in total and per file system)
+      How many MDS daemons (in total and per file system).
      </para>
     </listitem>
     <listitem>
      <para>
-      which features are (or have been) enabled
+      Which features are (or have been) enabled.
      </para>
     </listitem>
     <listitem>
      <para>
-      how many data pools
+      How many data pools.
      </para>
     </listitem>
     <listitem>
      <para>
-      approximate file system age (year + month of creation)
+      Approximate file system age (year and the month of creation).
      </para>
     </listitem>
     <listitem>
      <para>
-      how many files, bytes, and snapshots
+      How many files, bytes, and snapshots.
      </para>
     </listitem>
     <listitem>
      <para>
-      how much metadata is being cached
+      How much metadata is being cached.
      </para>
     </listitem>
    </itemizedlist>
@@ -170,58 +170,64 @@
    <itemizedlist>
     <listitem>
      <para>
-      which &ceph; release the monitors are running
+      Which &ceph; release the monitors are running.
      </para>
     </listitem>
     <listitem>
      <para>
-      whether msgr v1 or v2 addresses are used for the monitors
+      Whether msgr v1 or v2 addresses are used for the monitors.
      </para>
     </listitem>
     <listitem>
      <para>
-      whether IPv4 or IPv6 addresses are used for the monitors
+      Whether IPv4 or IPv6 addresses are used for the monitors.
      </para>
     </listitem>
     <listitem>
      <para>
-      whether &rados; cache tiering is enabled (and which mode)
+      Whether &rados; cache tiering is enabled (and the mode).
      </para>
     </listitem>
     <listitem>
      <para>
       whether pools are replicated or erasure coded, and which erasure code
-      profile plug-in and parameters are in use
+      Whether pools are replicated or erasure coded, and which erasure code
+      profile plug-in and parameters are in use.
      </para>
     </listitem>
     <listitem>
      <para>
       how many hosts are in the cluster, and how many hosts have each type of
-      daemon
+      How many hosts are in the cluster, and how many hosts have each type of
+      daemon.
      </para>
     </listitem>
     <listitem>
      <para>
-      whether a separate OSD cluster network is being used
+      Whether a separate OSD cluster network is being used.
      </para>
     </listitem>
     <listitem>
      <para>
-      how many RBD pools and images are in the cluster, and how many pools have
+      How many RBD pools and images are in the cluster, and how many pools have
+      RBD mirroring enabled.
       RBD mirroring enabled
      </para>
     </listitem>
     <listitem>
      <para>
       how many RGW daemons, zones, and zonegroups are present; which RGW
-      frontends are in use
+      How many RGW daemons, zones, and zonegroups are present and which RGW
+      frontends are in use.
      </para>
     </listitem>
     <listitem>
      <para>
       aggregate stats about the &crushmap;, such as which algorithms are used,
       how big buckets are, how many rules are defined, and what tunables are in
-      use
+      Aggregate stats about the &crushmap;, such as which algorithms are used,
+      how big buckets are, how many rules are defined, and what tunables are in
+      use.
      </para>
     </listitem>
    </itemizedlist>
@@ -251,7 +257,7 @@
    <para>
     <emphasis role="bold">New OSD daemon command
     <command>dump_recovery_reservations</command></emphasis>. It reveals the
-    recovery locks held (in_progress) and waiting in priority queues. Usage:
+    recovery locks held (<option>in_progress</option>) and waiting in priority queues. Usage:
    </para>
 <screen>
 &prompt.cephuser;ceph daemon osd.<replaceable>ID</replaceable> dump_recovery_reservations
@@ -272,13 +278,13 @@
    <para>
     <emphasis role="bold">RGW now supports S3 Object Lock set of
     APIs.</emphasis> RGW now supports S3 Object Lock set of APIs allowing for a
-    WORM model for storing objects. 6 new APIs have been added put/get bucket
+    WORM model for storing objects. 6 new APIs have been added PUT/GET bucket
     object lock, put/get object retention, put/get object legal hold.
    </para>
   </listitem>
   <listitem>
    <para>
-    <emphasis role="bold"> RGW now supports List Objects V2.</emphasis> RGW now
+    <emphasis role="bold">RGW now supports List Objects V2.</emphasis> RGW now
     supports List Objects V2 as specified at
     <link xlink:href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html"/>.
    </para>

--- a/xml/ceph_maintenance_updates.xml
+++ b/xml/ceph_maintenance_updates.xml
@@ -274,7 +274,7 @@
     <emphasis role="bold">RGW now supports S3 Object Lock set of
     APIs.</emphasis> RGW now supports S3 Object Lock set of APIs allowing for a
     WORM model for storing objects. 6 new APIs have been added PUT/GET bucket
-    object lock, put/get object retention, put/get object legal hold.
+    object lock, PUT/GET object retention, PUT/GET object legal hold.
    </para>
   </listitem>
   <listitem>

--- a/xml/ceph_maintenance_updates.xml
+++ b/xml/ceph_maintenance_updates.xml
@@ -56,10 +56,10 @@
   <listitem>
    <para>
     <emphasis role="bold"><option>pg_num</option> must be a power of two,
-    otherwise <literal>HEALTH_WARN</literal> is reported.</emphasis> &ceph; will now issue a
-    health warning if a &rados; pool has a <option>pg_num</option> value that
-    is not a power of two. You can fix this by adjusting the pool to a nearby
-    power of two:
+    otherwise <literal>HEALTH_WARN</literal> is reported.</emphasis> &ceph;
+    will now issue a health warning if a &rados; pool has a
+    <option>pg_num</option> value that is not a power of two. You can fix this
+    by adjusting the pool to a nearby power of two:
    </para>
 <screen>
 &prompt.cephuser;ceph osd pool set <replaceable>POOL-NAME</replaceable> pg_num <replaceable>NEW-PG-NUM</replaceable>
@@ -73,11 +73,11 @@
   </listitem>
   <listitem>
    <para>
-    <emphasis role="bold">Pool size needs to be greater than 1 otherwise <literal>HEALTH_WARN</literal> is
-    reported.</emphasis> &ceph; will issue a health warning if a &rados;
-    pool’s size is set to 1 or if the pool is configured
-    with no redundancy. &ceph; will stop issuing the warning if the pool size
-    is set to the minimum recommended value:
+    <emphasis role="bold">Pool size needs to be greater than 1 otherwise
+    <literal>HEALTH_WARN</literal> is reported.</emphasis> &ceph; will issue a
+    health warning if a &rados; pool’s size is set to 1 or if the pool is
+    configured with no redundancy. &ceph; will stop issuing the warning if the
+    pool size is set to the minimum recommended value:
    </para>
 <screen>
 &prompt.cephuser;ceph osd pool set <replaceable>POOL-NAME</replaceable> size <replaceable>NUM-REPLICAS</replaceable>
@@ -92,10 +92,10 @@
   <listitem>
    <para>
     <emphasis role="bold">Health warning is reported if average OSD heartbeat
-    ping time exceeds the threshold.</emphasis> A health warning is now generated
-    if the average OSD heartbeat ping time exceeds a configurable threshold for
-    any of the intervals computed. The OSD computes 1 minute, 5 minute and 15
-    minute intervals with average, minimum, and maximum values.
+    ping time exceeds the threshold.</emphasis> A health warning is now
+    generated if the average OSD heartbeat ping time exceeds a configurable
+    threshold for any of the intervals computed. The OSD computes 1 minute, 5
+    minute and 15 minute intervals with average, minimum, and maximum values.
    </para>
    <para>
     A new configuration option, <option>mon_warn_on_slow_ping_ratio</option>,
@@ -126,8 +126,8 @@
    </para>
    <para>
     A new 'device' channel (enabled by default) will report anonymized hard
-    disk and SSD health metrics to <literal>telemetry.ceph.com</literal> in order to build and
-    improve device failure prediction algorithms.
+    disk and SSD health metrics to <literal>telemetry.ceph.com</literal> in
+    order to build and improve device failure prediction algorithms.
    </para>
    <para>
     Telemetry reports information about &cephfs; file systems, including:
@@ -190,14 +190,12 @@
     </listitem>
     <listitem>
      <para>
-      whether pools are replicated or erasure coded, and which erasure code
       Whether pools are replicated or erasure coded, and which erasure code
       profile plug-in and parameters are in use.
      </para>
     </listitem>
     <listitem>
      <para>
-      how many hosts are in the cluster, and how many hosts have each type of
       How many hosts are in the cluster, and how many hosts have each type of
       daemon.
      </para>
@@ -211,20 +209,16 @@
      <para>
       How many RBD pools and images are in the cluster, and how many pools have
       RBD mirroring enabled.
-      RBD mirroring enabled
      </para>
     </listitem>
     <listitem>
      <para>
-      how many RGW daemons, zones, and zonegroups are present; which RGW
       How many RGW daemons, zones, and zonegroups are present and which RGW
       frontends are in use.
      </para>
     </listitem>
     <listitem>
      <para>
-      aggregate stats about the &crushmap;, such as which algorithms are used,
-      how big buckets are, how many rules are defined, and what tunables are in
       Aggregate stats about the &crushmap;, such as which algorithms are used,
       how big buckets are, how many rules are defined, and what tunables are in
       use.
@@ -257,7 +251,8 @@
    <para>
     <emphasis role="bold">New OSD daemon command
     <command>dump_recovery_reservations</command></emphasis>. It reveals the
-    recovery locks held (<option>in_progress</option>) and waiting in priority queues. Usage:
+    recovery locks held (<option>in_progress</option>) and waiting in priority
+    queues. Usage:
    </para>
 <screen>
 &prompt.cephuser;ceph daemon osd.<replaceable>ID</replaceable> dump_recovery_reservations

--- a/xml/deployment_docupdates.xml
+++ b/xml/deployment_docupdates.xml
@@ -48,7 +48,12 @@
   <title>Maintenance update of &productname; 6 documentation</title>
 
   <itemizedlist mark="bullet" spacing="normal">
-   <title>General Updates</title>
+   <listitem>
+    <para>
+     Added a list of new features for &ceph; 14.2.5 in the '&ceph; Maintenance
+     Updates Based on Upstream '&cephname;' Point Releases' appendix.
+    </para>
+   </listitem>
    <listitem>
     <para>
      Suggested running <command>rpmconfigcheck</command> to prevent losing
@@ -68,10 +73,6 @@
      (<link xlink:href="https://jira.suse.com/browse/SES-720"/>).
     </para>
    </listitem>
-  </itemizedlist>
-
-  <itemizedlist mark="bullet" spacing="normal">
-   <title>Bugfixes</title>
    <listitem>
     <para>
      Added a tip on monitoring cluster nodes' status during upgrade in


### PR DESCRIPTION
SES supports new Ceph Nautilus version, this update lists new features in that release.
As a part of this update, i also simplified docupdates sections by joining bugfixes and general updates.