### PR TITLE
Additional software channels (bsc#1158106)

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -449,6 +449,16 @@ mds standby for name = mds.456-another-mds
     Check that required repositories are configured on each cluster's node. To
     list all available repositories, run
    </para>
+   <tip>
+    <title>Upgrade without using SCC, SMT, or RMT</title>
+    <para>
+     If your nodes are not subscribed to one of the supported software
+     channels providers that handle automatic channel adjustment&mdash;such as
+     SMT, RMT, or SCC&mdash;you may need to enable additional software
+     modules/channels.
+    </para>
+   </tip>
+
 <screen>
 &prompt.sminion;zypper lr
 </screen>

--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -450,12 +450,12 @@ mds standby for name = mds.456-another-mds
     list all available repositories, run
    </para>
    <tip>
-    <title>Upgrade without using SCC, SMT, or RMT</title>
+    <title>Upgrade without Using SCC, SMT, or RMT</title>
     <para>
-     If your nodes are not subscribed to one of the supported software
-     channels providers that handle automatic channel adjustment&mdash;such as
-     SMT, RMT, or SCC&mdash;you may need to enable additional software
-     modules/channels.
+     If your nodes are not subscribed to one of the supported software channel
+     providers that handle automatic channel adjustment&mdash;such as SMT, RMT,
+     or SCC&mdash;you may need to enable additional software modules and
+     channels.
     </para>
    </tip>
 

--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -450,7 +450,7 @@ mds standby for name = mds.456-another-mds
     list all available repositories, run
    </para>
    <tip>
-    <title>Upgrade without Using SCC, SMT, or RMT</title>
+    <title>Upgrade Without Using SCC, SMT, or RMT</title>
     <para>
      If your nodes are not subscribed to one of the supported software channel
      providers that handle automatic channel adjustment&mdash;such as SMT, RMT,


### PR DESCRIPTION
When not using repository providers, the upgrade may require enabling additional channels/modules manually. This update adds a tip with that information.