### PR TITLE
Overriding default NTP settings (bsc#1160080)

### DIFF
--- a/xml/admin_ceph_troubleshooting.xml
+++ b/xml/admin_ceph_troubleshooting.xml
@@ -298,7 +298,7 @@ ID WEIGHT TYPE NAME    UP/DOWN REWEIGHT PRIMARY-AFFINITY
     xlink:href="https://www.suse.com/documentation/sles-15/book_sle_admin/data/sec_ntp_yast.html"/>.
   </para>
   <para>
-   If the &adm; is a virtual machine, you need to provide better time sources
+   If the &adm; is a virtual machine, provide better time sources
    for the cluster nodes by overriding the default NTP client configuration:
   </para>
   <orderedlist>

--- a/xml/admin_ceph_troubleshooting.xml
+++ b/xml/admin_ceph_troubleshooting.xml
@@ -312,22 +312,28 @@ ID WEIGHT TYPE NAME    UP/DOWN REWEIGHT PRIMARY-AFFINITY
  To add multiple time servers, the format is as follows:
 </para>
 <screen>time_server:
-  - <replaceable>CUSTOM_NTP_SERVER1</replaceable>
-  - <replaceable>CUSTOM_NTP_SERVER2</replaceable>
-  - <replaceable>CUSTOM_NTP_SERVER3</replaceable>
-[...]</screen>
+ - <replaceable>CUSTOM_NTP_SERVER1</replaceable>
+ - <replaceable>CUSTOM_NTP_SERVER2</replaceable>
+ - <replaceable>CUSTOM_NTP_SERVER3</replaceable>
+ [...]</screen>
    </listitem>
    <listitem>
     <para>
-     To apply the change, refresh the &spillar;:
+     Refresh the &spillar;:
     </para>
-<screen>&prompt.smaster;salt '*' saltutil.pillar_refresh</screen>
+    <screen>&prompt.smaster;salt '*' saltutil.pillar_refresh</screen>
    </listitem>
    <listitem>
     <para>
      Verify the changed value:
     </para>
-<screen>&prompt.smaster;salt '*' pillar.items</screen>
+    <screen>&prompt.smaster;salt '*' pillar.items</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Apply the new setting:
+    </para>
+    <screen>&prompt.smaster;salt '*' state.apply ceph.time</screen>
    </listitem>
   </orderedlist>
   <para>

--- a/xml/admin_ceph_troubleshooting.xml
+++ b/xml/admin_ceph_troubleshooting.xml
@@ -291,7 +291,7 @@ ID WEIGHT TYPE NAME    UP/DOWN REWEIGHT PRIMARY-AFFINITY
   <para>
    By default, &deepsea; uses the &adm; as the time server for other
    cluster nodes. Therefore, if the &adm; is not virtualized, select one or
-   more time servers/pools, and synchronize its local time against them.
+   more time servers or pools, and synchronize the local time against them.
    Verify that the time synchronization service is enabled on each system
    start-up. Find more information on setting up time synchronization in
    <link

--- a/xml/admin_ceph_troubleshooting.xml
+++ b/xml/admin_ceph_troubleshooting.xml
@@ -289,11 +289,41 @@ ID WEIGHT TYPE NAME    UP/DOWN REWEIGHT PRIMARY-AFFINITY
   </para>
 
   <para>
-   Time synchronization is managed with NTP (see
-   <link xlink:href="http://en.wikipedia.org/wiki/Network_Time_Protocol"/>).
-   Set each node to synchronize its time with one or more NTP servers,
-   preferably to the same group of NTP servers. If the time skew still occurs
-   on a node, follow these steps to fix it:
+   By default, &deepsea; uses the &adm; as the time server for other
+   cluster nodes. Therefore, if the &adm; is not virtualized, select one or
+   more time servers/pools, and synchronize its local time against them.
+   Verify that the time synchronization service is enabled on each system
+   start-up. Find more information on setting up time synchronization in
+   <link
+    xlink:href="https://www.suse.com/documentation/sles-15/book_sle_admin/data/sec_ntp_yast.html"/>.
+  </para>
+  <para>
+   If the &adm; is a virtual machine, you need to provide better time sources
+   for the cluster nodes by overriding the default NTP client configuration:
+  </para>
+  <orderedlist>
+   <listitem>
+    <para>
+     Edit <filename>/srv/pillar/ceph/stack/global.yml</filename> on the
+     &smaster; node and add the following line:
+    </para>
+<screen>time_server: <replaceable>CUSTOM_NTP_SERVER</replaceable></screen>
+   </listitem>
+   <listitem>
+    <para>
+     To apply the change, refresh the &spillar;:
+    </para>
+<screen>&prompt.smaster;salt '*' saltutil.pillar_refresh</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Verify the changed value:
+    </para>
+<screen>&prompt.smaster;salt '*' pillar.items</screen>
+   </listitem>
+  </orderedlist>
+  <para>
+   If the time skew still occurs on a node, follow these steps to fix it:
   </para>
 
 <screen>&prompt.root;systemctl stop chronyd.service

--- a/xml/admin_ceph_troubleshooting.xml
+++ b/xml/admin_ceph_troubleshooting.xml
@@ -308,6 +308,14 @@ ID WEIGHT TYPE NAME    UP/DOWN REWEIGHT PRIMARY-AFFINITY
      &smaster; node and add the following line:
     </para>
 <screen>time_server: <replaceable>CUSTOM_NTP_SERVER</replaceable></screen>
+<para>
+ To add multiple time servers, the format is as follows:
+</para>
+<screen>time_server:
+  - <replaceable>CUSTOM_NTP_SERVER1</replaceable>
+  - <replaceable>CUSTOM_NTP_SERVER2</replaceable>
+  - <replaceable>CUSTOM_NTP_SERVER3</replaceable>
+[...]</screen>
    </listitem>
    <listitem>
     <para>

--- a/xml/admin_install_salt.xml
+++ b/xml/admin_install_salt.xml
@@ -475,21 +475,39 @@
    </step>
    <step>
     <para>
-     Select one or more time servers/pools, and synchronize the local time
-     against them. Verify that the time synchronization service is enabled on
-     each system start-up. You can use the <command>yast ntp-client</command>
-     command found in a <package>yast2-ntp-client</package> package to
-     configure time synchronization.
+     By default, &deepsea; will use the &adm; as the time server for other
+     cluster nodes. Therefore, if the &adm; is not virtualized, select one or
+     more time servers/pools, and synchronize its local time against them.
+     Verify that the time synchronization service is enabled on each system
+     start-up. Find more information on setting up time synchronization in
+     <link
+      xlink:href="https://www.suse.com/documentation/sles-15/book_sle_admin/data/sec_ntp_yast.html"/>.
     </para>
-    <tip>
-     <para>
-      Virtual machines are not reliable NTP sources.
-     </para>
-    </tip>
     <para>
-     Find more information on setting up NTP in
-     <link xlink:href="https://www.suse.com/documentation/sles-15/book_sle_admin/data/sec_ntp_yast.html"/>.
+     If the &adm; is a virtual machine, you need to provide better time sources
+     for the cluster nodes by overriding the default NTP client configuration:
     </para>
+    <orderedlist>
+     <listitem>
+      <para>
+       Edit <filename>/srv/pillar/ceph/stack/global.yml</filename> on the
+       &smaster; node and add the following line:
+      </para>
+<screen>time_server: <replaceable>CUSTOM_NTP_SERVER</replaceable></screen>
+     </listitem>
+     <listitem>
+      <para>
+       To apply the change, refresh the &spillar;:
+      </para>
+<screen>&prompt.smaster;salt '*' saltutil.pillar_refresh</screen>
+     </listitem>
+     <listitem>
+      <para>
+       Verify the changed value:
+      </para>
+<screen>&prompt.smaster;salt '*' pillar.items</screen>
+     </listitem>
+    </orderedlist>
    </step>
    <step>
     <para>

--- a/xml/admin_install_salt.xml
+++ b/xml/admin_install_salt.xml
@@ -505,16 +505,22 @@
      </listitem>
      <listitem>
       <para>
-       To apply the change, refresh the &spillar;:
+       Refresh the &spillar;:
       </para>
-<screen>&prompt.smaster;salt '*' saltutil.pillar_refresh</screen>
+      <screen>&prompt.smaster;salt '*' saltutil.pillar_refresh</screen>
      </listitem>
      <listitem>
       <para>
        Verify the changed value:
       </para>
-<screen>&prompt.smaster;salt '*' pillar.items</screen>
+      <screen>&prompt.smaster;salt '*' pillar.items</screen>
      </listitem>
+     <listitem>
+    <para>
+     Apply the new setting:
+    </para>
+    <screen>&prompt.smaster;salt '*' state.apply ceph.time</screen>
+   </listitem>
     </orderedlist>
    </step>
    <step>

--- a/xml/admin_install_salt.xml
+++ b/xml/admin_install_salt.xml
@@ -475,16 +475,16 @@
    </step>
    <step>
     <para>
-     By default, &deepsea; will use the &adm; as the time server for other
+     By default, &deepsea; uses the &adm; as the time server for other
      cluster nodes. Therefore, if the &adm; is not virtualized, select one or
-     more time servers/pools, and synchronize its local time against them.
+     more time servers or pools, and synchronize the local time against them.
      Verify that the time synchronization service is enabled on each system
      start-up. Find more information on setting up time synchronization in
      <link
       xlink:href="https://www.suse.com/documentation/sles-15/book_sle_admin/data/sec_ntp_yast.html"/>.
     </para>
     <para>
-     If the &adm; is a virtual machine, you need to provide better time sources
+     If the &adm; is a virtual machine, provide better time sources
      for the cluster nodes by overriding the default NTP client configuration:
     </para>
     <orderedlist>

--- a/xml/admin_install_salt.xml
+++ b/xml/admin_install_salt.xml
@@ -494,6 +494,14 @@
        &smaster; node and add the following line:
       </para>
 <screen>time_server: <replaceable>CUSTOM_NTP_SERVER</replaceable></screen>
+<para>
+ To add multiple time servers, the format is as follows:
+</para>
+<screen>time_server:
+  - <replaceable>CUSTOM_NTP_SERVER1</replaceable>
+  - <replaceable>CUSTOM_NTP_SERVER2</replaceable>
+  - <replaceable>CUSTOM_NTP_SERVER3</replaceable>
+[...]</screen>
      </listitem>
      <listitem>
       <para>


### PR DESCRIPTION
Deployment section about time synchronization was misleading, this update fixes it and describes how to override the default DeepSea's configuration.