### PR TITLE
'salt osd.retain' is obsoleted (bsc#1160219)

### DIFF
--- a/xml/admin_saltcluster.xml
+++ b/xml/admin_saltcluster.xml
@@ -785,7 +785,7 @@ Device Path Size rotates available Model name
    </step>
    <step>
     <para>
-     Remove unneeded &salt; grains (best after all OSDs have been migrated to LVM):
+     Remove unnecessary &salt; grains (best after all OSDs have been migrated to LVM):
     </para>
 <screen>&prompt.smaster;salt -I roles:storage grains.delkey ceph</screen>
    </step>

--- a/xml/admin_saltcluster.xml
+++ b/xml/admin_saltcluster.xml
@@ -785,9 +785,9 @@ Device Path Size rotates available Model name
    </step>
    <step>
     <para>
-     Update &salt; grains:
+     Remove unneeded &salt; grains (best after all OSDs have been migrated to LVM):
     </para>
-<screen>&prompt.smaster;salt '<replaceable>RECOVERED_MINION</replaceable>' osd.retain</screen>
+<screen>&prompt.smaster;salt -I roles:storage grains.delkey ceph</screen>
    </step>
   </procedure>
  </sect1>


### PR DESCRIPTION
The 'salt osd.retain' command for updating Salt grains after OSD recovery is obsoleted in SES6. This update suggest alternative way to remove stale grains.