### PR TITLE
Updated unclear strings with understandable alternatives

### DIFF
--- a/xml/admin_ceph_cephfs.xml
+++ b/xml/admin_ceph_cephfs.xml
@@ -599,9 +599,9 @@ mds standby for fscid = 2</screen>
        based on the MDS capability, and a quota is configured on an ancestor
        directory they do not have access to (<filename>/home</filename>), the
        client will not enforce it. When using path-based access restrictions,
-       be sure to configure the quota on the directory where the client is
-       restricted too (<filename>/home/user</filename>) or something nested
-       beneath it.
+       be sure to configure the quota on the directory that the client can
+       access (for example <filename>/home/user</filename> or
+       <filename>/home/user/quota_dir</filename>).
       </para>
      </listitem>
     </varlistentry>

--- a/xml/admin_ceph_datamgm.xml
+++ b/xml/admin_ceph_datamgm.xml
@@ -80,7 +80,7 @@
   <listitem>
    <para>
     <xref linkend="datamgm-devices" xrefstyle="select: title"/> consist
-    of any object storage device corresponding to a 
+    of any object storage device corresponding to a
     <systemitem>ceph-osd</systemitem> daemon.
    </para>
   </listitem>
@@ -676,7 +676,7 @@ maps appear equivalent
       <entry>
        <para>
         Abbreviation for "Point of Delivery": in this context, a group of PDUs,
-        or a group of rows of racks.        
+        or a group of rows of racks.
        </para>
       </entry>
      </row>
@@ -1302,7 +1302,7 @@ rule example2 {
     (<option>PGP_NUM</option>) before your cluster will rebalance.
     <option>PGP_NUM</option> will be the number of placement groups that will
     be considered for placement by the CRUSH algorithm. Increasing
-    <option>PGP_NUM</option> splits the placement groups but data will not be
+    <option>PG_NUM</option> splits the placement groups but data will not be
     migrated to the newer placement groups until <option>PGP_NUM</option> is
     increased. <option>PGP_NUM</option> should be equal to
     <option>PG_NUM</option>. To increase the number of placement groups for

--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -285,8 +285,9 @@ mds standby for name = mds.456-another-mds
     <para>
      This will add MDS daemons with the new names before removing the old MDS
      daemons. The number of MDS daemons will double for a short time. Clients
-     will be able to access &cephfs; with a short pause to failover. Therefore
-     plan the migration for times when you expect little or no &cephfs; load.
+     will be able to access &cephfs; only after a short pause to failover.
+     Therefore plan the migration for times when you expect little or no
+     &cephfs; load.
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/admin_gui_dashboard.xml
+++ b/xml/admin_gui_dashboard.xml
@@ -416,7 +416,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term><guimenu>Client Recovery</guimenu></term>
+      <term><guimenu>Client Throughput</guimenu></term>
       <listitem>
        <para></para>
       </listitem>
@@ -1344,7 +1344,7 @@
     not override these values on the pool or RBD image layer. An option value
     specified globally can be overridden on a per-pool or per-image basis.
     Options specified on a pool will be applied to all RBD images of that pool
-    unless overridden by a configuration option set on a pool. Options
+    unless overridden by a configuration option set on an image. Options
     specified on an image will override options specified on a pool and will
     override options specified globally.
    </para>

--- a/xml/admin_install_salt.xml
+++ b/xml/admin_install_salt.xml
@@ -1482,8 +1482,7 @@ default_drive_group_name:
 &prompt.smaster;salt-run disks.list
 </screen>
      <para>
-      This runner returns you a structure of matching disks based on your drive
-      groups. If you are not happy with the result, repeat the previous step.
+      This runner returns you a structure of matching disks based on your &drvgrps;. If you are not happy with the result, repeat the previous step.
      </para>
      <tip>
       <title>Detailed Report</title>
@@ -1500,7 +1499,7 @@ default_drive_group_name:
     <step>
      <para>
       Deploy OSDs. On the next &deepsea; stage 3 invocation, the OSD disks
-      will be deployed according to your drive group specification.
+      will be deployed according to your &drvgrps; specification.
      </para>
     </step>
    </procedure>

--- a/xml/admin_install_salt.xml
+++ b/xml/admin_install_salt.xml
@@ -1482,7 +1482,9 @@ default_drive_group_name:
 &prompt.smaster;salt-run disks.list
 </screen>
      <para>
-      This runner returns you a structure of matching disks based on your &drvgrps;. If you are not happy with the result, repeat the previous step.
+      This runner returns you a structure of matching disks based on your
+      &drvgrps;. If you are not happy with the result, repeat the previous
+      step.
      </para>
      <tip>
       <title>Detailed Report</title>

--- a/xml/admin_saltcluster.xml
+++ b/xml/admin_saltcluster.xml
@@ -973,11 +973,11 @@ Device Path Size rotates available Model name
    </para>
    <para>
     We strongly recommend to use a staging tool to apply patches which have
-    <literal>frozen</literal> or <literal>staged</literal> patch levels. This ensures that
-    new nodes joining the
-    cluster have the same patch level as the nodes already running in the
-    cluster. This way you avoid the need to apply the latest patches to all the
-    cluster's nodes before new nodes can join the cluster.
+    <literal>frozen</literal> or <literal>staged</literal> patch levels. This
+    ensures that new nodes joining the cluster have the same patch level as the
+    nodes already running in the cluster. This way you avoid the need to apply
+    the latest patches to all the cluster's nodes before new nodes can join the
+    cluster.
    </para>
   </sect2>
 

--- a/xml/admin_saltcluster.xml
+++ b/xml/admin_saltcluster.xml
@@ -634,8 +634,8 @@ Device Path Size rotates available Model name
 /dev/sdf 40.00 GB True False QEMU HARDDISK
 /dev/vda 25.00 GB True False</screen>
      <para>
-      LVM metadata is now removed. It is now safe to <command>dd</command> the
-      device.
+      LVM metadata has been removed. You can safely run the
+      <command>dd</command> command on the device.
      </para>
     </step>
     <step>
@@ -972,12 +972,11 @@ Device Path Size rotates available Model name
     created at the same point in time.
    </para>
    <para>
-    We strongly recommend to use a staging tool for patches with
-    <emphasis role="bold">frozen / staged patch levels</emphasis>. This ensures
-    that new nodes joining the cluster have the same patch level as the nodes
-    already running in the cluster. This way you avoid the need to apply the
-    latest patches to all the cluster's nodes before new nodes can join the
-    cluster.
+    We strongly recommend to use a staging tool to apply patches which have
+    'frozen' or 'staged' patch levels. This ensures that new nodes joining the
+    cluster have the same patch level as the nodes already running in the
+    cluster. This way you avoid the need to apply the latest patches to all the
+    cluster's nodes before new nodes can join the cluster.
    </para>
   </sect2>
 

--- a/xml/admin_saltcluster.xml
+++ b/xml/admin_saltcluster.xml
@@ -973,7 +973,8 @@ Device Path Size rotates available Model name
    </para>
    <para>
     We strongly recommend to use a staging tool to apply patches which have
-    'frozen' or 'staged' patch levels. This ensures that new nodes joining the
+    <literal>frozen</literal> or <literal>staged</literal> patch levels. This ensures that
+    new nodes joining the
     cluster have the same patch level as the nodes already running in the
     cluster. This way you avoid the need to apply the latest patches to all the
     cluster's nodes before new nodes can join the cluster.

--- a/xml/ceph_maintenance_updates.xml
+++ b/xml/ceph_maintenance_updates.xml
@@ -379,7 +379,7 @@
     been changed from <literal>firefly</literal> to <literal>hammer</literal>,
     which means the cluster will issue a health warning if your CRUSH tunables
     are older than Hammer. There is generally a small (but non-zero) amount of
-    data that will move around by making the switch to Hammer tunables.
+    data that will be re-balanced after making the switch to Hammer tunables.
    </para>
    <para>
     If possible, we recommend that you set the oldest allowed client to

--- a/xml/ceph_prompts.xml
+++ b/xml/ceph_prompts.xml
@@ -53,9 +53,9 @@
 
   <para>
    These are lower level commands to configure and fine tune all aspects of the
-   cluster and its gateways on the command line. <command>ceph</command>,
-   <command>rbd</command>, <command>radosgw-admin</command>, or
-   <command>crushtool</command> to name some of them.
+   cluster and its gateways on the command line, for example
+   <command>ceph</command>, <command>rbd</command>,
+   <command>radosgw-admin</command>, or <command>crushtool</command>.
   </para>
 
   <para>

--- a/xml/deployment_cifs.xml
+++ b/xml/deployment_cifs.xml
@@ -688,7 +688,7 @@ dc1.domain.example.com  internet address = 10.99.0.1
      After you decide which winbind back-end to use, you need to specify the
      ranges to use with the <option>idmap config</option> option in
      <filename>smb.conf</filename>. By default, there are multiple blocks of
-     users and groups on a Unix domain member:
+     user and group IDs reserved on a Unix domain member:
     </para>
     <table>
      <title>Default Users and Group ID Blocks</title>


### PR DESCRIPTION
The localization team pointed me to several string in SES6 manuals that were unclear and could be said in a simple language. This update offer more legible alternatives.