### PR TITLE
Removing specific instances of x86 in favor of <replaceable> (BSC#1155012)

### DIFF
--- a/xml/admin_ceph_gateway.xml
+++ b/xml/admin_ceph_gateway.xml
@@ -292,12 +292,12 @@ for bucket in conn.get_all_buckets():
      and &sle; 15. Before installing the package, you need to activate the
      module and refresh the software repository:
     </para>
-<screen>&prompt.root;SUSEConnect -p sle-module-public-cloud/12/x86_64
+<screen>&prompt.root;SUSEConnect -p sle-module-public-cloud/12/<replaceable>SYSTEM-ARCH</replaceable>
 sudo zypper refresh</screen>
     <para>
      Or
     </para>
-<screen>&prompt.root;SUSEConnect -p sle-module-public-cloud/15/x86_64
+<screen>&prompt.root;SUSEConnect -p sle-module-public-cloud/15/<replaceable>SYSTEM-ARCH</replaceable>
 &prompt.root;zypper refresh</screen>
     <para>
      To install the <command>swift</command> command, run the following:

--- a/xml/admin_ceph_iscsi.xml
+++ b/xml/admin_ceph_iscsi.xml
@@ -71,15 +71,15 @@
     address; for multipath access repeat these steps with iscsi2.example.com):
    </para>
 <screen>&prompt.root;iscsiadm -m discovery -t sendtargets -p iscsi1.example.com
-192.168.124.104:3260,1 iqn.2003-01.org.linux-iscsi.iscsi.x86:testvol</screen>
+192.168.124.104:3260,1 iqn.2003-01.org.linux-iscsi.iscsi.<replaceable>SYSTEM-ARCH</replaceable>:testvol</screen>
    <para>
     Then, log in to the portal. If the login completes successfully, any
     RBD-backed logical units on the portal will immediately become available on
     the system SCSI bus:
    </para>
 <screen>&prompt.root;iscsiadm -m node -p iscsi1.example.com --login
-Logging in to [iface: default, target: iqn.2003-01.org.linux-iscsi.iscsi.x86:testvol, portal: 192.168.124.104,3260] (multiple)
-Login to [iface: default, target: iqn.2003-01.org.linux-iscsi.iscsi.x86:testvol, portal: 192.168.124.104,3260] successful.</screen>
+Logging in to [iface: default, target: iqn.2003-01.org.linux-iscsi.iscsi.<replaceable>SYSTEM-ARCH</replaceable>:testvol, portal: 192.168.124.104,3260] (multiple)
+Login to [iface: default, target: iqn.2003-01.org.linux-iscsi.iscsi.<replaceable>SYSTEM-ARCH</replaceable>:testvol, portal: 192.168.124.104,3260] successful.</screen>
    <para>
     Repeat this process for other portal IP addresses or hosts.
    </para>
@@ -130,8 +130,8 @@ realtime =none                   extsz=4096   blocks=0, rtextents=0</screen>
     a particular target, run the following command:
    </para>
 <screen>&prompt.root;iscsiadm -m node -p iscsi1.example.com --logout
-Logging out of session [sid: 18, iqn.2003-01.org.linux-iscsi.iscsi.x86:testvol, portal: 192.168.124.104,3260]
-Logout of [sid: 18, target: iqn.2003-01.org.linux-iscsi.iscsi.x86:testvol, portal: 192.168.124.104,3260] successful.</screen>
+Logging out of session [sid: 18, iqn.2003-01.org.linux-iscsi.iscsi.<replaceable>SYSTEM-ARCH</replaceable>:testvol, portal: 192.168.124.104,3260]
+Logout of [sid: 18, target: iqn.2003-01.org.linux-iscsi.iscsi.<replaceable>SYSTEM-ARCH</replaceable>:testvol, portal: 192.168.124.104,3260] successful.</screen>
    <para>
     As with discovery and login, you must repeat the logout steps for all
     portal IP addresses or host names.

--- a/xml/admin_ceph_libvirt.xml
+++ b/xml/admin_ceph_libvirt.xml
@@ -214,7 +214,7 @@ Id    Name                           State
      Under &lt;devices&gt; there should be a &lt;disk&gt; entry.
     </para>
 <screen>&lt;devices&gt;
-    &lt;emulator&gt;/usr/bin/qemu-system-x86_64&lt;/emulator&gt;
+    &lt;emulator&gt;/usr/bin/qemu-system-<replaceable>SYSTEM-ARCH</replaceable>&lt;/emulator&gt;
     &lt;disk type='file' device='disk'&gt;
       &lt;driver name='qemu' type='raw'/&gt;
       &lt;source file='/path/to/image/recent-linux.img'/&gt;

--- a/xml/deployment_hwrecommend.xml
+++ b/xml/deployment_hwrecommend.xml
@@ -32,12 +32,17 @@
    frequency, and RAM perspective, there is no real difference between CPU
    architectures for sizing.
   </para>
-
   <para>
    As with smaller &x86; processors (non-server), lower-performance
    &arm;-based cores may not provide an optimal experience, especially when
    used for erasure coded pools.
   </para>
+  <note>
+    <para>
+      Throughout the documentation, the use of <replaceable>SYSTEM-ARCH</replaceable>
+      is used in place of &x86; or &arm;.
+    </para>
+  </note>
  </sect1>
  <sect1 xml:id="ses-bp-minimum-cluster">
   <title>Minimum Cluster Configuration</title>

--- a/xml/deployment_hwrecommend.xml
+++ b/xml/deployment_hwrecommend.xml
@@ -39,7 +39,7 @@
   </para>
   <note>
     <para>
-      Throughout the documentation, the use of <replaceable>SYSTEM-ARCH</replaceable>
+      Throughout the documentation, <replaceable>SYSTEM-ARCH</replaceable>
       is used in place of &x86; or &arm;.
     </para>
   </note>

--- a/xml/deployment_iscsi.xml
+++ b/xml/deployment_iscsi.xml
@@ -313,18 +313,18 @@
 <screen>&prompt.root;&gwcli;</screen>
    <para>
     Go to <literal>iscsi-targets</literal> and create a target with the name
-    <literal>iqn.2003-01.org.linux-iscsi.iscsi.x86:testvol</literal>:
+    <literal>iqn.2003-01.org.linux-iscsi.iscsi.<replaceable>SYSTEM-ARCH</replaceable>:testvol</literal>:
    </para>
 <screen>
 &prompt.gwcli; /> cd /iscsi-targets
-&prompt.gwcli; /iscsi-targets> create iqn.2003-01.org.linux-iscsi.iscsi.x86:testvol
+&prompt.gwcli; /iscsi-targets> create iqn.2003-01.org.linux-iscsi.iscsi.<replaceable>SYSTEM-ARCH</replaceable>:testvol
 </screen>
    <para>
     Create the iSCSI gateways by specifying the gateway <literal>name</literal>
     and <literal>ip</literal> address:
    </para>
 <screen>
-&prompt.gwcli; /iscsi-targets> cd iqn.2003-01.org.linux-iscsi.iscsi.x86:testvol/gateways
+&prompt.gwcli; /iscsi-targets> cd iqn.2003-01.org.linux-iscsi.iscsi.<replaceable>SYSTEM-ARCH</replaceable>:testvol/gateways
 &prompt.gwcli; /iscsi-target...tvol/gateways> create iscsi1 192.168.124.104
 &prompt.gwcli; /iscsi-target...tvol/gateways> create iscsi2 192.168.124.105
 </screen>
@@ -345,7 +345,7 @@
     Map the RBD image to the target:
    </para>
 <screen>
-&prompt.gwcli; /disks> cd /iscsi-targets/iqn.2003-01.org.linux-iscsi.iscsi.x86:testvol/disks
+&prompt.gwcli; /disks> cd /iscsi-targets/iqn.2003-01.org.linux-iscsi.iscsi.<replaceable>SYSTEM-ARCH</replaceable>:testvol/disks
 &prompt.gwcli; /iscsi-target...testvol/disks> add iscsi-images/testvol
 </screen>
    <note>
@@ -382,7 +382,7 @@
      disabling the ACL authentication:
     </para>
 <screen>
-&prompt.gwcli; /> cd /iscsi-targets/iqn.2003-01.org.linux-iscsi.iscsi.x86:testvol/hosts
+&prompt.gwcli; /> cd /iscsi-targets/iqn.2003-01.org.linux-iscsi.iscsi.<replaceable>SYSTEM-ARCH</replaceable>:testvol/hosts
 &prompt.gwcli; /iscsi-target...testvol/hosts> auth disable_acl
 </screen>
    </sect3>
@@ -393,7 +393,7 @@
      initiators are allowed to connect. You can define an initiator by doing:
     </para>
 <screen>
-&prompt.gwcli; /> cd /iscsi-targets/iqn.2003-01.org.linux-iscsi.iscsi.x86:testvol/hosts
+&prompt.gwcli; /> cd /iscsi-targets/iqn.2003-01.org.linux-iscsi.iscsi.<replaceable>SYSTEM-ARCH</replaceable>:testvol/hosts
 &prompt.gwcli; /iscsi-target...testvol/hosts> create iqn.1996-04.de.suse:01:e6ca28cc9f20
 </screen>
     <para>
@@ -411,7 +411,7 @@
      specifying a user name and password for each initiator:
     </para>
 <screen>
-&prompt.gwcli; /> cd /iscsi-targets/iqn.2003-01.org.linux-iscsi.iscsi.x86:testvol/hosts/iqn.1996-04.de.suse:01:e6ca28cc9f20
+&prompt.gwcli; /> cd /iscsi-targets/iqn.2003-01.org.linux-iscsi.iscsi.<replaceable>SYSTEM-ARCH</replaceable>:testvol/hosts/iqn.1996-04.de.suse:01:e6ca28cc9f20
 &prompt.gwcli; /iscsi-target...:e6ca28cc9f20> auth username=common12 password=pass12345678
 </screen>
     <note>
@@ -486,14 +486,14 @@
      <command>info</command> command:
     </para>
 <screen>
-&prompt.gwcli; /> cd /iscsi-targets/iqn.2003-01.org.linux-iscsi.iscsi.x86:testvol
-&prompt.gwcli; /iscsi-target...i.x86:testvol> info
+&prompt.gwcli; /> cd /iscsi-targets/iqn.2003-01.org.linux-iscsi.iscsi.<replaceable>SYSTEM-ARCH</replaceable>:testvol
+&prompt.gwcli; /iscsi-target...i.<replaceable>SYSTEM-ARCH</replaceable>:testvol> info
 </screen>
     <para>
      And change a setting using the <command>reconfigure</command> command:
     </para>
 <screen>
-&prompt.gwcli; /iscsi-target...i.x86:testvol> reconfigure login_timeout 20
+&prompt.gwcli; /iscsi-target...i.<replaceable>SYSTEM-ARCH</replaceable>:testvol> reconfigure login_timeout 20
 </screen>
     <para>
      The available 'target' settings are:


### PR DESCRIPTION
SES 6 supports both x86 and arm arch, however a lot of commands
specifically poin to x86. This patch offers a suggestion on how to
change this.