### PR TITLE
Aligned list of pool values (bsc#1113674)

### DIFF
--- a/xml/admin_ceph_erasure.xml
+++ b/xml/admin_ceph_erasure.xml
@@ -33,6 +33,11 @@
   For background information on Erasure Code, see
   <link xlink:href="https://en.wikipedia.org/wiki/Erasure_code"/>.
  </para>
+ <para>
+  For a list of pool values related to EC pools, refer to <xref
+   linkend="pool-values-ec"/>.
+ </para>
+
  <note>
   <para>
    When using &filestore;, you cannot access erasure coded pools with the RBD

--- a/xml/admin_operating_pools.xml
+++ b/xml/admin_operating_pools.xml
@@ -574,7 +574,7 @@ pool4                     1.1 MiB      13      0     39                  0      
       <para>
        Set or unset the <literal>WRITE_FADVISE_DONTNEED</literal> flag on a given
        pool's read/write requests to bypass putting data into cache. Default is
-       <literal>flase</literal>. Applies to both replicated and EC pools.
+       <literal>false</literal>. Applies to both replicated and EC pools.
       </para>
      </listitem>
     </varlistentry>

--- a/xml/admin_operating_pools.xml
+++ b/xml/admin_operating_pools.xml
@@ -563,7 +563,7 @@ pool4                     1.1 MiB      13      0     39                  0      
      <term>noscrub,nodeep-scrub</term>
      <listitem>
       <para>
-       Disables (deep)-scrubbing of the data for the specific pool to resolve
+       Disables (deep) scrubbing of the data for the specific pool to resolve
        temporary high I/O load.
       </para>
      </listitem>

--- a/xml/admin_operating_pools.xml
+++ b/xml/admin_operating_pools.xml
@@ -488,7 +488,7 @@ pool4                     1.1 MiB      13      0     39                  0      
    </para>
 <screen>&prompt.cephuser;ceph osd pool set <replaceable>pool-name</replaceable> <replaceable>KEY</replaceable> <replaceable>VALUE</replaceable></screen>
    <para>
-    Following is a list of pool values, sorted by a pool type.
+    The following is a list of pool values sorted by a pool type:
    </para>
    <variablelist>
     <title>Common Pool Values</title>

--- a/xml/admin_operating_pools.xml
+++ b/xml/admin_operating_pools.xml
@@ -572,7 +572,7 @@ pool4                     1.1 MiB      13      0     39                  0      
      <term>write_fadvise_dontneed</term>
      <listitem>
       <para>
-       Set/Unset the <literal>WRITE_FADVISE_DONTNEED</literal> flag on a given
+       Set or unset the <literal>WRITE_FADVISE_DONTNEED</literal> flag on a given
        pool's read/write requests to bypass putting data into cache. Default is
        <literal>flase</literal>. Applies to both replicated and EC pools.
       </para>

--- a/xml/admin_operating_pools.xml
+++ b/xml/admin_operating_pools.xml
@@ -486,31 +486,12 @@ pool4                     1.1 MiB      13      0     39                  0      
    <para>
     To set a value to a pool, execute:
    </para>
-<screen>&prompt.cephuser;ceph osd pool set <replaceable>pool-name</replaceable> <replaceable>key</replaceable> <replaceable>value</replaceable></screen>
+<screen>&prompt.cephuser;ceph osd pool set <replaceable>pool-name</replaceable> <replaceable>KEY</replaceable> <replaceable>VALUE</replaceable></screen>
    <para>
-    You may set values for the following keys:
+    Following is a list of pool values, sorted by a pool type.
    </para>
    <variablelist>
-    <varlistentry>
-     <term>size</term>
-     <listitem>
-      <para>
-       Sets the number of replicas for objects in the pool. See
-       <xref linkend="ceph-pools-options-num-of-replicas"/> for further
-       details. Replicated pools only.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>min_size</term>
-     <listitem>
-      <para>
-       Sets the minimum number of replicas required for I/O. See
-       <xref linkend="ceph-pools-options-num-of-replicas"/> for further
-       details. Replicated pools only.
-      </para>
-     </listitem>
-    </varlistentry>
+    <title>Common Pool Values</title>
     <varlistentry>
      <term>crash_replay_interval</term>
      <listitem>
@@ -579,10 +560,11 @@ pool4                     1.1 MiB      13      0     39                  0      
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>nosizechange</term>
+     <term>noscrub,nodeep-scrub</term>
      <listitem>
       <para>
-       Prevents the pool's size from being changed.
+       Disables (deep)-scrubbing of the data for the specific pool to resolve
+       temporary high I/O load.
       </para>
      </listitem>
     </varlistentry>
@@ -591,16 +573,76 @@ pool4                     1.1 MiB      13      0     39                  0      
      <listitem>
       <para>
        Set/Unset the <literal>WRITE_FADVISE_DONTNEED</literal> flag on a given
-       pool.
+       pool. Default is <literal>flase</literal>. Applies to both replicated
+       and EC pools.
       </para>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>noscrub,nodeep-scrub</term>
+     <term>scrub_min_interval</term>
      <listitem>
       <para>
-       Disables (deep)-scrubbing of the data for the specific pool to resolve
-       temporary high I/O load.
+       The minimum interval in seconds for pool scrubbing when the cluster load
+       is low. The default <literal>0</literal> means that the
+       <option>osd_scrub_min_interval</option> value from the &ceph;
+       configuration file is used.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>scrub_max_interval</term>
+     <listitem>
+      <para>
+       The maximum interval in seconds for pool scrubbing, regardless of the
+       cluster load. The default <literal>0</literal> means that the
+       <option>osd_scrub_max_interval</option> value from the &ceph;
+       configuration file is used.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>deep_scrub_interval</term>
+     <listitem>
+      <para>
+       The interval in seconds for the pool <emphasis>deep</emphasis>
+       scrubbing. The default <literal>0</literal> means that the
+       <option>osd_deep_scrub</option> value from the &ceph; configuration file
+       is used.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+   <variablelist>
+    <title>Replicated Pool Values</title>
+    <varlistentry>
+     <term>size</term>
+     <listitem>
+      <para>
+       Sets the number of replicas for objects in the pool. See
+       <xref linkend="ceph-pools-options-num-of-replicas"/> for further
+       details. Replicated pools only.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>min_size</term>
+     <listitem>
+      <para>
+       Sets the minimum number of replicas required for I/O. See
+       <xref linkend="ceph-pools-options-num-of-replicas"/> for further
+       details. Replicated pools only.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>nosizechange</term>
+     <listitem>
+      <para>
+       Prevents the pool's size from being changed. When a pool is created, the
+       default value is taken from the value of the
+       <option>osd_pool_default_flag_nosizechange</option> parameter which is
+       <literal>false</literal> by default. Applies to replicated pools only
+       because you cannot change size for EC pools.
       </para>
      </listitem>
     </varlistentry>
@@ -633,7 +675,11 @@ pool4                     1.1 MiB      13      0     39                  0      
       <para>
        The duration of a hit set period in seconds for cache pools. The higher
        the number, the more RAM consumed by the
-       <systemitem>ceph-osd</systemitem> daemon.
+       <systemitem>ceph-osd</systemitem> daemon. When a pool is created, the
+       default value is taken from the value of the
+       <option>osd_tier_default_cache_hit_set_period</option> parameter, which
+       is <literal>1200</literal> by default. Applies to replicated pools only
+       because EC pools cannot be used as a cache tier.
       </para>
      </listitem>
     </varlistentry>
@@ -744,6 +790,9 @@ pool4                     1.1 MiB      13      0     39                  0      
       </para>
      </listitem>
     </varlistentry>
+   </variablelist>
+   <variablelist xml:id="pool-values-ec">
+    <title>Erasure Coded Pool Values</title>
     <varlistentry>
      <term>fast_read</term>
      <listitem>
@@ -757,39 +806,6 @@ pool4                     1.1 MiB      13      0     39                  0      
        these replies. This approach causes more CPU load and less disk/network
        load. Currently, this flag is only supported for erasure coding pools.
        Default is <literal>0</literal>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>scrub_min_interval</term>
-     <listitem>
-      <para>
-       The minimum interval in seconds for pool scrubbing when the cluster load
-       is low. The default <literal>0</literal> means that the
-       <option>osd_scrub_min_interval</option> value from the &ceph;
-       configuration file is used.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>scrub_max_interval</term>
-     <listitem>
-      <para>
-       The maximum interval in seconds for pool scrubbing, regardless of the
-       cluster load. The default <literal>0</literal> means that the
-       <option>osd_scrub_max_interval</option> value from the &ceph;
-       configuration file is used.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>deep_scrub_interval</term>
-     <listitem>
-      <para>
-       The interval in seconds for the pool <emphasis>deep</emphasis>
-       scrubbing. The default <literal>0</literal> means that the
-       <option>osd_deep_scrub</option> value from the &ceph; configuration file
-       is used.
       </para>
      </listitem>
     </varlistentry>

--- a/xml/admin_operating_pools.xml
+++ b/xml/admin_operating_pools.xml
@@ -573,8 +573,8 @@ pool4                     1.1 MiB      13      0     39                  0      
      <listitem>
       <para>
        Set/Unset the <literal>WRITE_FADVISE_DONTNEED</literal> flag on a given
-       pool. Default is <literal>flase</literal>. Applies to both replicated
-       and EC pools.
+       pool's read/write requests to bypass putting data into cache. Default is
+       <literal>flase</literal>. Applies to both replicated and EC pools.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
The current list of values that you can set on a pool mixes both replicated and EC pools. This update divides the pool values into three lists corresponding to pool types.