### PR TITLE
Run upgrade.check runner to verify upgrade conditions (jsc#SES-356)

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -119,11 +119,10 @@
      </listitem>
      <listitem>
       <para>
-       Check if the cluster uses the new bucket type 'straw2':
+       Run the <command>salt-run upgrade.check</command> command to verify that
+       the cluster uses the new bucket type <literal>straw2</literal> and that
+       the &adm; is not a storage node.
       </para>
-<screen>
-&prompt.cephuser;ceph osd crush dump | grep straw
-</screen>
      </listitem>
      <listitem>
       <para>
@@ -238,10 +237,10 @@ apparmor_init: default-complain
    </listitem>
    <listitem>
     <para>
-     From &productname; &productnumber;, MDS names starting with a digit are
-     no longer allowed and MDS daemons will refuse to start. You can check
-     whether your daemons have such names either by running the <command>ceph
-     fs status</command> command, or by restarting an MDS and checking its logs
+     From &productname; &productnumber;, MDS names starting with a digit are no
+     longer allowed and MDS daemons will refuse to start. You can check whether
+     your daemons have such names either by running the <command>ceph fs
+     status</command> command, or by restarting an MDS and checking its logs
      for the following message:
     </para>
 <screen>
@@ -459,7 +458,6 @@ mds standby for name = mds.456-another-mds
      channels.
     </para>
    </tip>
-
 <screen>
 &prompt.sminion;zypper lr
 </screen>
@@ -787,8 +785,8 @@ mds standby for name = mds.456-another-mds
    these files against the current configuration files to ensure that no local
    changes have been lost. If necessary, update the affected files. For more
    information on working with <filename>.rpmnew</filename>,
-   <filename>.rpmorig</filename>, and <filename>.rpmsave</filename> files, refer
-   to
+   <filename>.rpmorig</filename>, and <filename>.rpmsave</filename> files,
+   refer to
    <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-admin/#sec-rpm-packages-manage"/>.
   </para>
 
@@ -1216,9 +1214,9 @@ Nodes running older software versions must be upgraded in the following order:
    </step>
    <step>
     <para>
-     Find the node hosting one of the standby MDS daemons. Consult the output of
-     the <command>ceph fs status</command> command and start the upgrade of the
-     MDS cluster on this node.
+     Find the node hosting one of the standby MDS daemons. Consult the output
+     of the <command>ceph fs status</command> command and start the upgrade of
+     the MDS cluster on this node.
     </para>
 <screen>
 &prompt.cephuser;ceph fs status
@@ -1799,8 +1797,8 @@ role-storage/cluster/*.sls
 </screen>
    <para>
     Alternatively, you can inspect the content of the files in the
-    <filename>/srv/pillar/ceph/proposals/profile-*/</filename> directories. They
-    have a similar structure to the following:
+    <filename>/srv/pillar/ceph/proposals/profile-*/</filename> directories.
+    They have a similar structure to the following:
    </para>
 <screen>
 ceph:
@@ -1873,9 +1871,9 @@ ceph:
   <sect2 xml:id="upgrade-osd-deployment">
    <title>OSD Deployment</title>
    <para>
-    For simple cases such as stand-alone OSDs, the migration will happen
-    over time. Whenever you remove or replace an OSD from the cluster, it will
-    be replaced by a new, LVM-based OSD.
+    For simple cases such as stand-alone OSDs, the migration will happen over
+    time. Whenever you remove or replace an OSD from the cluster, it will be
+    replaced by a new, LVM-based OSD.
    </para>
    <tip>
     <title>Migrate to LVM Format</title>


### PR DESCRIPTION
The `salt-run upgrade.check` runner verifies several points that could prevent the cluster from upgrading correctly. This update inserts this runner before the actual upgrade procedure.