### PR TITLE
Fixed unclear localization strings, round 2

### DIFF
--- a/xml/admin_ceph_datamgm.xml
+++ b/xml/admin_ceph_datamgm.xml
@@ -131,8 +131,9 @@ device 3 osd.3class ssd
    <para>
     The flexibility of the &crushmap; in controlling data placement is one of
     the &ceph;'s strengths. It is also one of the most difficult parts of the
-    cluster to manage. <emphasis>Device classes</emphasis> automate one of the
-    most common reasons why &crushmap;s are directly manually edited.
+    cluster to manage. <emphasis>Device classes</emphasis> automate the most
+    common changes to &crushmap;s that the administrator had to do manually
+    previously.
    </para>
    <sect3>
     <title>The CRUSH Management Problem</title>

--- a/xml/admin_ceph_gateway.xml
+++ b/xml/admin_ceph_gateway.xml
@@ -870,7 +870,7 @@ rgw_frontends = beast port=80 ssl_port=443 ssl_certificate=/etc/ceph/rgw.pem</sc
    <para>
     A synchronization module configuration is local to a zone. The
     synchronization module determines whether the zone exports data or can only
-    consume data that was modified in another zone. As of luminous the
+    consume data that was modified in another zone. As of Luminous the
     supported synchronization plug-ins are <literal>ElasticSearch</literal>,
     <literal>rgw</literal>, which is the default synchronization plug-in that
     synchronizes data between the zones and <literal>log</literal> which is a
@@ -962,7 +962,7 @@ rgw_frontends = beast port=80 ssl_port=443 ssl_certificate=/etc/ceph/rgw.pem</sc
    <title>ElasticSearch Synchronization Module</title>
    <para>
     This synchronization module writes the metadata from other zones to
-    ElasticSearch. As of luminous this is JSON of data fields we currently
+    ElasticSearch. As of Luminous this is JSON of data fields we currently
     store in ElasticSearch.
    </para>
 <screen>

--- a/xml/admin_operating_monitor.xml
+++ b/xml/admin_operating_monitor.xml
@@ -394,9 +394,9 @@ osd.2 is near full at 87%
     <term>OSD_NO_SORTBITWISE</term>
     <listitem>
      <para>
-      No pre-luminous v12 OSDs are running but the <option>sortbitwise</option>
+      No pre-Luminous v12 OSDs are running but the <option>sortbitwise</option>
       flag has not been set. You need to set the <option>sortbitwise</option>
-      flag before luminous v12 or newer OSDs can start:
+      flag before Luminous v12 or newer OSDs can start:
      </para>
 <screen>&prompt.cephuser;ceph osd set sortbitwise</screen>
     </listitem>

--- a/xml/ceph_maintenance_updates.xml
+++ b/xml/ceph_maintenance_updates.xml
@@ -355,7 +355,7 @@
     <command>radosgw-admin</command> introduces two subcommands that allow the
     managing of expire-stale objects that might be left behind after a bucket
     reshard in earlier versions of &ogw;. Expire-stale objects are expired
-    objects that should have been automatically erased but for some reason
+    objects that should have been automatically erased but
     still exist and need to be listed and removed manually. One subcommand
     lists such objects and the other deletes them.
    </para>

--- a/xml/ceph_maintenance_updates.xml
+++ b/xml/ceph_maintenance_updates.xml
@@ -354,8 +354,10 @@
    <para>
     <command>radosgw-admin</command> introduces two subcommands that allow the
     managing of expire-stale objects that might be left behind after a bucket
-    reshard in earlier versions of &ogw;. One subcommand lists such objects and
-    the other deletes them.
+    reshard in earlier versions of &ogw;. Expire-stale objects are expired
+    objects that should have been automatically erased but for some reason
+    still exist and need to be listed and removed manually. One subcommand
+    lists such objects and the other deletes them.
    </para>
   </listitem>
   <listitem>

--- a/xml/manager_modules.xml
+++ b/xml/manager_modules.xml
@@ -76,7 +76,7 @@
    <title>Supported Mode</title>
    <para>
     We currently only support the 'crush-compat' mode because the 'upmap' mode
-    requires an OSD feature that prevents any pre-luminous OSDs from connecting
+    requires an OSD feature that prevents any pre-Luminous OSDs from connecting
     to the cluster.
    </para>
   </important>


### PR DESCRIPTION
Small updates to make several snippets more clear as suggested by the localization team.
As an addition, all 'luminous' cases were capitalized to 'Luminous' for consistency.