### PR TITLE
Prompt fixes in the upgrade chapter (bsc#1161801)

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -1284,7 +1284,7 @@ cephfs - 2 clients
      Identify which OSD daemons are running on a particular node:
     </para>
 <screen>
-&prompt.cephuser.osd;ceph osd tree
+&prompt.cephuser;ceph osd tree
 </screen>
    </step>
    <step>
@@ -1293,20 +1293,20 @@ cephfs - 2 clients
      upgraded:
     </para>
 <screen>
-&prompt.cephuser.osd;ceph osd add-noout osd.<replaceable>OSD_ID</replaceable>
+&prompt.cephuser;ceph osd add-noout osd.<replaceable>OSD_ID</replaceable>
 </screen>
     <para>
      For example:
     </para>
-<screen>&prompt.cephuser.osd;for i in $(ceph osd ls-tree <replaceable>OSD_NODE_NAME</replaceable>);do echo "osd: $i"; ceph osd add-noout osd.$i; done</screen>
+<screen>&prompt.cephuser;for i in $(ceph osd ls-tree <replaceable>OSD_NODE_NAME</replaceable>);do echo "osd: $i"; ceph osd add-noout osd.$i; done</screen>
     <para>
      Verify with:
     </para>
-<screen>&prompt.cephuser.osd;ceph health detail | grep noout</screen>
+<screen>&prompt.cephuser;ceph health detail | grep noout</screen>
     <para>
      or
     </para>
-<screen>&prompt.cephuser.osd;ceph –s
+<screen>&prompt.cephuser;ceph –s
 cluster:
  id:     44442296-033b-3275-a803-345337dc53da
  health: HEALTH_WARN
@@ -1333,7 +1333,7 @@ cluster:
      Activate all OSDs found in the system:
     </para>
 <screen>
-&prompt.cephuser.osd;;ceph-volume simple activate --all
+&prompt.cephuser.osd;ceph-volume simple activate --all
 </screen>
     <tip>
      <title>Activating Data Partitions Individually</title>
@@ -1384,7 +1384,7 @@ d7bd2685-5b92-4074-8161-30d146cd0290
      Address the 'Legacy BlueStore stats reporting detected on XX OSD(s)'
      message:
     </para>
-<screen>&prompt.cephuser.osd;ceph –s
+<screen>&prompt.cephuser;ceph –s
 cluster:
  id:     44442296-033b-3275-a803-345337dc53da
  health: HEALTH_WARN
@@ -1404,12 +1404,12 @@ cluster:
      repair</command> for all OSDs on the <replaceable>NODE_NAME</replaceable>
      node:
     </para>
-<screen>OSDNODE=<replaceable>OSD_NODE_NAME</replaceable>;\
+<screen>&prompt.cephuser;OSDNODE=<replaceable>OSD_NODE_NAME</replaceable>;\
  for OSD in $(ceph osd ls-tree $OSDNODE);\
  do echo "osd=" $OSD;\
- salt $OSDNODE cmd.run 'systemctl stop ceph-osd@$OSD';\
- salt $OSDNODE cmd.run 'ceph-bluestore-tool repair --path /var/lib/ceph/osd/ceph-$OSD';\
- salt $OSDNODE cmd.run 'systemctl start ceph-osd@$OSD';\
+ salt $OSDNODE* cmd.run "systemctl stop ceph-osd@$OSD";\
+ salt $OSDNODE* cmd.run "ceph-bluestore-tool repair --path /var/lib/ceph/osd/ceph-$OSD";\
+ salt $OSDNODE* cmd.run "systemctl start ceph-osd@$OSD";\
  done</screen>
    </step>
    <step>
@@ -1417,20 +1417,20 @@ cluster:
      Unset the 'noout' flag for each OSD daemon on the node that is upgraded:
     </para>
 <screen>
-&prompt.cephuser.osd;ceph osd rm-noout osd.<replaceable>OSD_ID</replaceable>
+&prompt.cephuser;ceph osd rm-noout osd.<replaceable>OSD_ID</replaceable>
 </screen>
     <para>
      For example:
     </para>
-<screen>&prompt.cephuser.osd;for i in $(ceph osd ls-tree <replaceable>OSD_NODE_NAME</replaceable>);do echo "osd: $i"; ceph osd rm-noout osd.$i; done</screen>
+<screen>&prompt.cephuser;for i in $(ceph osd ls-tree <replaceable>OSD_NODE_NAME</replaceable>);do echo "osd: $i"; ceph osd rm-noout osd.$i; done</screen>
     <para>
      Verify with:
     </para>
-<screen>&prompt.cephuser.osd;ceph health detail | grep noout</screen>
+<screen>&prompt.cephuser;ceph health detail | grep noout</screen>
     <para>
      Note:
     </para>
-<screen>&prompt.cephuser.osd;ceph –s
+<screen>&prompt.cephuser;ceph –s
 cluster:
  id:     44442296-033b-3275-a803-345337dc53da
  health: HEALTH_WARN
@@ -1441,7 +1441,7 @@ cluster:
      Verify the cluster status. It will be similar to the following output:
     </para>
 <screen>
-&prompt.cephuser.osd;ceph status
+&prompt.cephuser;ceph status
 cluster:
   id:     e0d53d64-6812-3dfe-8b72-fd454a6dcf12
   health: HEALTH_WARN


### PR DESCRIPTION
Several commands had prompts that instructed the admin to run the corresponding commands on an OSD node instead of the Admin node. This update fixes them.