### PR TITLE
Add warning about free space when adding replicas (bsc#1161691)

### DIFF
--- a/xml/ceph_maintenance_updates.xml
+++ b/xml/ceph_maintenance_updates.xml
@@ -92,7 +92,7 @@
     <title>Additional Replicas Require Extra Space</title>
     <para>
      Ensure there is sufficent free space <emphasis>before</emphasis> adding
-     replicas. You can check using the commands: 
+     replicas. You can check using the following commands: 
     </para>
 <screen>&prompt.cephuser;ceph df</screen>
     <para>

--- a/xml/ceph_maintenance_updates.xml
+++ b/xml/ceph_maintenance_updates.xml
@@ -88,6 +88,25 @@
 <screen>
 &prompt.cephuser;ceph config set global mon_warn_on_pool_no_redundancy false
 </screen>
+   <warning>
+    <title>Additional Replicas Require Extra Space</title>
+    <para>
+     Ensure there is sufficent free space <emphasis>before</emphasis> adding
+     replicas. You can check using the commands: 
+    </para>
+<screen>&prompt.cephuser;ceph df</screen>
+    <para>
+     and
+    </para>
+<screen>&prompt.cephuser;ceph osd df</screen>
+    <para>
+     Each replica requires enough free space to hold another copy of the
+     cluster's existing contents. For example, if there were 100&nbsp;GB of data
+     and only 50&nbsp;GB of free space, then increasing the number of replicas
+     from 1 to 2 will cause the cluster to run out of space. 
+    </para>
+   </warning>
+   
   </listitem>
   <listitem>
    <para>


### PR DESCRIPTION
After discussion with @Martin-Weiss, added a warning about free cluster space when adding replicas. 

This fixes:
https://bugzilla.suse.com/show_bug.cgi?id=1161691