### PR TITLE
Shutdown and start of the whole cluster (bsc#1126210)

### DIFF
--- a/xml/admin_operating_services.xml
+++ b/xml/admin_operating_services.xml
@@ -150,7 +150,7 @@ ceph-rbd-mirror@.service
   </sect2>
  </sect1>
  <sect1 xml:id="Deepsea-restart">
-  <title>Restarting &ceph; Services USing &deepsea;</title>
+  <title>Restarting &ceph; Services Using &deepsea;</title>
 
   <para>
    After applying updates to the cluster nodes, the affected &ceph; related
@@ -244,7 +244,7 @@ ceph-rbd-mirror@.service
   </sect2>
  </sect1>
  <sect1 xml:id="ceph-cluster-shutdown">
-  <title>Graceful Shutdown of the Whole &ceph; Cluster</title>
+  <title>Shutdown and Start of the Whole &ceph; Cluster</title>
 
   <para>
    There are occasions when you need to stop all &ceph; related services in the
@@ -252,23 +252,70 @@ ceph-rbd-mirror@.service
    again. For example, in case of a planned power outage.
   </para>
 
-  <para>
-   To start the whole &ceph; cluster, run the <command>ceph.startup</command>
-   runner:
-  </para>
-
-<screen>
-&prompt.smaster;salt-run state.orch ceph.startup
-</screen>
-
-  <para>
-   To shut down the whole &ceph; cluster, disable safety measures and run the
-   <command>ceph.shutdown</command> runner:
-  </para>
-
+  <procedure>
+   <title>Shutting Down the Whole &ceph; Cluster</title>
+   <step>
+    <para>
+     Shut down or disconnect any clients accessing the cluster.
+    </para>
+   </step>
+   <step>
+    <para>
+     To prevent CRUSH to automatically rebalance the cluster, set the cluster
+     to <literal>noout</literal>:
+    </para>
+<screen>&prompt.smaster;ceph osd set noout</screen>
+   </step>
+   <step>
+    <para>
+     Disable safety measures and run the <command>ceph.shutdown</command> runner:
+    </para>
 <screen>
 &prompt.smaster;salt-run disengage.safety
 &prompt.smaster;salt-run state.orch ceph.shutdown
 </screen>
+   </step>
+   <step>
+    <para>
+     Power off all cluster nodes:
+    </para>
+<screen>&prompt.smaster;salt -C 'G@deepsea:*' cmd.run "shutdown -h"</screen>
+   </step>
+  </procedure>
+
+  <procedure>
+   <title>Starting the Whole &ceph; Cluster</title>
+   <step>
+    <para>
+     Power on the &adm;.
+    </para>
+   </step>
+   <step>
+    <para>
+     Power on the &mon; nodes.
+    </para>
+   </step>
+   <step>
+    <para>
+     Power on the &osd; nodes.
+    </para>
+   </step>
+   <step>
+    <para>
+     Unset the previously set <literal>noout</literal> flag:
+    </para>
+<screen>&prompt.smaster;ceph osd unset noout</screen>
+   </step>
+   <step>
+    <para>
+     Power on all configured gateways.
+    </para>
+   </step>
+   <step>
+    <para>
+     Power on or connect cluster clients.
+    </para>
+   </step>
+  </procedure>
  </sect1>
 </chapter>

--- a/xml/admin_operating_services.xml
+++ b/xml/admin_operating_services.xml
@@ -261,7 +261,7 @@ ceph-rbd-mirror@.service
    </step>
    <step>
     <para>
-     To prevent CRUSH to automatically rebalance the cluster, set the cluster
+     To prevent CRUSH from automatically rebalancing the cluster, set the cluster
      to <literal>noout</literal>:
     </para>
 <screen>&prompt.smaster;ceph osd set noout</screen>


### PR DESCRIPTION
Updated and extended the way and order of nodes during a complete cluster shutdown/start-up.
This update applies to SES6+