### PR TITLE
ceph.maintenance.upgrade runner not yet supported (bsc#1158449)

### DIFF
--- a/xml/admin_saltcluster.xml
+++ b/xml/admin_saltcluster.xml
@@ -1041,8 +1041,15 @@ Device Path Size rotates available Model name
      <para>
       Update all other software packages on the cluster:
      </para>
-<screen>&prompt.smaster;salt-run state.orch ceph.maintenance.upgrade</screen>
+<screen>&prompt.smaster;salt-run state.orch ceph.stage.0</screen>
     </step>
+    <step>
+     <para>
+      Restart &ceph; related services:
+     </para>
+<screen>&prompt.smaster;salt-run state.orch ceph.restart</screen>
+    </step>
+
    </procedure>
   </sect2>
  </sect1>


### PR DESCRIPTION
The 'ceph.maintenance.upgrade' runner is not supported anymore and this update replaces it with two other commands.