### PR TITLE
 Add §s on managing & using Ceph user accounts (bsc#1114306) 

### DIFF
--- a/xml/admin_rbd.xml
+++ b/xml/admin_rbd.xml
@@ -155,7 +155,41 @@
    After you create a &rbd;, you can use it like any other disk device: format
    it, mount it to be able to exchange files, and unmount it when done.
   </para>
-
+  <sect2 xml:id="ceph-rbd-creatuser">
+   <title>Creating a &ceph; User Account</title>
+   <para>
+    Dy default, the <command>rbd</command> command will access the cluster using
+    the &ceph; <literal>admin</literal> user. This user has full administrative
+    access to the cluster. This runs the risk of accidentally causing damage,
+    similarly to using a Linux workstation as &rootuser;. Thus, it is preferable
+    to create user accounts with fewer privileges and use these accounts for
+    normal read/write access.
+   </para>
+   <para>
+    To create a new user account, use the <command>ceph</command> command with the
+    <command>auth get-or-create</command> subcommand and both Monitor and &osd;
+    capabilities as follows:    
+   </para>
+<screen>&prompt.cephuser;ceph auth get-or-create client.{ID} mon 'profile rbd' osd 'profile {profile name} [pool={pool-name}][, profile ...]' mgr 'profile rbd [pool={pool-name}]'</screen>
+   <para>
+    For example, to create a user called <literal>qemu</literal> with read-write
+    access to the pool <literal>vms</literal> and read-only access to the pool
+    <literal>images</literal>, execute the following:
+   </para>
+   <screen>ceph auth get-or-create client.<replaceable>qemu</replaceable> mon 'profile rbd' osd 'profile rbd pool=vms, profile rbd-read-only pool=images' mgr 'profile rbd pool=images'</screen>
+   <para>
+    The output from the <command>ceph auth get-or-create</command> command will
+    be the keyring for the specified user, which can be written to
+    <filename>/etc/ceph/ceph.client.<replaceable>{ID}</replaceable>.keyring.</filename>
+   </para>
+   <note>
+    <para>
+    The user ID can be specified when using the rbd command by providing the
+    optional <literal>--id</literal> <replaceable>{id}</replaceable> argument. 
+    </para>
+   </note>
+  </sect2>
+  
   <sect2 xml:id="ceph-rbd-auth">
    <title>User Name and Authentication</title>
    <para>

--- a/xml/admin_rbd.xml
+++ b/xml/admin_rbd.xml
@@ -213,6 +213,7 @@
   
   <sect2 xml:id="ceph-rbd-prep">
    <title>Preparing a &rbd; for Use</title>
+   
    <procedure>
     <step>
      <para>
@@ -224,7 +225,7 @@
     </step>
     <step>
      <para>
-      Map the image to a new block device.
+      Map the image to a new block device:
      </para>
      <screen>&prompt.cephuser;rbd map --pool mypool myimage</screen>
     </step>
@@ -254,7 +255,7 @@ id pool   image   snap device
     </step>
     <step>
      <para>
-      Make an XFS file system on the <filename>/dev/rbd0</filename> device.
+      Make an XFS file system on the <filename>/dev/rbd0</filename> device:
      </para>
      <screen>&prompt.root;mkfs.xfs /dev/rbd0
       log stripe unit (4194304 bytes) is too large (maximum is 256KiB)
@@ -271,8 +272,8 @@ id pool   image   snap device
     </step>
     <step>
      <para>
-      Mount the device and check it is correctly mounted. Replace
-      <filename>/mnt</filename> with your mount point.
+      Replacing <filename>/mnt</filename> with your mount point, mount the
+      device and check it is correctly mounted: 
      </para>
      <screen>&prompt.root;mount /dev/rbd0 /mnt
       &prompt.root;mount | grep rbd0
@@ -297,7 +298,7 @@ id pool   image   snap device
        </listitem>
        <listitem>
         <para>
-         Grow the file system to fill up the new size of the device.
+         Grow the file system to fill up the new size of the device:
         </para>
 <screen>&prompt.root;xfs_growfs /mnt
 [...]
@@ -318,12 +319,11 @@ data blocks changed from 2097152 to 2560000</screen>
    </procedure>
    
    <tip>
-    <title>Manual (Un)mounting</title>
+    <title>Manual Mounting and Unmounting</title>
     <para>
-     Since manually mapping and mounting RBD images after boot and unmounting
-     and unmapping them before shutdown can be tedious, an
-     <command>rbdmap</command> script and &systemd; unit is provided. Refer to
-     <xref linkend="ceph-rbd-rbdmap"/>.
+     A <command>rbdmap</command> script and &systemd; unit is provided to make
+     the process of mapping and mounting RBDs after boot and unmounting them 
+     before shutdown smoother. Refer to <xref linkend="ceph-rbd-rbdmap"/>.
     </para>
    </tip>
   </sect2>

--- a/xml/admin_rbd.xml
+++ b/xml/admin_rbd.xml
@@ -185,7 +185,7 @@
    </para>
    <note>
     <para>
-     The user ID can be specified when using the <command>rbd</command> command by providing the
+     When using the <command>rbd</command> command, you can specify the user ID by providing the
      optional <command>--id</command> <replaceable>ID</replaceable> argument. 
     </para>
    </note>

--- a/xml/admin_rbd.xml
+++ b/xml/admin_rbd.xml
@@ -230,9 +230,9 @@
      <para>
       List all mapped devices:
      </para>
-     <screen>&prompt.cephuser;rbd showmapped
-      id pool   image   snap device
-      0  mypool myimage -    /dev/rbd0</screen>
+<screen>&prompt.cephuser;rbd showmapped
+id pool   image   snap device
+0  mypool myimage -    /dev/rbd0</screen>
      <para>
       The device we want to work on is <filename>/dev/rbd0</filename>.
      </para>

--- a/xml/admin_rbd.xml
+++ b/xml/admin_rbd.xml
@@ -308,10 +308,10 @@ data blocks changed from 2097152 to 2560000</screen>
      <para>
       After you finish accessing the device, you can unmap and unmount it.
      </para>
-     <screen>
-      &prompt.cephuser;rbd unmap /dev/rbd0
-      &prompt.root;unmount /mnt
-     </screen>
+<screen>
+&prompt.cephuser;rbd unmap /dev/rbd0
+&prompt.root;unmount /mnt
+</screen>
     </step>
    </procedure>
    

--- a/xml/admin_rbd.xml
+++ b/xml/admin_rbd.xml
@@ -190,10 +190,7 @@
     </para>
    </note>
    <para>
-    For more details on managing &ceph; user accounts, refer to the
-    <link
-     xlink:href="https://docs.ceph.com/docs/nautilus/rados/operations/user-management/">
-     official &ceph; documentation</link>.
+    For more details on managing &ceph; user accounts, refer to <xref linkend="cha-storage-cephx"/>.
    </para>
   </sect2>
   

--- a/xml/admin_rbd.xml
+++ b/xml/admin_rbd.xml
@@ -181,7 +181,7 @@
    <para>
     The output from the <command>ceph auth get-or-create</command> command will
     be the keyring for the specified user, which can be written to
-    <filename>/etc/ceph/ceph.client.<replaceable>ID</replaceable>.keyring.</filename>
+    <filename>/etc/ceph/ceph.client.<replaceable>ID</replaceable>.keyring</filename>.
    </para>
    <note>
     <para>

--- a/xml/admin_rbd.xml
+++ b/xml/admin_rbd.xml
@@ -155,43 +155,50 @@
    After you create a &rbd;, you can use it like any other disk device: format
    it, mount it to be able to exchange files, and unmount it when done.
   </para>
+  <para>
+   The <command>rbd</command> command defaults to accessing the cluster using
+   the &ceph; <literal>admin</literal> user account. This account has full
+   administrative access to the cluster. This runs the risk of accidentally
+   causing damage, similarly to logging into a Linux workstation as &rootuser;.
+   Thus, it is preferable to create user accounts with fewer privileges and use
+   these accounts for normal read/write &rbd; access.
+  </para>
+   
   <sect2 xml:id="ceph-rbd-creatuser">
    <title>Creating a &ceph; User Account</title>
    <para>
-    Dy default, the <command>rbd</command> command will access the cluster using
-    the &ceph; <literal>admin</literal> user. This user has full administrative
-    access to the cluster. This runs the risk of accidentally causing damage,
-    similarly to using a Linux workstation as &rootuser;. Thus, it is preferable
-    to create user accounts with fewer privileges and use these accounts for
-    normal read/write access.
-   </para>
-   <para>
     To create a new user account, use the <command>ceph</command> command with the
-    <command>auth get-or-create</command> subcommand and both Monitor and &osd;
-    capabilities as follows:    
+    <command>auth get-or-create</command> subcommand and Monitor and &osd;
+    capabilities:
    </para>
-<screen>&prompt.cephuser;ceph auth get-or-create client.{ID} mon 'profile rbd' osd 'profile {profile name} [pool={pool-name}][, profile ...]' mgr 'profile rbd [pool={pool-name}]'</screen>
+<screen>&prompt.cephuser;ceph auth get-or-create client.<replaceable>ID</replaceable> mon 'profile rbd' osd 'profile <replaceable>profile name</replaceable> [pool=<replaceable>pool-name</replaceable>][, profile ...]' mgr 'profile rbd [pool=<replaceable>pool-name</replaceable>]'</screen>
    <para>
-    For example, to create a user called <literal>qemu</literal> with read-write
-    access to the pool <literal>vms</literal> and read-only access to the pool
-    <literal>images</literal>, execute the following:
+    For example, to create a user called <replaceable>qemu</replaceable> with read-write
+    access to the pool <replaceable>vms</replaceable> and read-only access to the pool
+    <replaceable>images</replaceable>, execute the following:
    </para>
-   <screen>ceph auth get-or-create client.<replaceable>qemu</replaceable> mon 'profile rbd' osd 'profile rbd pool=vms, profile rbd-read-only pool=images' mgr 'profile rbd pool=images'</screen>
+<screen>ceph auth get-or-create client.<replaceable>qemu</replaceable> mon 'profile rbd' osd 'profile rbd pool=<replaceable>vms</replaceable>, profile rbd-read-only pool=<replaceable>images</replaceable>' mgr 'profile rbd pool=<replaceable>images</replaceable>'</screen>
    <para>
     The output from the <command>ceph auth get-or-create</command> command will
     be the keyring for the specified user, which can be written to
-    <filename>/etc/ceph/ceph.client.<replaceable>{ID}</replaceable>.keyring.</filename>
+    <filename>/etc/ceph/ceph.client.<replaceable>ID</replaceable>.keyring.</filename>
    </para>
    <note>
     <para>
-    The user ID can be specified when using the rbd command by providing the
-    optional <literal>--id</literal> <replaceable>{id}</replaceable> argument. 
+     The user ID can be specified when using the <command>rbd</command> command by providing the
+     optional <command>--id</command> <replaceable>ID</replaceable> argument. 
     </para>
    </note>
+   <para>
+    For more details on managing &ceph; user accounts, refer to the
+    <link
+     xlink:href="https://docs.ceph.com/docs/nautilus/rados/operations/user-management/">
+     official &ceph; documentation</link>.
+   </para>
   </sect2>
   
   <sect2 xml:id="ceph-rbd-auth">
-   <title>User Name and Authentication</title>
+   <title>User Authentication</title>
    <para>
     To specify a user name, use <option>--id
      <replaceable>user-name</replaceable></option>. If you use
@@ -374,9 +381,7 @@
        In the following example you can see how to specify a user name and a
        keyring with a corresponding secret:
       </para>
-<screen>
-&prompt.cephuser;rbdmap map mypool/myimage id=rbd_user,keyring=/etc/ceph/ceph.client.rbd.keyring
-</screen>
+<screen>&prompt.cephuser;rbdmap map mypool/myimage id=<replaceable>rbd_user</replaceable>,keyring=/etc/ceph/ceph.client.rbd.keyring</screen>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/xml/admin_rbd.xml
+++ b/xml/admin_rbd.xml
@@ -156,134 +156,138 @@
    it, mount it to be able to exchange files, and unmount it when done.
   </para>
 
-  <procedure>
-   <step>
-    <para>
-     Make sure your &ceph; cluster includes a pool with the disk image you want
-     to map. Assume the pool is called <literal>mypool</literal> and the image
-     is <literal>myimage</literal>.
-    </para>
-<screen>&prompt.cephuser;rbd list mypool</screen>
-   </step>
-   <step>
-    <para>
-     Map the image to a new block device.
-    </para>
-<screen>&prompt.cephuser;rbd map --pool mypool myimage</screen>
-    <tip>
-     <title>User Name and Authentication</title>
-     <para>
-      To specify a user name, use <option>--id
-      <replaceable>user-name</replaceable></option>. If you use
-      <systemitem>cephx</systemitem> authentication, you also need to specify a
-      secret. It may come from a keyring or a file containing the secret:
-     </para>
-<screen>&prompt.cephuser;rbd map --pool rbd myimage --id admin --keyring /path/to/keyring</screen>
-     <para>
-      or
-     </para>
-<screen>&prompt.cephuser;rbd map --pool rbd myimage --id admin --keyfile /path/to/file</screen>
-    </tip>
-   </step>
-   <step>
-    <para>
-     List all mapped devices:
-    </para>
-<screen>&prompt.cephuser;rbd showmapped
- id pool   image   snap device
- 0  mypool myimage -    /dev/rbd0</screen>
-    <para>
-     The device we want to work on is <filename>/dev/rbd0</filename>.
-    </para>
-    <tip>
-     <title>RBD Device Path</title>
-     <para>
-      Instead of
-      <filename>/dev/rbd<replaceable>DEVICE_NUMBER</replaceable></filename>,
-      you can use
-      <filename>/dev/rbd/<replaceable>POOL_NAME</replaceable>/<replaceable>IMAGE_NAME</replaceable></filename>
-      as a persistent device path. For example:
-     </para>
-<screen>
-/dev/rbd/mypool/myimage
-</screen>
-    </tip>
-   </step>
-   <step>
-    <para>
-     Make an XFS file system on the <filename>/dev/rbd0</filename> device.
-    </para>
-<screen>&prompt.root;mkfs.xfs /dev/rbd0
- log stripe unit (4194304 bytes) is too large (maximum is 256KiB)
- log stripe unit adjusted to 32KiB
- meta-data=/dev/rbd0              isize=256    agcount=9, agsize=261120 blks
-          =                       sectsz=512   attr=2, projid32bit=1
-          =                       crc=0        finobt=0
- data     =                       bsize=4096   blocks=2097152, imaxpct=25
-          =                       sunit=1024   swidth=1024 blks
- naming   =version 2              bsize=4096   ascii-ci=0 ftype=0
- log      =internal log           bsize=4096   blocks=2560, version=2
-          =                       sectsz=512   sunit=8 blks, lazy-count=1
- realtime =none                   extsz=4096   blocks=0, rtextents=0</screen>
-   </step>
-   <step>
-    <para>
-     Mount the device and check it is correctly mounted. Replace
-     <filename>/mnt</filename> with your mount point.
-    </para>
-<screen>&prompt.root;mount /dev/rbd0 /mnt
-&prompt.root;mount | grep rbd0
-/dev/rbd0 on /mnt type xfs (rw,relatime,attr2,inode64,sunit=8192,...</screen>
-    <para>
-     Now you can move data to and from the device as if it was a local
-     directory.
-    </para>
-    <tip>
-     <title>Increasing the Size of RBD Device</title>
-     <para>
-      If you find that the size of the RBD device is no longer enough, you can
-      easily increase it.
-     </para>
-     <orderedlist spacing="normal">
-      <listitem>
-       <para>
-        Increase the size of the RBD image, for example up to 10 GB.
-       </para>
-<screen>&prompt.cephuser;rbd resize --size 10000 mypool/myimage
- Resizing image: 100% complete...done.</screen>
-      </listitem>
-      <listitem>
-       <para>
-        Grow the file system to fill up the new size of the device.
-       </para>
-<screen>&prompt.root;xfs_growfs /mnt
- [...]
- data blocks changed from 2097152 to 2560000</screen>
-      </listitem>
-     </orderedlist>
-    </tip>
-   </step>
-   <step>
-    <para>
-     After you finish accessing the device, you can unmap and unmount it.
-    </para>
-<screen>
-&prompt.cephuser;rbd unmap /dev/rbd0
-&prompt.root;unmount /mnt
-</screen>
-   </step>
-  </procedure>
-
-  <tip>
-   <title>Manual (Un)mounting</title>
+  <sect2 xml:id="ceph-rbd-auth">
+   <title>User Name and Authentication</title>
    <para>
-    Since manually mapping and mounting RBD images after boot and unmounting
-    and unmapping them before shutdown can be tedious, an
-    <command>rbdmap</command> script and &systemd; unit is provided. Refer to
-    <xref linkend="ceph-rbd-rbdmap"/>.
+    To specify a user name, use <option>--id
+     <replaceable>user-name</replaceable></option>. If you use
+    <systemitem>cephx</systemitem> authentication, you also need to specify a
+    secret. It may come from a keyring or a file containing the secret:
    </para>
-  </tip>
-
+   <screen>&prompt.cephuser;rbd map --pool rbd myimage --id admin --keyring /path/to/keyring</screen>
+   <para>
+    or
+   </para>
+   <screen>&prompt.cephuser;rbd map --pool rbd myimage --id admin --keyfile /path/to/file</screen>
+  </sect2>
+  
+  <sect2 xml:id="ceph-rbd-prep">
+   <title>Preparing a &rbd; for Use</title>
+   <procedure>
+    <step>
+     <para>
+      Make sure your &ceph; cluster includes a pool with the disk image you want
+      to map. Assume the pool is called <literal>mypool</literal> and the image
+      is <literal>myimage</literal>.
+     </para>
+     <screen>&prompt.cephuser;rbd list mypool</screen>
+    </step>
+    <step>
+     <para>
+      Map the image to a new block device.
+     </para>
+     <screen>&prompt.cephuser;rbd map --pool mypool myimage</screen>
+    </step>
+    <step>
+     <para>
+      List all mapped devices:
+     </para>
+     <screen>&prompt.cephuser;rbd showmapped
+      id pool   image   snap device
+      0  mypool myimage -    /dev/rbd0</screen>
+     <para>
+      The device we want to work on is <filename>/dev/rbd0</filename>.
+     </para>
+     <tip>
+      <title>RBD Device Path</title>
+      <para>
+       Instead of
+       <filename>/dev/rbd<replaceable>DEVICE_NUMBER</replaceable></filename>,
+       you can use
+       <filename>/dev/rbd/<replaceable>POOL_NAME</replaceable>/<replaceable>IMAGE_NAME</replaceable></filename>
+       as a persistent device path. For example:
+      </para>
+      <screen>
+       /dev/rbd/mypool/myimage
+      </screen>
+     </tip>
+    </step>
+    <step>
+     <para>
+      Make an XFS file system on the <filename>/dev/rbd0</filename> device.
+     </para>
+     <screen>&prompt.root;mkfs.xfs /dev/rbd0
+      log stripe unit (4194304 bytes) is too large (maximum is 256KiB)
+      log stripe unit adjusted to 32KiB
+      meta-data=/dev/rbd0              isize=256    agcount=9, agsize=261120 blks
+      =                       sectsz=512   attr=2, projid32bit=1
+      =                       crc=0        finobt=0
+      data     =                       bsize=4096   blocks=2097152, imaxpct=25
+      =                       sunit=1024   swidth=1024 blks
+      naming   =version 2              bsize=4096   ascii-ci=0 ftype=0
+      log      =internal log           bsize=4096   blocks=2560, version=2
+      =                       sectsz=512   sunit=8 blks, lazy-count=1
+      realtime =none                   extsz=4096   blocks=0, rtextents=0</screen>
+    </step>
+    <step>
+     <para>
+      Mount the device and check it is correctly mounted. Replace
+      <filename>/mnt</filename> with your mount point.
+     </para>
+     <screen>&prompt.root;mount /dev/rbd0 /mnt
+      &prompt.root;mount | grep rbd0
+      /dev/rbd0 on /mnt type xfs (rw,relatime,attr2,inode64,sunit=8192,...</screen>
+     <para>
+      Now you can move data to and from the device as if it was a local
+      directory.
+     </para>
+     <tip>
+      <title>Increasing the Size of RBD Device</title>
+      <para>
+       If you find that the size of the RBD device is no longer enough, you can
+       easily increase it.
+      </para>
+      <orderedlist spacing="normal">
+       <listitem>
+        <para>
+         Increase the size of the RBD image, for example up to 10 GB.
+        </para>
+        <screen>&prompt.cephuser;rbd resize --size 10000 mypool/myimage
+         Resizing image: 100% complete...done.</screen>
+       </listitem>
+       <listitem>
+        <para>
+         Grow the file system to fill up the new size of the device.
+        </para>
+        <screen>&prompt.root;xfs_growfs /mnt
+         [...]
+         data blocks changed from 2097152 to 2560000</screen>
+       </listitem>
+      </orderedlist>
+     </tip>
+    </step>
+    <step>
+     <para>
+      After you finish accessing the device, you can unmap and unmount it.
+     </para>
+     <screen>
+      &prompt.cephuser;rbd unmap /dev/rbd0
+      &prompt.root;unmount /mnt
+     </screen>
+    </step>
+   </procedure>
+   
+   <tip>
+    <title>Manual (Un)mounting</title>
+    <para>
+     Since manually mapping and mounting RBD images after boot and unmounting
+     and unmapping them before shutdown can be tedious, an
+     <command>rbdmap</command> script and &systemd; unit is provided. Refer to
+     <xref linkend="ceph-rbd-rbdmap"/>.
+    </para>
+   </tip>
+  </sect2>
+  
   <sect2 xml:id="ceph-rbd-rbdmap">
    <title>rbdmap: Map RBD Devices at Boot Time</title>
    <para>

--- a/xml/admin_rbd.xml
+++ b/xml/admin_rbd.xml
@@ -1222,7 +1222,7 @@ rbd cache max dirty = 0
   <title>QoS Settings</title>
 
   <para>
-   Generallyi, Quality of Service (QoS) refers to methods of traffic
+   Generally, Quality of Service (QoS) refers to methods of traffic
    prioritization and resource reservation. It is particularly important for
    the transportation of traffic with special requirements.
   </para>

--- a/xml/admin_rbd.xml
+++ b/xml/admin_rbd.xml
@@ -167,17 +167,19 @@
   <sect2 xml:id="ceph-rbd-creatuser">
    <title>Creating a &ceph; User Account</title>
    <para>
-    To create a new user account, use the <command>ceph</command> command with the
-    <command>auth get-or-create</command> subcommand and &mon; and &osd;
-    capabilities:
+    To create a new user account with &mgr;, &mon;, and &osd; capabilities, use
+    the <command>ceph</command> command with the <command>auth get-or-create</command>
+    subcommand:
    </para>
-<screen>&prompt.cephuser;ceph auth get-or-create client.<replaceable>ID</replaceable> mon 'profile rbd' osd 'profile <replaceable>profile name</replaceable> [pool=<replaceable>pool-name</replaceable>][, profile ...]' mgr 'profile rbd [pool=<replaceable>pool-name</replaceable>]'</screen>
+<screen>&prompt.cephuser;ceph auth get-or-create client.<replaceable>ID</replaceable> mon 'profile rbd' osd 'profile <replaceable>profile name</replaceable> \
+  [pool=<replaceable>pool-name</replaceable>] [, profile ...]' mgr 'profile rbd [pool=<replaceable>pool-name</replaceable>]'</screen>
    <para>
     For example, to create a user called <replaceable>qemu</replaceable> with read-write
     access to the pool <replaceable>vms</replaceable> and read-only access to the pool
     <replaceable>images</replaceable>, execute the following:
    </para>
-<screen>ceph auth get-or-create client.<replaceable>qemu</replaceable> mon 'profile rbd' osd 'profile rbd pool=<replaceable>vms</replaceable>, profile rbd-read-only pool=<replaceable>images</replaceable>' mgr 'profile rbd pool=<replaceable>images</replaceable>'</screen>
+<screen>ceph auth get-or-create client.<replaceable>qemu</replaceable> mon 'profile rbd' osd 'profile rbd pool=<replaceable>vms</replaceable>, profile rbd-read-only pool=<replaceable>images</replaceable>' \
+  mgr 'profile rbd pool=<replaceable>images</replaceable>'</screen>
    <para>
     The output from the <command>ceph auth get-or-create</command> command will
     be the keyring for the specified user, which can be written to

--- a/xml/admin_rbd.xml
+++ b/xml/admin_rbd.xml
@@ -168,7 +168,7 @@
    <title>Creating a &ceph; User Account</title>
    <para>
     To create a new user account, use the <command>ceph</command> command with the
-    <command>auth get-or-create</command> subcommand and Monitor and &osd;
+    <command>auth get-or-create</command> subcommand and &mon; and &osd;
     capabilities:
    </para>
 <screen>&prompt.cephuser;ceph auth get-or-create client.<replaceable>ID</replaceable> mon 'profile rbd' osd 'profile <replaceable>profile name</replaceable> [pool=<replaceable>pool-name</replaceable>][, profile ...]' mgr 'profile rbd [pool=<replaceable>pool-name</replaceable>]'</screen>

--- a/xml/admin_rbd.xml
+++ b/xml/admin_rbd.xml
@@ -297,9 +297,9 @@
         <para>
          Grow the file system to fill up the new size of the device.
         </para>
-        <screen>&prompt.root;xfs_growfs /mnt
-         [...]
-         data blocks changed from 2097152 to 2560000</screen>
+<screen>&prompt.root;xfs_growfs /mnt
+[...]
+data blocks changed from 2097152 to 2560000</screen>
        </listitem>
       </orderedlist>
      </tip>


### PR DESCRIPTION
As per:
https://bugzilla.suse.com/show_bug.cgi?id=1114306

Promoted the tip on Ceph user authentication to a new subsection at the start of
§ 12.2 Mounting and Unmounting

Added new material from upstream docs on creating new A/Cs

This is all the material I have access to -- for info on installing additional components I need some more info.
