### PR TITLE
CHAP authentication username/password update (bsc#1165729)

### DIFF
--- a/xml/deployment_iscsi.xml
+++ b/xml/deployment_iscsi.xml
@@ -416,12 +416,12 @@
 </screen>
     <note>
      <para>
-      User names must have a length of 8 to 64 characters and can only contain
-      letters, '.', '@', '-', '_' or ':'.
+      User names must have a length of 8 to 64 characters and can contain
+      alphanumeric characters, '.', '@', '-', '_' or ':'.
      </para>
      <para>
-      Passwords must have a length of 12 to 16 characters and can only contain
-      letters, '@', '-', '_' or '/'.
+      Passwords must have a length of 12 to 16 characters and can contain
+      alphanumeric characters, '@', '-', '_' or '/'.
      </para>
     </note>
     <para>


### PR DESCRIPTION
Username and passwoords for iSCSI CHAP authentication can contain not only letters, but numbers as well. This update extends the list of valid characters.