### PR TITLE
Fixing incorrect command for SES 6 (BSC#1166525)

### DIFF
--- a/xml/admin_operating_services.xml
+++ b/xml/admin_operating_services.xml
@@ -279,7 +279,8 @@ ceph-rbd-mirror@.service
      Disable safety measures and run the <command>ceph.shutdown</command> runner:
     </para>
 <screen>
-&prompt.smaster;salt-run state.orch ceph.startup
+&prompt.smaster;salt-run disengage.safety
+&prompt.smaster;salt-run state.orch ceph.shutdown
 </screen>
    </step>
    <step>


### PR DESCRIPTION
This was fixed in master, but apparently was not backported to SES 6.
This fixes that.