### PR TITLE
Fix typo in admin_monitoring_alerting.xml: s/soff/off/

### DIFF
--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -1960,7 +1960,7 @@ ceph-volume lvm create --osd-id $N --data /path/to/device</screen>
           To re-enable telemetry (and make this warning go away):</para>
 <screen>&prompt.cephuser;ceph telemetry on</screen>
           <para>To disable telemetry (and make this warning go away):</para>
-<screen>&prompt.cephuser;ceph telemetry soff</screen>
+<screen>&prompt.cephuser;ceph telemetry off</screen>
       </listitem>
     </varlistentry>
   </variablelist>


### PR DESCRIPTION
"ceph telemetry soff" is not a valid command.  To turn off telemetry, use "ceph telemetry off".  Fixed typo.