### PR TITLE
Convert ceph-salt config nodes to lowercase

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -297,28 +297,29 @@ minion1:
 &prompt.smaster;ceph-salt config
 <prompt>/></prompt> ls
 o- / ............................................................... [...]
-  o- Ceph_Cluster .................................................. [...]
-  | o- Minions .............................................. [no minions]
-  | o- Roles ....................................................... [...]
-  |   o- Admin .............................................. [no minions]
-  |   o- Bootstrap ........................................... [no minion]
-  o- Cephadm_Bootstrap ......................................... [enabled]
-  | o- Ceph_Conf ................................................... [...]
-  | o- Dashboard ................................................... [...]
+  o- ceph_cluster .................................................. [...]
+  | o- minions .............................................. [no minions]
+  | o- roles ....................................................... [...]
+  |   o- admin .............................................. [no minions]
+  |   o- bootstrap ........................................... [no minion]
+  o- cephadm_bootstrap ......................................... [enabled]
+  | o- ceph_conf ................................................... [...]
+  | o- dashboard ................................................... [...]
   |   o- password ................................... [randomly generated]
   |   o- username ................................................ [admin]
-  o- Containers .................................................... [...]
-  | o- Images ...................................................... [...]
+  o- containers .................................................... [...]
+  | o- images ...................................................... [...]
   |   o- ceph ............................................ [no image path]
-  o- SSH ............................................... [no key pair set]
-  | o- Private_Key .................................. [no private key set]
-  | o- Public_Key .................................... [no public key set]
-  o- System_Update ................................................. [...]
-  | o- Packages ................................................ [enabled]
-  | o- Reboot .................................................. [enabled]
-  o- Time_Server ............................................... [enabled]
-    o- External_Servers .......................................... [empty]
-    o- Server_Hostname ......................................... [not set]
+  | o- registries ................................................ [empty]
+  o- ssh ............................................... [no key pair set]
+  | o- private_key .................................. [no private key set]
+  | o- public_key .................................... [no public key set]
+  o- system_update ................................................. [...]
+  | o- packages ................................................ [enabled]
+  | o- reboot .................................................. [enabled]
+  o- time_server ............................................... [enabled]
+    o- external_servers .......................................... [empty]
+    o- server_hostname ......................................... [not set]
 </screen>
     <para>
      As you can see from the output of &cephsalt;'s <command>ls</command>
@@ -333,9 +334,9 @@ o- / ............................................................... [...]
        command:
       </para>
 <screen>
-<prompt>/></prompt> cd /Ceph_Cluster/Minions/
-<prompt>/Ceph_Cluster/Minions></prompt> ls
-o- Minions .................................................. [Minions: 5]
+<prompt>/></prompt> cd /ceph_cluster/minions/
+<prompt>/ceph_cluster/minions></prompt> ls
+o- minions .................................................. [Minions: 5]
   o- ses-master.example.com ................................... [no roles]
   o- ses-min1.example.com ..................................... [no roles]
 [...]
@@ -347,8 +348,8 @@ o- Minions .................................................. [Minions: 5]
        the property as the first argument:
       </para>
 <screen>
-<prompt>/></prompt> /Ceph_Cluster/Minions/ ls
-o- Minions .................................................. [Minions: 5]
+<prompt>/></prompt> /ceph_cluster/minions/ ls
+o- minions .................................................. [Minions: 5]
   o- ses-master.example.com ................................... [no roles]
   o- ses-min1.example.com ..................................... [no roles]
 [...]
@@ -407,16 +408,16 @@ o- Minions .................................................. [Minions: 5]
      either specify the &sminion;s by their full names, or use a glob
      expressions '*' and '?' to include multiple &sminion;s at once. Use the
      <command>add</command> subcommand under the
-     <literal>/Ceph_Cluster/Minions</literal> path. The following command
+     <literal>/ceph_cluster/minions</literal> path. The following command
      includes all accepted &sminion;s:
     </para>
-<screen>&prompt.smaster;ceph-salt config /Ceph_Cluster/Minions add '*'</screen>
+<screen>&prompt.smaster;ceph-salt config /ceph_cluster/minions add '*'</screen>
     <para>
      Verify that the specified &sminion;s were added:
     </para>
 <screen>
-&prompt.smaster;ceph-salt config /Ceph_Cluster/Minions ls
-o- Minions ................................................. [Minions: 5]
+&prompt.smaster;ceph-salt config /ceph_cluster/minions ls
+o- minions ................................................. [Minions: 5]
   o- ses-master.example.com .................................. [no roles]
   o- ses-min1.example.com .................................... [no roles]
   o- ses-min2.example.com .................................... [no roles]
@@ -448,10 +449,10 @@ o- Minions ................................................. [Minions: 5]
      To specify the &adm;, run the following command:
     </para>
 <screen>
-&smaster;ceph-salt config ceph-salt config /Ceph_Cluster/Roles/Admin add ses-master.example.com
+&smaster;ceph-salt config ceph-salt config /ceph_cluster/roles/admin add ses-master.example.com
 1 minion added.
-&prompt.smaster;ceph-salt config /Ceph_Cluster/Roles/Admin ls
-o- Admin ................................................... [Minions: 1]
+&prompt.smaster;ceph-salt config /ceph_cluster/roles/admin ls
+o- admin ................................................... [Minions: 1]
   o- ses-master.example.com ............................ [no other roles]
 </screen>
     <tip>
@@ -471,10 +472,10 @@ o- Admin ................................................... [Minions: 1]
      services.
     </para>
 <screen>
-&prompt.smaster;ceph-salt config /Ceph_Cluster/Roles/Bootstrap set ses-min1.example.com
+&prompt.smaster;ceph-salt config /ceph_cluster/roles/bootstrap set ses-min1.example.com
 Value set.
-&prompt.smaster;ceph-salt config /Ceph_Cluster/Roles/Bootstrap ls
-o- Bootstrap ..................................... [ses-min1.example.com]
+&prompt.smaster;ceph-salt config /ceph_cluster/roles/bootstrap ls
+o- bootstrap ..................................... [ses-min1.example.com]
 </screen>
     <tip>
      <para>
@@ -482,10 +483,10 @@ o- Bootstrap ..................................... [ses-min1.example.com]
       keyring as well:
      </para>
 <screen>
-&smaster;ceph-salt config ceph-salt config /Ceph_Cluster/Roles/Admin add ses-min1.example.com
+&smaster;ceph-salt config ceph-salt config /ceph_cluster/roles/admin add ses-min1.example.com
 1 minion added.
-&prompt.smaster;ceph-salt config /Ceph_Cluster/Roles/Admin ls
-o- Admin ................................................... [Minions: 1]
+&prompt.smaster;ceph-salt config /ceph_cluster/roles/admin ls
+o- admin ................................................... [Minions: 1]
   o- ses-master.example.com ............................ [no other roles]
   o- ses-min1.suse.cz .......................... [other roles: bootstrap]
 </screen>
@@ -498,12 +499,12 @@ o- Admin ................................................... [Minions: 1]
      need to generate the private and public part of the SSH key pair:
     </para>
 <screen>
-&prompt.smaster;ceph-salt config /SSH generate
+&prompt.smaster;ceph-salt config /ssh generate
 Key pair generated.
-&prompt.smaster;ceph-salt config /SSH ls
-o- SSH ................................................... [Key Pair set]
-  o- Private_Key ...... [53:b1:eb:65:d2:3a:ff:51:6c:e2:1b:ca:84:8e:0e:83]
-  o- Public_Key ....... [53:b1:eb:65:d2:3a:ff:51:6c:e2:1b:ca:84:8e:0e:83]
+&prompt.smaster;ceph-salt config /ssh ls
+o- ssh ................................................... [Key Pair set]
+  o- private_key ...... [53:b1:eb:65:d2:3a:ff:51:6c:e2:1b:ca:84:8e:0e:83]
+  o- public_key ....... [53:b1:eb:65:d2:3a:ff:51:6c:e2:1b:ca:84:8e:0e:83]
 </screen>
    </sect3>
    <sect3 xml:id="deploy-cephadm-configure-ntp">
@@ -515,13 +516,13 @@ o- SSH ................................................... [Key Pair set]
      cluster node on system start-up.
     </para>
 <screen>
-&prompt.smaster;ceph-salt config /Time_Server/Server_Hostname set ses-master.example.com
-&prompt.smaster;ceph-salt config /Time_Server/External_Servers add 0.pt.pool.ntp.org
-&prompt.smaster;ceph-salt config /Time_Server ls
-o- Time_Server ................................................ [enabled]
-  o- External_Servers ............................................... [1]
+&prompt.smaster;ceph-salt config /time_server/server_hostname set ses-master.example.com
+&prompt.smaster;ceph-salt config /time_server/external_servers add 0.pt.pool.ntp.org
+&prompt.smaster;ceph-salt config /time_server ls
+o- time_server ................................................ [enabled]
+  o- external_servers ............................................... [1]
   | o- 0.pt.pool.ntp.org .......................................... [...]
-  o- Server_Hostname ........................... [ses-master.example.com]
+  o- server_hostname ........................... [ses-master.example.com]
 </screen>
     <para>
      Find more information on setting up time synchronization in
@@ -535,12 +536,12 @@ o- Time_Server ................................................ [enabled]
      &cephadm; needs to know a valid URI path to container images that will be
      used during the deployment step. Verify whether the default path is set:
     </para>
-<screen>&prompt.smaster;ceph-salt config /Containers/Images/ceph ls</screen>
+<screen>&prompt.smaster;ceph-salt config /containers/images/ceph ls</screen>
     <para>
      If there is no default path set or your deployment requires a specific
      path, add it as follows:
     </para>
-<screen>&prompt.smaster;ceph-salt config /Containers/Images/ceph set registry.suse.com/ses/7/ceph/ceph</screen>
+<screen>&prompt.smaster;ceph-salt config /containers/images/ceph set registry.suse.com/ses/7/ceph/ceph</screen>
    </sect3>
    <sect3 xml:id="deploy-cephadm-configure-verify">
     <title>Verify Cluster Configuration</title>
@@ -551,35 +552,36 @@ o- Time_Server ................................................ [enabled]
 <screen>
 &prompt.smaster;ceph-salt config ls
 o- / .................................................................. [...]
-  o- Ceph_Cluster ..................................................... [...]
-  | o- Minions ................................................. [Minions: 5]
+  o- ceph_cluster ..................................................... [...]
+  | o- minions ................................................. [Minions: 5]
   | | o- ses-master.example.com ..................................... [admin]
   | | o- ses-min1.example.com ................................... [bootstrap]
   | | o- ses-min2.example.com .................................... [no roles]
   | | o- ses-min3.example.com .................................... [no roles]
   | | o- ses-min4.example.com .................................... [no roles]
-  | o- Roles .......................................................... [...]
-  |   o- Admin ................................................. [Minions: 1]
+  | o- roles .......................................................... [...]
+  |   o- admin ................................................. [Minions: 1]
   |   | o- ses-master.example.com .......................... [no other roles]
-  |   o- Bootstrap ................................... [ses-min1.example.com]
-  o- Cephadm_Bootstrap ............................................ [enabled]
-  | o- Ceph_Conf ...................................................... [...]
-  | o- Dashboard ...................................................... [...]
+  |   o- bootstrap ................................... [ses-min1.example.com]
+  o- cephadm_bootstrap ............................................ [enabled]
+  | o- ceph_conf ...................................................... [...]
+  | o- dashboard ...................................................... [...]
   |   o- password ...................................... [randomly generated]
   |   o- username ................................................... [admin]
-  o- Containers ....................................................... [...]
-  | o- Images ......................................................... [...]
+  o- containers ....................................................... [...]
+  | o- images ......................................................... [...]
   |   o- ceph ........................... [registry.suse.com/ses/7/ceph/ceph]
-  o- SSH ..................................................... [Key Pair set]
-  | o- Private_Key ........ [53:b1:eb:65:d2:3a:ff:51:6c:e2:1b:ca:84:8e:0e:83]
-  | o- Public_Key ......... [53:b1:eb:65:d2:3a:ff:51:6c:e2:1b:ca:84:8e:0e:83]
-  o- System_Update .................................................... [...]
-  | o- Packages ................................................... [enabled]
-  | o- Reboot ..................................................... [enabled]
-  o- Time_Server .................................................. [enabled]
-    o- External_Servers ................................................. [1]
+  | o- registries ................................................... [empty]
+  o- ssh ..................................................... [Key Pair set]
+  | o- private_key ........ [53:b1:eb:65:d2:3a:ff:51:6c:e2:1b:ca:84:8e:0e:83]
+  | o- public_key ......... [53:b1:eb:65:d2:3a:ff:51:6c:e2:1b:ca:84:8e:0e:83]
+  o- system_update .................................................... [...]
+  | o- packages ................................................... [enabled]
+  | o- reboot ..................................................... [enabled]
+  o- time_server .................................................. [enabled]
+    o- external_servers ................................................. [1]
     | o- 0.pt.pool.ntp.org ............................................ [...]
-    o- Server_Hostname ............................. [ses-master.example.com]
+    o- server_hostname ............................. [ses-master.example.com]
 </screen>
     <tip>
      <title>Status of Cluster Configuration</title>


### PR DESCRIPTION
Since https://github.com/ceph/ceph-salt/pull/166, config nodes are lowercase.

Also, since https://github.com/ceph/ceph-salt/pull/113, we now have a new `/containers/registries` config node.

Signed-off-by: Ricardo Marques <rimarques@suse.com>