### PR TITLE
Fixing ganesha file name - Closes #250

### DIFF
--- a/xml/admin_nfsganesha.xml
+++ b/xml/admin_nfsganesha.xml
@@ -792,7 +792,7 @@ role-ganesha_cfs/cluster/<replaceable>NODE1</replaceable>.sls
 
   <para>
    You change the default debug level <literal>NIV_EVENT</literal> by editing
-   the file <filename>/etc/sysconfig/nfs-ganesha</filename>. Replace
+   the file <filename>/etc/sysconfig/ganesha</filename>. Replace
    <literal>NIV_EVENT</literal> with <literal>NIV_DEBUG</literal> or
    <literal>NIV_FULL_DEBUG</literal>. Increasing the log verbosity can produce
    large amounts of data in the log files.


### PR DESCRIPTION
Backport to SES 6. The name depends on the suse_version macro in rpm