### PR TITLE
Add missing ceph-salt '/time_server/subnet' node

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -320,6 +320,7 @@ o- / ............................................................... [...]
   o- time_server ............................................... [enabled]
     o- external_servers .......................................... [empty]
     o- server_hostname ......................................... [not set]
+    o- subnet .................................................. [not set]
 </screen>
     <para>
      As you can see from the output of &cephsalt;'s <command>ls</command>
@@ -523,6 +524,7 @@ o- time_server ................................................ [enabled]
   o- external_servers ............................................... [1]
   | o- 0.pt.pool.ntp.org .......................................... [...]
   o- server_hostname ........................... [ses-master.example.com]
+  o- subnet .............................................. [10.20.6.0/24]
 </screen>
     <para>
      Find more information on setting up time synchronization in
@@ -582,6 +584,7 @@ o- / .................................................................. [...]
     o- external_servers ................................................. [1]
     | o- 0.pt.pool.ntp.org ............................................ [...]
     o- server_hostname ............................. [ses-master.example.com]
+    o- subnet ................................................ [10.20.6.0/24]
 </screen>
     <tip>
      <title>Status of Cluster Configuration</title>


### PR DESCRIPTION
`/time_server/subnet` exists since https://github.com/ceph/ceph-salt/pull/165

Signed-off-by: Ricardo Marques <rimarques@suse.com>