### PR TITLE
Fix typo in `ceph orch status`

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -664,9 +664,9 @@ config: OK
     <title>Displaying the Orchestrator Status</title>
     <para>
      The following command shows the current mode and status of the &ceph;
-     orchestrator. It also show actions that are currently in progress.
+     orchestrator.
     </para>
-<screen>&prompt.cephuser;ceph org status</screen>
+<screen>&prompt.cephuser;ceph orch status</screen>
    </sect3>
    <sect3 xml:id="deploy-cephadm-day2-orch-list">
     <title>Listing Devices, Services, and Daemons</title>


### PR DESCRIPTION
Also removes mention of in-progress operation status (which we don't have)

Signed-off-by: Tim Serong <tserong@suse.com>