### PR TITLE
Rename `ceph-salt deploy` to `ceph-salt apply`

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -617,7 +617,7 @@ config: OK
     Deploy the previously configured minimal &ceph; cluster by running the
     following command:
    </para>
-<screen>&prompt.smaster;ceph-salt deploy</screen>
+<screen>&prompt.smaster;ceph-salt apply</screen>
    <para>
     The above command will open an interactive user interface that shows the
     current progress of each minion.
@@ -636,10 +636,10 @@ config: OK
    <tip>
     <title>Non-interactive Mode</title>
     <para>
-     If you need to run the deployment from a script, there is also a
+     If you need to apply the configuration from a script, there is also a
      non-interactive mode:
     </para>
-<screen>&prompt.smaster;ceph-salt deploy --non-interactive</screen>
+<screen>&prompt.smaster;ceph-salt apply --non-interactive</screen>
    </tip>
   </sect2>
  </sect1>


### PR DESCRIPTION
https://github.com/ceph/ceph-salt/pull/200 will rename `ceph-salt deploy` command to `ceph-salt apply`.

Signed-off-by: Ricardo Marques <rimarques@suse.com>