### PR TITLE
Changed 'tip' to 'important' (bsc#1169856)

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -483,7 +483,7 @@ Value set.
 &prompt.smaster;ceph-salt config /ceph_cluster/roles/bootstrap ls
 o- bootstrap ..................................... [ses-min1.example.com]
 </screen>
-    <tip>
+    <important>
      <para>
       The minion that will bootstrap the cluster needs to have the admin
       keyring as well:
@@ -496,7 +496,7 @@ o- admin ................................................... [Minions: 1]
   o- ses-master.example.com ............................ [no other roles]
   o- ses-min1.suse.cz .......................... [other roles: bootstrap]
 </screen>
-    </tip>
+    </important>
    </sect3>
    <sect3 xml:id="deploy-cephadm-configure-ssh">
     <title>Generate SSH Key Pair</title>


### PR DESCRIPTION
Specifying the admin keyring to the first bootstrap MON is mandotory, therefore changing a 'tip' to 'important'