### PR TITLE
deploy_cephadm.xml: fixed typo

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -1049,7 +1049,7 @@ ses-min4
    <para>
     <emphasis>&drvgrps;</emphasis> specify the layouts of OSDs in the &ceph;
     cluster. They are defined in a single YAML file. In this section, we will
-    use <filename>drive_groups.xml</filename> as an example.
+    use <filename>drive_groups.yml</filename> as an example.
    </para>
    <para>
     An administrator should manually specify a group of OSDs that are


### PR DESCRIPTION
Replaced `drive_groups.xml` with `drive_groups.yml` (as it's a YAML file)

Signed-off-by: Lenz Grimmer <lgrimmer@suse.com>