### PR TITLE
Added section on dashboard credentials (gh#SUSE/doc-ses#301)

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -555,6 +555,17 @@ o- time_server ................................................ [enabled]
       xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-ntp.html#sec-ntp-yast"/>.
     </para>
    </sect3>
+   <sect3 xml:id="deploy-cephadm-configure-dashboardlogin">
+    <title>Configure &dashboard; Login Credentials</title>
+    <para>
+     &dashboard; will be available after the basic cluster is deployed.
+     To access it, you need to set a valid user name and password, for example:
+    </para>
+<screen>
+&prompt.smaster;ceph-salt config /cephadm_bootstrap/dashboard/username set admin
+&prompt.smaster;ceph-salt config /cephadm_bootstrap/dashboard/password set <replaceable>PWD</replaceable>
+</screen>
+   </sect3>
    <sect3 xml:id="deploy-cephadm-configure-imagepath">
     <title>Configure Path to Container Images</title>
     <para>


### PR DESCRIPTION
The deployment procedure missed instructions on configuring Dashboard's login credentials.
This update adds such section and fixes #301 