### PR TITLE
Removed old way of getting dashboard credetials (gh#SUSE/doc-ses#300)

### DIFF
--- a/xml/admin_gui_dashboard.xml
+++ b/xml/admin_gui_dashboard.xml
@@ -23,15 +23,14 @@
  </para>
  <para>
   The &dashboard; is automatically enabled and configured with &deepsea;'s
-  stage 3 during the deployment procedure (see
-  DEAD LINK). In a &ceph; cluster with multiple
-  &mgr; instances, only the dashboard running on the currently active &mgr;
-  daemon will serve incoming requests. Accessing the dashboard's TCP port on
-  any of the other &mgr; instances that are currently on standby will perform
-  an HTTP redirect (303) to the currently active &mgr;'s dashboard URL. This
-  way, you can point your browser to any of the &mgr; instances in order to
-  access the dashboard. Consider this behavior when securing access with
-  firewall or planning for HA setup.
+  stage 3 during the deployment procedure (see DEAD LINK). In a &ceph; cluster
+  with multiple &mgr; instances, only the dashboard running on the currently
+  active &mgr; daemon will serve incoming requests. Accessing the dashboard's
+  TCP port on any of the other &mgr; instances that are currently on standby
+  will perform an HTTP redirect (303) to the currently active &mgr;'s dashboard
+  URL. This way, you can point your browser to any of the &mgr; instances in
+  order to access the dashboard. Consider this behavior when securing access
+  with firewall or planning for HA setup.
  </para>
  <sect1 xml:id="dashboard-webui-general">
   <title>Dashboard's Web User Interface</title>
@@ -58,14 +57,9 @@
     </mediaobject>
    </figure>
    <para>
-    You need a user account in order to log in to the dashboard Web
-    application. &deepsea; creates a default user 'admin' with administrator
-    privileges for you. If you decide to log in with the default 'admin' user,
-    retrieve the corresponding password by running
+    Log in by using the credentials that you created during cluster deployment
+    (see <xref linkend="deploy-cephadm-configure-dashboardlogin"/>).
    </para>
-<screen>
-&prompt.smaster;salt-call grains.get dashboard_creds
-</screen>
    <tip>
     <title>Custom User Account</title>
     <para>
@@ -433,7 +427,8 @@
       <term><guimenu>Scrub</guimenu></term>
       <listitem>
        <para>
-        Shows the scrub (see <xref linkend="op-pg-scrubpg"/>) status. It is either disabled, enabled, or active.
+        Shows the scrub (see <xref linkend="op-pg-scrubpg"/>) status. It is
+        either disabled, enabled, or active.
        </para>
       </listitem>
      </varlistentry>
@@ -1196,7 +1191,8 @@
     <title>More Information on &igw;s</title>
     <para>
      For more general information about &igw;s, refer to
-     <!-- DEAD_LINK  <xref linkend="cha-ceph-as-iscsi"/> and <xref linkend="cha-ceph-iscsi"/> -->.
+<!-- DEAD_LINK  <xref linkend="cha-ceph-as-iscsi"/> and <xref linkend="cha-ceph-iscsi"/> -->
+     .
     </para>
    </tip>
    <para>


### PR DESCRIPTION
Dashboard login credentials can no longer be obtained from DS grain,
this update fixes #300.

NOTE: this PR is failing because it referes XML ID that is not yet merged into 'master'