### PR TITLE
Correct /ceph_cluster/roles/admin ls output

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -489,9 +489,9 @@ o- bootstrap ..................................... [ses-min1.example.com]
 &prompt.smaster;ceph-salt config /ceph_cluster/roles/admin add ses-min1.example.com
 1 minion added.
 &prompt.smaster;ceph-salt config /ceph_cluster/roles/admin ls
-o- admin ................................................... [Minions: 1]
+o- admin ................................................... [Minions: 2]
   o- ses-master.example.com ............................ [no other roles]
-  o- ses-min1.suse.cz .......................... [other roles: bootstrap]
+  o- ses-min1.example.com ...................... [other roles: bootstrap]
 </screen>
     </important>
    </sect3>
@@ -695,13 +695,14 @@ o- / ............................................................... [...]
   o- ceph_cluster .................................................. [...]
   | o- minions .............................................. [Minions: 5]
   | | o- ses-master.example.com .................................. [admin]
-  | | o- ses-min1.example.com ................................ [bootstrap]
+  | | o- ses-min1.example.com ......................... [bootstrap, admin]
   | | o- ses-min2.example.com ................................. [no roles]
   | | o- ses-min3.example.com ................................. [no roles]
   | | o- ses-min4.example.com ................................. [no roles]
   | o- roles ....................................................... [...]
-  |   o- admin .............................................. [Minions: 1]
+  |   o- admin .............................................. [Minions: 2]
   |   | o- ses-master.example.com ....................... [no other roles]
+  |   | o- ses-min1.example.com ................. [other roles: bootstrap]
   |   o- bootstrap ................................ [ses-min1.example.com]
   o- cephadm_bootstrap ......................................... [enabled]
   | o- advanced .................................................... [...]


### PR DESCRIPTION
In the example the host `ses-min1.example.com` has been added to role admin:
`ceph-salt config /ceph_cluster/roles/admin add ses-min1.example.com`. But the command `ceph-salt config /ceph_cluster/roles/admin ls` is showing the hostname: `ses-min1.suse.cz` afterwards.
Correct the amount of admin minions too.

Signed-off-by: Tatjana Dehler <tdehler@suse.com>