### PR TITLE
standby-for options have been deprecated within cephfs (BSC#1171365)

### DIFF
--- a/xml/admin_ceph_cephfs.xml
+++ b/xml/admin_ceph_cephfs.xml
@@ -382,103 +382,31 @@ setfattr -n ceph.dir.pin -v 0 a/b # "a/b" is now pinned to rank 0
    more 'standby' daemons that will take over during the MDS daemon failover.
   </para>
 
-  <sect2 xml:id="ceph-cephfs-failover-standby">
-   <title>Configuring Standby Daemons</title>
+  <sect2 xml:id="ceph-cephfs-failover-standbyreplace">
+   <title>Configuring Standby Replay</title>
    <para>
-    There are several configuration settings that control how a daemon will
-    behave while in standby. You can specify them in the
-    <filename>ceph.conf</filename> on the host where the MDS daemon runs. The
-    daemon loads these settings when it starts, and sends them to the monitor.
+    Each &cephfs; file system may be configured to add standby-replay daemons.
+    These standby daemons follow the active MDS's metadata journal to reduce
+    failover time in the event active MDS becomes unavailable. Each active
+    MDS may have only one standby-replay daemon following it.
    </para>
    <para>
-    By default, if none of these settings are used, all MDS daemons which do
-    not hold a rank will be used as 'standbys' for any rank.
+     Configure standby-replace on a file system with the following comamnd:
+   </para>
+<screen>
+&prompt.cephuser;ceph fs set <replaceable>FS-NAME</replaceable> allow_standby_replay <replaceable>BOOL</replaceable>
+</screen>
+   <para>
+     Once set the monitors will assign available standby daemons to follow
+     the active MDS's in that file system.
    </para>
    <para>
-    The settings which associate a standby daemon with a particular name or
-    rank do not guarantee that the daemon will only be used for that rank. They
-    mean that when several standbys are available, the associated standby
-    daemon will be used. If a rank is failed, and a standby is available, it
-    will be used even if it is associated with a different rank or named
-    daemon.
+     Once an MDS has entered the standby-replay state, it will only be used as a
+     standby for the rank that it is following. If another rank fails, this
+     standby-replay daemon will not be used as a replacement, even if no other
+     standbys are available. For this reason, it is advised that if standby-replay
+     is used then every active MDS should have a standby-replay daemon.
    </para>
-   <variablelist>
-    <varlistentry>
-     <term>mds_standby_replay</term>
-     <listitem>
-      <para>
-       If set to true, then the standby daemon will continuously read the
-       metadata journal of an up rank. This will give it a warm metadata cache,
-       and speed up the process of failing over if the daemon serving the rank
-       fails.
-      </para>
-      <para>
-       An up rank may only have one standby replay, daemon assigned to it. If
-       two daemons are both set to be standby replay then one of them will
-       arbitrarily win, and the other will become a normal non-replay standby.
-      </para>
-      <para>
-       When a daemon has entered the standby replay state, it will only be used
-       as a standby for the rank that it is following. If another rank fails,
-       this standby replay daemon will not be used as a replacement, even if no
-       other standbys are available.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>mds_standby_for_name</term>
-     <listitem>
-      <para>
-       Set this to make the standby daemon only take over a failed rank if the
-       last daemon to hold it matches this name.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>mds_standby_for_rank</term>
-     <listitem>
-      <para>
-       Set this to make the standby daemon only take over the specified rank.
-       If another rank fails, this daemon will not be used to replace it.
-      </para>
-      <para>
-       Use in conjunction with<option>mds_standby_for_fscid</option> to be
-       specific about which file system's rank you are targeting in case of
-       multiple file systems.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>mds_standby_for_fscid</term>
-     <listitem>
-      <para>
-       If <option>mds_standby_for_rank</option> is set, this is simply a
-       qualifier to say which file system's rank is being referred to.
-      </para>
-      <para>
-       If <option>mds_standby_for_rank</option> is not set, then setting FSCID
-       will cause this daemon to target any rank in the specified FSCID. Use
-       this if you have a daemon that you want to use for any rank, but only
-       within a particular file system.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>mon_force_standby_active</term>
-     <listitem>
-      <para>
-       This setting is used on monitor hosts. It defaults to true.
-      </para>
-      <para>
-       If it is false, then daemons configured with
-       <option>standby_replay=true</option> will only become active if the
-       rank/name that they have been configured to follow fails. On the other
-       hand, if this setting is true, then a daemon configured with
-       <option>standby_replay=true</option> may be assigned some other rank.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
   </sect2>
 
   <sect2 xml:id="ceph-cephfs-failover-examples">

--- a/xml/admin_ceph_cephfs.xml
+++ b/xml/admin_ceph_cephfs.xml
@@ -382,7 +382,7 @@ setfattr -n ceph.dir.pin -v 0 a/b # "a/b" is now pinned to rank 0
    more 'standby' daemons that will take over during the MDS daemon failover.
   </para>
 
-  <sect2 xml:id="ceph-cephfs-failover-standbyreplace">
+  <sect2 xml:id="ceph-cephfs-failover-standby">
    <title>Configuring Standby Replay</title>
    <para>
     Each &cephfs; file system may be configured to add standby-replay daemons.
@@ -391,7 +391,7 @@ setfattr -n ceph.dir.pin -v 0 a/b # "a/b" is now pinned to rank 0
     MDS may have only one standby-replay daemon following it.
    </para>
    <para>
-     Configure standby-replace on a file system with the following comamnd:
+     Configure standby-replay on a file system with the following comamnd:
    </para>
 <screen>
 &prompt.cephuser;ceph fs set <replaceable>FS-NAME</replaceable> allow_standby_replay <replaceable>BOOL</replaceable>

--- a/xml/admin_ceph_cephfs.xml
+++ b/xml/admin_ceph_cephfs.xml
@@ -387,7 +387,7 @@ setfattr -n ceph.dir.pin -v 0 a/b # "a/b" is now pinned to rank 0
    <para>
     Each &cephfs; file system may be configured to add standby-replay daemons.
     These standby daemons follow the active MDS's metadata journal to reduce
-    failover time in the event active MDS becomes unavailable. Each active
+    failover time in the event that the active MDS becomes unavailable. Each active
     MDS may have only one standby-replay daemon following it.
    </para>
    <para>
@@ -398,7 +398,7 @@ setfattr -n ceph.dir.pin -v 0 a/b # "a/b" is now pinned to rank 0
 </screen>
    <para>
      Once set the monitors will assign available standby daemons to follow
-     the active MDS's in that file system.
+     the active MDSs in that file system.
    </para>
    <para>
      Once an MDS has entered the standby-replay state, it will only be used as a


### PR DESCRIPTION
Removing documentation for standby-for options and adding
upstream documentation.