### PR TITLE
Specify multiple minions at once for Ceph services (gh#SUSE/doc-ses#330)

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -1008,8 +1008,10 @@ o- minions ................................................. [Minions: 5]
       to append the subnet address. For example:
      </para>
 <screen>
-&prompt.cephuser;ceph orch apply mon ses-min1:10.1.2.0/24,ses-min2:10.1.5.0/24
-&prompt.cephuser;ceph orch apply mgr ses-min1:10.1.2.0/24,ses-min2:10.1.5.0/24
+&prompt.cephuser;ceph orch apply mon \
+ ses-min1:10.1.2.0/24,ses-min2:10.1.5.0/24,ses-min3:10.1.10.0/24
+&prompt.cephuser;ceph orch apply mgr \
+ ses-min1:10.1.2.0/24,ses-min2:10.1.5.0/24,ses-min3:10.1.10.0/24
 </screen>
     </tip>
     <tip>

--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -990,17 +990,17 @@ o- minions ................................................. [Minions: 5]
     <para>
      To deploy new MONs, run:
     </para>
-<screen>&prompt.cephuser;ceph orch apply mon <replaceable>SHORT_MON_HOST_NAME</replaceable></screen>
+<screen>&prompt.cephuser;ceph orch apply mon <replaceable>SHORT_MON_HOST_NAMES</replaceable></screen>
     <para>
      To deploy new MGRs, run:
     </para>
-<screen>&prompt.cephuser;ceph orch apply mgr <replaceable>SHORT_MGR_HOST_NAME</replaceable></screen>
+<screen>&prompt.cephuser;ceph orch apply mgr <replaceable>SHORT_MGR_HOST_NAMES</replaceable></screen>
     <para>
      For example:
     </para>
 <screen>
-&prompt.cephuser;ceph orch apply mon ses-min1
-&prompt.cephuser;ceph orch apply mgr ses-min1
+&prompt.cephuser;ceph orch apply mon ses-min1,ses-min2,ses-min3
+&prompt.cephuser;ceph orch apply mgr ses-min1,ses-min2,ses-min3
 </screen>
     <tip>
      <para>
@@ -1008,10 +1008,8 @@ o- minions ................................................. [Minions: 5]
       to append the subnet address. For example:
      </para>
 <screen>
-&prompt.cephuser;ceph orch apply mon ses-min1:10.1.2.0/24
-&prompt.cephuser;ceph orch apply mon ses-min2:10.1.5.0/24
-&prompt.cephuser;ceph orch apply mgr ses-min1:10.1.2.0/24
-&prompt.cephuser;ceph orch apply mgr ses-min2:10.1.5.0/24
+&prompt.cephuser;ceph orch apply mon ses-min1:10.1.2.0/24,ses-min2:10.1.5.0/24
+&prompt.cephuser;ceph orch apply mgr ses-min1:10.1.2.0/24,ses-min2:10.1.5.0/24
 </screen>
     </tip>
     <tip>


### PR DESCRIPTION
One needs to specify all minions at once separated by commas when applying Ceph services.
Closes #330 