### PR TITLE
Removed CLI per host adding OSD (bsc#1172129)

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -1106,7 +1106,7 @@ ses-min4
      </para>
     </important>
     <para>
-     There are several ways you can deploy new OSDs:
+     There are two recommended ways you can deploy new OSDs:
     </para>
     <itemizedlist>
      <listitem>

--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -1115,6 +1115,7 @@ ses-min4
       </para>
 <screen>&prompt.cephuser;ceph orch apply osd --all-available-devices</screen>
      </listitem>
+<!-- 2020-06-02 tbazant: not a recommended way by swagner & jschmid
      <listitem>
       <para>
        Create an OSD from a specific device on a specific host:
@@ -1125,6 +1126,7 @@ ses-min4
       </para>
 <screen>&prompt.cephuser;ceph orch daemon add osd ses-min1:/dev/sdb</screen>
      </listitem>
+-->
      <listitem>
       <para>
        Use &drvgrps; (see <xref linkend="drive-groups"/>) to describe devices


### PR DESCRIPTION
This update removes the `ceph orch daemon add osd` way of adding OSDs, in favour of the Drivegroups approach