### PR TITLE
Fix ceph-salt registries path

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -666,7 +666,7 @@ o- time_server ................................................ [enabled]
        On the &smaster;, add the <emphasis>insecure</emphasis> local repository
        to the &cephsalt; configuration:
       </para>
-<screen>&prompt.smaster;ceph-salt config /containers/registries \
+<screen>&prompt.smaster;ceph-salt config /containers/registries_conf/registries \
  add prefix=registry.suse.com \
  location=<replaceable>LOCAL_REGISTRY_HOST_IP</replaceable>:5000/registry.suse.com insecure=true
 </screen>


### PR DESCRIPTION
Since https://github.com/ceph/ceph-salt/pull/262, path has changed from `/containers/registries` to `/containers/registries_conf/registries`.

Signed-off-by: Ricardo Marques <rimarques@suse.com>