### PR TITLE
Extends section on container registry (gh#359)

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -597,9 +597,11 @@ o- time_server ................................................ [enabled]
    <sect3 xml:id="deploy-cephadm-configure-registry">
     <title>Configure Container Registry</title>
     <para>
-     Optionally, you can set an alternative container registry. This will serve
-     as a mirror of a public online registry and is useful in the following
-     scenarios:
+     Optionally, you can set a local container registry. This will serve as a
+     mirror of the <literal>registry.suse.com</literal> registry. Remember you
+     need to re-sync the local registry whenever there are new updated
+     containers available from <literal>registry.suse.com</literal>. Creating a
+     local registry is useful in the following scenarios:
     </para>
     <itemizedlist>
      <listitem>
@@ -622,6 +624,16 @@ o- time_server ................................................ [enabled]
       </para>
      </listitem>
     </itemizedlist>
+    <tip>
+     <title>Registry Cache</title>
+     <para>
+      To avoid re-syncing the local registry when new updated containers
+      appear, you can configure a <emphasis>registry cache</emphasis>. Find
+      more information about containers and air-gapped scenarios in
+      <link
+       xlink:href="https://documentation.suse.com/suse-caasp/4.1/html/caasp-deployment/_deployment_scenarios.html#_airgapped_deployment"/>.
+     </para>
+    </tip>
     <tip>
      <title>Container Tools</title>
      <para>

--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -684,7 +684,7 @@ o- time_server ................................................ [enabled]
  location=<replaceable>LOCAL_REGISTRY_HOST_IP</replaceable>:5000/registry.suse.com
 </screen>
       <para>
-       If your deployment requires an insecure access, add the
+       If your deployment requires insecure access, add the
        <option>insecure=true</option> option:
       </para>
 <screen>

--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -664,7 +664,7 @@ o- time_server ................................................ [enabled]
      </step>
      <step>
       <para>
-       Mirror SES &productnumber; related containers to the local registry:
+       Mirror SES &productnumber; related images to the local registry:
       </para>
 <screen>
 &prompt.root;skopeo copy \
@@ -675,10 +675,20 @@ o- time_server ................................................ [enabled]
      </step>
      <step>
       <para>
-       On the &smaster;, add the <emphasis>insecure</emphasis> local repository
-       to the &cephsalt; configuration:
+       On the &smaster;, add the local repository to the &cephsalt;
+       configuration:
       </para>
-<screen>&prompt.smaster;ceph-salt config /containers/registries_conf/registries \
+<screen>
+&prompt.smaster;ceph-salt config /containers/registries_conf/registries \
+ add prefix=registry.suse.com \
+ location=<replaceable>LOCAL_REGISTRY_HOST_IP</replaceable>:5000/registry.suse.com
+</screen>
+      <para>
+       If your deployment requires an insecure access, add the
+       <option>insecure=true</option> option:
+      </para>
+<screen>
+&prompt.smaster;ceph-salt config /containers/registries_conf/registries \
  add prefix=registry.suse.com \
  location=<replaceable>LOCAL_REGISTRY_HOST_IP</replaceable>:5000/registry.suse.com insecure=true
 </screen>

--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -664,7 +664,7 @@ o- time_server ................................................ [enabled]
      </step>
      <step>
       <para>
-       Mirror SES &productnumber; related images to the local registry:
+       Mirror SES &productnumber; related container images to the local registry:
       </para>
 <screen>
 &prompt.root;skopeo copy \

--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -619,8 +619,9 @@ o- time_server ................................................ [enabled]
      </listitem>
      <listitem>
       <para>
-       You have a good reason to avoid secure access to the registry and want
-       to setup and access an insecure one.
+       If configuration or network issues prevent your cluster from accessing
+       remote registries across a secure link, so you need a local, unencrypted
+       registry instead.
       </para>
      </listitem>
     </itemizedlist>
@@ -664,7 +665,8 @@ o- time_server ................................................ [enabled]
      </step>
      <step>
       <para>
-       Mirror SES &productnumber; related container images to the local registry:
+       Mirror SES &productnumber; related container images to the local
+       registry:
       </para>
 <screen>
 &prompt.root;skopeo copy \


### PR DESCRIPTION

[deploy-cephadm-day1_color_en.pdf](https://github.com/SUSE/doc-ses/files/4817930/deploy-cephadm-day1_color_en.pdf)
- mentions cache registry and adds a reference to CaaSP ait-gapped section (closes #359 )
- fixes wording (closes #377 )
- removes deafault insecure access example (closes #374)