### PR TITLE
Adding warning to ceph-salt export command  - Closes#339

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -529,7 +529,7 @@ o- ssh ................................................... [Key Pair set]
 </screen>
    <note>
      <para>
-       The resulting exported json configuration includes a private SSH key.
+       The resulting exported JSON configuration includes a private SSH key.
        Take care when dumping this file to ensure that it can not be accessed
        by others.
      </para>

--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -799,9 +799,9 @@ config: OK
 <screen>&prompt.smaster;ceph-salt export > cluster.json</screen>
     <warning>
       <para>
-       Executing the <command>ceph-salt export</command> includes the
+       The output of the <command>ceph-salt export</command> includes the
        SSH private key. If you are concerned about the security implications,
-       then do not execute this command unless necessary.
+       do not execute this command without taking appropriate precautions.
       </para>
     </warning>
     <para>

--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -527,6 +527,23 @@ o- ssh ................................................... [Key Pair set]
   o- private_key ...... [53:b1:eb:65:d2:3a:ff:51:6c:e2:1b:ca:84:8e:0e:83]
   o- public_key ....... [53:b1:eb:65:d2:3a:ff:51:6c:e2:1b:ca:84:8e:0e:83]
 </screen>
+   <note>
+     <para>
+       The resulting exported json configuration includes a private SSH key.
+       Take care when dumping this file to ensure that it can not be accessed
+       by others.
+     </para>
+     <para>
+       To ensure this does not occur, you can take an extra precaution by
+       using <command>umask</command>:
+     </para>
+<screen>&prompt.cephuser;umask 077
+&prompt.cephuser;ceph-salt export > cluster.json</screen>
+     <para>
+       The <command>umask</command> change avoids accidental granting of
+       non-root access on the same host.
+     </para>
+   </note>
    </sect3>
    <sect3 xml:id="deploy-cephadm-configure-ntp">
     <title>Configure Time Server</title>

--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -527,23 +527,6 @@ o- ssh ................................................... [Key Pair set]
   o- private_key ...... [53:b1:eb:65:d2:3a:ff:51:6c:e2:1b:ca:84:8e:0e:83]
   o- public_key ....... [53:b1:eb:65:d2:3a:ff:51:6c:e2:1b:ca:84:8e:0e:83]
 </screen>
-   <note>
-     <para>
-       The resulting exported JSON configuration includes a private SSH key.
-       Take care when dumping this file to ensure that it can not be accessed
-       by others.
-     </para>
-     <para>
-       To ensure this does not occur, you can take an extra precaution by
-       using <command>umask</command>:
-     </para>
-<screen>&prompt.cephuser;umask 077
-&prompt.cephuser;ceph-salt export > cluster.json</screen>
-     <para>
-       The <command>umask</command> change avoids accidental granting of
-       non-root access on the same host.
-     </para>
-   </note>
    </sect3>
    <sect3 xml:id="deploy-cephadm-configure-ntp">
     <title>Configure Time Server</title>
@@ -814,6 +797,13 @@ config: OK
      valid, it is a good idea to export its configuration to a file:
     </para>
 <screen>&prompt.smaster;ceph-salt export > cluster.json</screen>
+    <warning>
+      <para>
+       Executing the <command>ceph-salt export</command> includes the
+       SSH private key. If you are concerned about the security implications,
+       then do not execute this command unless necessary.
+      </para>
+    </warning>
     <para>
      In case you break the cluster configuration and need to revert to a backup
      state, run:


### PR DESCRIPTION
Originally the request was to add umask, but to avoid overcomplication, adding a warning to the export command should ensure individual are aware of the risk.