### PR TITLE
Moving the glossary to the end Closes#312

### DIFF
--- a/xml/book_storage_admin.xml
+++ b/xml/book_storage_admin.xml
@@ -60,6 +60,6 @@
   <xi:include href="admin_cephx.xml" parse="xml"/>
  </part>
  <xi:include href="ceph_maintenance_updates.xml" parse="xml"/>
- <xi:include href="ses_glossary.xml" parse="xml"/>
  <xi:include href="docupdates.xml" parse="xml"/>
+ <xi:include href="ses_glossary.xml" parse="xml"/>
 </book>

--- a/xml/book_storage_deployment.xml
+++ b/xml/book_storage_deployment.xml
@@ -37,7 +37,7 @@
   <xi:include href="deploy_caasp.xml" parse="xml"/>
 <!-- <xi:include href="deploy_customized.xml" parse="xml"/> -->
  </part>
-<!-- 
+<!--
  <part xml:id="additional-software">
   <title>Installing Additional Services</title>
   <xi:include href="deployment_additional_software_intro.xml" parse="xml"/>
@@ -52,6 +52,6 @@
   <xi:include href="admin_ceph_upgrade.xml" parse="xml"/>
  </part>
  <xi:include href="ceph_maintenance_updates.xml" parse="xml"/>
- <xi:include href="ses_glossary.xml" parse="xml"/>
  <xi:include href="docupdates.xml" parse="xml"/>
+ <xi:include href="ses_glossary.xml" parse="xml"/>
 </book>

--- a/xml/book_storage_security.xml
+++ b/xml/book_storage_security.xml
@@ -24,6 +24,6 @@
  </info>
   <xi:include href="ceph_prompts.xml" parse="xml"/>
   <xi:include href="ceph_maintenance_updates.xml" parse="xml"/>
-  <xi:include href="ses_glossary.xml" parse="xml"/>
   <xi:include href="docupdates.xml" parse="xml"/>
+  <xi:include href="ses_glossary.xml" parse="xml"/>
 </book>

--- a/xml/book_storage_troubleshooting.xml
+++ b/xml/book_storage_troubleshooting.xml
@@ -38,6 +38,6 @@
   <xi:include href="bp_troubleshooting_tips.xml" parse="xml"/>
   <xi:include href="bp_troubleshooting_faqs.xml" parse="xml"/>
   <xi:include href="ceph_maintenance_updates.xml" parse="xml"/>
-  <xi:include href="ses_glossary.xml" parse="xml"/>
   <xi:include href="docupdates.xml" parse="xml"/>
+  <xi:include href="ses_glossary.xml" parse="xml"/>
 </book>


### PR DESCRIPTION
The glossary is currently set before the docuupdates in each of
the guides, but breaks up the appendix lettering. This looks
messy and inconsistent. This change aligns the ordering so that
it no longer breaks up the lettering sequence.