### PR TITLE
Updating time sync disable note with xref (BSC#1171596)

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -361,7 +361,8 @@ mds standby for name = mds.456-another-mds
     <para>
       If you want to manually maintain the <systemitem class="daemon">chronyd</systemitem>
       configuration, follow the instructions below and ensure you disable
-      the time configuration (as describe below).
+      the time configuration. See <xref linkend="using-customized-files"/> for more
+      information. 
     </para>
   </warning>
 

--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -361,7 +361,7 @@ mds standby for name = mds.456-another-mds
     <para>
       If you want to manually maintain the <systemitem class="daemon">chronyd</systemitem>
       configuration, follow the instructions below and ensure you disable
-      the time configuration. See <xref linkend="disable-time-sync"/> for more
+      <systemitem class="daemon">ntpd</systemitem> time configuration. See <xref linkend="disable-time-sync"/> for more
       information.
     </para>
   </warning>

--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -361,8 +361,8 @@ mds standby for name = mds.456-another-mds
     <para>
       If you want to manually maintain the <systemitem class="daemon">chronyd</systemitem>
       configuration, follow the instructions below and ensure you disable
-      the time configuration. See <xref linkend="using-customized-files"/> for more
-      information. 
+      the time configuration. See <xref linkend="disable-time-sync"/> for more
+      information.
     </para>
   </warning>
 

--- a/xml/deployment_ds_custom.xml
+++ b/xml/deployment_ds_custom.xml
@@ -51,7 +51,7 @@
     and therefore need to skip it, create a 'no-operation' file following this
     example:
    </para>
-   <procedure>
+   <procedure xml:id="disable-time-sync">
     <title>Disabling Time Synchronization</title>
     <step>
      <para>


### PR DESCRIPTION
Fujistu requested a clarification on the disabling time sync note. See https://bugzilla.suse.com/show_bug.cgi?id=1171596#c19