### PR TITLE
Specify security and realm smb.conf parameters (bsc#1157369)

### DIFF
--- a/xml/deployment_cifs.xml
+++ b/xml/deployment_cifs.xml
@@ -700,9 +700,21 @@ dc1.domain.example.com  internet address = 10.99.0.1
    <title>Configuring &samba;</title>
    <para>
     This section introduces information about specific configuration options
-    that you need to include in the &samba; configuration file
+    that you need to include in the &samba; configuration.
+   </para>
+   <para>
+    &ad; domain membership is primarily configured by setting
+    <literal>security = ADS</literal> alongside appropriate Kerberos realm
+    and ID mapping parameters in the <literal>[global]</literal> section of
     <filename>/etc/samba/smb.conf</filename>.
    </para>
+<screen>
+[global]
+  security = ADS
+  workgroup = DOMAIN
+  realm = DOMAIN.EXAMPLE.COM
+  ...
+</screen>
    <sect3>
     <title>Choose Back-end for ID Mapping in <systemitem>winbindd</systemitem></title>
     <para>


### PR DESCRIPTION
"security = ADS" must be configured for winbind to function for AD
domain membership (bsc#1157369).