### PR TITLE
rework HA/standalone Samba service documentation

### DIFF
--- a/xml/deployment_cifs.xml
+++ b/xml/deployment_cifs.xml
@@ -526,8 +526,19 @@ Clone Set: base-clone [dlm]
 <screen>&prompt.root;<command>smbclient</command> <option>//192.168.2.1/myshare</option></screen>
     </step>
    </procedure>
+
+  <sect3 xml:id="samba-ha-service-restart">
+   <title>Restarting HA &samba; Resources</title>
+   <para>
+    Following any &samba; or CTDB configuration changes, HA resources may need to
+    be restarted for the changes to take effect. This can be done by via:
+   </para>
+<screen>&prompt.root;<command>crm</command> resource restart cl-ctdb</screen>
+  </sect3>
+
   </sect2>
  </sect1>
+
  <sect1 xml:id="cephfs-ad">
   <title>&sgw; Joining &ad;</title>
 

--- a/xml/deployment_cifs.xml
+++ b/xml/deployment_cifs.xml
@@ -305,24 +305,22 @@
        <para>
         Make sure the following packages are installed before you proceed:
         <package>ctdb</package>, <package>tdb-tools</package>, and
-        <package>samba</package> (needed for
-        <systemitem
-         class="daemon">smb.service</systemitem> and
-        <systemitem
-         class="daemon">nmb.service</systemitem>).
+        <package>samba</package>.
        </para>
-<screen>&prompt.cephuser.smb;<command>zypper</command> in ctdb tdb-tools samba samba-ceph</screen>
+<screen>&prompt.root;<command>zypper</command> in ctdb tdb-tools samba samba-ceph</screen>
       </step>
       <step>
        <para>
-        Make sure the services <literal>ctdb</literal>, <literal>smb</literal>,
-        and <literal>nmb</literal> are stopped and disabled:
+        Make sure the &samba; and CTDB services are stopped and disabled:
        </para>
-<screen>&prompt.cephuser.smb;sudo systemctl disable ctdb
-&prompt.cephuser.smb;sudo systemctl disable smb
-&prompt.cephuser.smb;sudo systemctl disable nmb
-&prompt.cephuser.smb;sudo systemctl stop smb
-&prompt.cephuser.smb;sudo systemctl stop nmb</screen>
+<screen>&prompt.root;systemctl disable ctdb
+&prompt.root;systemctl disable smb
+&prompt.root;systemctl disable nmb
+&prompt.root;systemctl disable winbind
+&prompt.root;systemctl stop ctdb
+&prompt.root;systemctl stop smb
+&prompt.root;systemctl stop nmb
+&prompt.root;systemctl stop winbind</screen>
       </step>
       <step>
        <para>
@@ -476,17 +474,34 @@ Full list of resources:
         op monitor interval="10" timeout="20" \
         op start interval="0" timeout="200" \
         op stop interval="0" timeout="100"
-&prompt.crm.conf;<command>primitive</command> nmb systemd:nmb \
-    op start timeout="100" interval="0" \
-    op stop timeout="100" interval="0" \
-    op monitor interval="60" timeout="100"
 &prompt.crm.conf;<command>primitive</command> smb systemd:smb \
     op start timeout="100" interval="0" \
     op stop timeout="100" interval="0" \
     op monitor interval="60" timeout="100"
-&prompt.crm.conf;<command>group</command> g-ctdb ctdb nmb smb
+&prompt.crm.conf;<command>primitive</command> nmb systemd:nmb \
+    op start timeout="100" interval="0" \
+    op stop timeout="100" interval="0" \
+    op monitor interval="60" timeout="100"
+&prompt.crm.conf;<command>primitive</command> winbind systemd:winbind \
+    op start timeout="100" interval="0" \
+    op stop timeout="100" interval="0" \
+    op monitor interval="60" timeout="100"
+&prompt.crm.conf;<command>group</command> g-ctdb ctdb winbind nmb smb
 &prompt.crm.conf;<command>clone</command> cl-ctdb g-ctdb meta interleave="true"
 &prompt.crm.conf;<command>commit</command></screen>
+     <tip>
+      <title>Optional <systemitem class="daemon">nmb</systemitem> and
+      <systemitem class="daemon">winbind</systemitem> primitives</title>
+      <para>
+       If you do not require network share browsing, you do not need to add
+       the <systemitem class="daemon">nmb</systemitem> primitive.
+      </para>
+      <para>
+       The <systemitem class="daemon">winbind</systemitem> primitive is only
+       needed when configured as an &ad; domain member. See
+       <xref linkend="cephfs-ad"/>.
+      </para>
+     </tip>
      <para>
       The binary
       <command>/usr/lib64/ctdb/ctdb_mutex_ceph_rados_helper</command> in the

--- a/xml/deployment_cifs.xml
+++ b/xml/deployment_cifs.xml
@@ -187,18 +187,41 @@
 </screen>
      </important>
     </step>
-    <step>
-     <para>
-      Start and enable the Samba daemon:
-     </para>
-<screen>
-&prompt.cephuser.smb;sudo systemctl start smb.service
-&prompt.cephuser.smb;sudo systemctl enable smb.service
-&prompt.cephuser.smb;sudo systemctl start nmb.service
-&prompt.cephuser.smb;sudo systemctl enable nmb.service
-</screen>
-    </step>
    </procedure>
+
+  <sect3 xml:id="samba-service-restart">
+   <title>Starting &samba; Services</title>
+   <para>
+    Start or restart stand-alone &samba; services using the following
+    commands:
+   </para>
+<screen>
+&prompt.root;systemctl restart smb.service
+&prompt.root;systemctl restart nmb.service
+&prompt.root;systemctl restart winbind.service
+</screen>
+   <para>
+    To ensure that &samba; services start on boot, enable them via:
+   </para>
+<screen>
+&prompt.root;systemctl enable smb.service
+&prompt.root;systemctl enable nmb.service
+&prompt.root;systemctl enable winbind.service
+</screen>
+   <tip>
+    <title>Optional <systemitem class="daemon">nmb</systemitem> and
+    <systemitem class="daemon">winbind</systemitem> services</title>
+    <para>
+     If you do not require network share browsing, you do not need to enable
+     and start the <systemitem class="daemon">nmb</systemitem> service.
+    </para>
+    <para>
+     The <systemitem class="daemon">winbind</systemitem> service is only needed
+     when configured as an &ad; domain member. See <xref linkend="cephfs-ad"/>.
+    </para>
+   </tip>
+  </sect3>
+
   </sect2>
 
   <sect2 xml:id="sec-ses-cifs-ha">
@@ -962,26 +985,10 @@ group:  files winbind
   <sect2 xml:id="cephfs-ad-services">
    <title>Starting the Services</title>
    <para>
-    There are three services that you need to enable and start to have a fully
-    functioning Unix domain member:
-    <systemitem class="daemon">smbd</systemitem>,
-    <systemitem class="daemon">nmbd</systemitem>, and
-    <systemitem class="daemon">winbindd</systemitem>. Enable and start them by
-    using the following commands:
+    Following configuration changes, restart &samba; services as per
+    <xref linkend="samba-service-restart"/> or
+    <xref linkend="samba-ha-service-restart"/>.
    </para>
-<screen>
-&prompt.cephuser.smb;sudo systemctl enable smbd.service &amp;&amp; systemctl start smbd.service
-&prompt.cephuser.smb;sudo systemctl enable nmbd.service &amp;&amp; systemctl start nmbd.service
-&prompt.cephuser.smb;sudo systemctl enable winbindd.service &amp;&amp; systemctl start winbindd.service
-</screen>
-   <tip>
-    <title>Optional <systemitem class="daemon">nmbd</systemitem></title>
-    <para>
-     If you do not require network browsing, you do not need to enable and
-     start the <systemitem class="daemon">nmbd</systemitem> service on a Unix
-     domain member.
-    </para>
-   </tip>
   </sect2>
 
   <sect2 xml:id="cephfs-ad-testing">


### PR DESCRIPTION
This patchset attempts to address https://github.com/SUSE/doc-ses/issues/244
- Split out Samba service restart instructions for standalone and HA deployments
- Add winbind HA instructions, needed for AD membership