### PR TITLE
Update deploy_cephadm.xml

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -846,7 +846,7 @@ o- / ............................................................... [...]
      </para>
 <screen>
 &prompt.smaster;ceph-salt status
-cluster: 5 minions, 5 hosts managed by cephadm
+cluster: 5 minions, 0 hosts managed by cephadm
 config: OK
 </screen>
     </tip>


### PR DESCRIPTION
At this stage, 0 nodes are managed by cephadm as it is configured but not actually implemented yet, thus the example should reflect this. "ceph-salt status" will only show the nodes actually managed by cephadm after having executed "ceph-salt apply".