### PR TITLE
Configuration database #458

### DIFF
--- a/xml/admin_operating_monitor.xml
+++ b/xml/admin_operating_monitor.xml
@@ -1151,38 +1151,6 @@ ID  CLASS  WEIGHT   TYPE NAME              STATUS  REWEIGHT  PRI-AFF
    <xref linkend="op-mon-osd-pg"/>.
   </para>
  </sect1>
- <sect1 xml:id="monitor-adminsocket">
-  <title>Using the Admin Socket</title>
-
-  <para>
-   <remark role="fixme">Maybe give an example use case? No obvious difference to normal ceph command?!</remark>
-   The &ceph; admin socket allows you to query a daemon via a socket interface.
-   By default, &ceph; sockets reside under <filename>/var/run/ceph</filename>.
-   To access a daemon via the admin socket, log in to the host running the
-   daemon and use the following command:
-  </para>
-
-<screen>&prompt.cephuser;ceph --admin-daemon /var/run/ceph/<replaceable>socket-name</replaceable></screen>
-
-  <para>
-   To view the available admin socket commands, execute the following command:
-  </para>
-
-<screen>&prompt.cephuser;ceph --admin-daemon /var/run/ceph/<replaceable>socket-name</replaceable> help</screen>
-
-  <para>
-   The admin socket command enables you to show and set your configuration at
-   runtime. Refer to <xref linkend="ceph-config-runtime"/> for details.
-  </para>
-
-  <para>
-   Additionally, you can set configuration values at runtime directly (the
-   admin socket bypasses the monitor, unlike <command>ceph tell</command>
-   <replaceable>daemon-type</replaceable>.<replaceable>id</replaceable>
-   injectargs, which relies on the monitor but does not require you to log in
-   directly to the host in question).
-  </para>
- </sect1>
  <sect1 xml:id="storage-capacity">
   <title>Storage Capacity</title>
 

--- a/xml/runtime_config.xml
+++ b/xml/runtime_config.xml
@@ -21,7 +21,7 @@
   <title>The <filename>ceph.conf</filename> File</title>
 
   <para>
-   &cephadm; uses a minimized <filename>ceph.conf</filename> file that only
+   &cephadm; uses a basic <filename>ceph.conf</filename> file that only
    contains a minimal set of options for connecting to MONs, authenticating,
    and fetching configuration information. In most cases, this is limited to the
    <option>mon_host</option> option (although this can be avoided through the

--- a/xml/runtime_config.xml
+++ b/xml/runtime_config.xml
@@ -76,13 +76,16 @@
       only to daemons or clients running on a particular host.
      </para>
     </listitem>
-    <para>
-     <replaceable>CLASS</replaceable>:<replaceable>DEVICE_CLASS</replaceable>
-     where <replaceable>DEVICE_CLASS</replaceable> is the name of a CRUSH
-     device class such as <literal>hdd</literal> or <literal>ssd</literal>. For
-     example, <literal>class:ssd</literal> will limit the option only to OSDs
-     backed by SSDs. This mask has no effect for non-OSD daemons or clients.
-    </para>
+    <listitem>
+     <para>
+      <replaceable>CLASS</replaceable>:<replaceable>DEVICE_CLASS</replaceable>
+      where <replaceable>DEVICE_CLASS</replaceable> is the name of a CRUSH
+      device class such as <literal>hdd</literal> or <literal>ssd</literal>.
+      For example, <literal>class:ssd</literal> will limit the option only to
+      OSDs backed by SSDs. This mask has no effect for non-OSD daemons or
+      clients.
+     </para>
+    </listitem>
    </itemizedlist>
   </sect2>
 

--- a/xml/runtime_config.xml
+++ b/xml/runtime_config.xml
@@ -31,14 +31,14 @@
   <important>
    <para>
     The <filename>ceph.conf</filename> file no longer serves as a central place
-    for storing cluster configuration in favor of the configuration database
+    for storing cluster configuration, in favor of the configuration database
     (see <xref linkend="cha-ceph-configuration-db"/>).
    </para>
    <para>
     If you still need to change cluster configuration via the
-    <filename>ceph.conf</filename> file, for example, because you use a client
-    that does not support reading options form the configuration database, you
-    need to run the following command and take care of maintaining and
+    <filename>ceph.conf</filename> file&mdash;for example, because you use a client
+    that does not support reading options form the configuration database&mdash;you
+    need to run the following command, and take care of maintaining and
     distributing the <filename>ceph.conf</filename> file across the whole
     cluster:
    </para>
@@ -92,7 +92,7 @@
   <sect2 xml:id="cha-ceph-configuration-db-commands">
    <title>Setting and Reading Configuration Options</title>
    <para>
-    Use the following commands to set or read cluster configuration option. The
+    Use the following commands to set or read cluster configuration options. The
     <replaceable>WHO</replaceable> parameter may be a section name, a mask, or
     a combination of both separated by a slash (/) character. For example,
     <literal>osd/rack:foo</literal> represents all OSD daemons in the rack
@@ -131,7 +131,7 @@
       <para>
        Shows the reported running configuration for a running daemon. These
        settings may differ from those stored by the monitors if there are also
-       local configuration files in use or options have been overridden on the
+       local configuration files in use, or options have been overridden on the
        command line or at run time. The source of the option values is reported
        as part of the output.
       </para>
@@ -248,7 +248,7 @@
 <screen>&prompt.cephuser;ceph config show osd.0 debug_osd</screen>
     <para>
      You can also connect to a running daemon from the node where its process
-     is running and observe its configuration:
+     is running, and observe its configuration:
     </para>
 <screen>&prompt.cephuser;ceph daemon osd.0 config show</screen>
     <para>

--- a/xml/runtime_config.xml
+++ b/xml/runtime_config.xml
@@ -36,11 +36,11 @@
    </para>
    <para>
     If you still need to change cluster configuration via the
-    <filename>ceph.conf</filename> file&mdash;for example, because you use a client
-    that does not support reading options form the configuration database&mdash;you
-    need to run the following command, and take care of maintaining and
-    distributing the <filename>ceph.conf</filename> file across the whole
-    cluster:
+    <filename>ceph.conf</filename> file&mdash;for example, because you use a
+    client that does not support reading options form the configuration
+    database&mdash;you need to run the following command, and take care of
+    maintaining and distributing the <filename>ceph.conf</filename> file across
+    the whole cluster:
    </para>
 <screen>&prompt.cephuser;ceph config set mgr mgr/cephadm/manage_etc_ceph_ceph_conf false</screen>
   </important>
@@ -92,9 +92,9 @@
   <sect2 xml:id="cha-ceph-configuration-db-commands">
    <title>Setting and Reading Configuration Options</title>
    <para>
-    Use the following commands to set or read cluster configuration options. The
-    <replaceable>WHO</replaceable> parameter may be a section name, a mask, or
-    a combination of both separated by a slash (/) character. For example,
+    Use the following commands to set or read cluster configuration options.
+    The <replaceable>WHO</replaceable> parameter may be a section name, a mask,
+    or a combination of both separated by a slash (/) character. For example,
     <literal>osd/rack:foo</literal> represents all OSD daemons in the rack
     called <literal>foo</literal>.
    </para>
@@ -252,11 +252,11 @@
     </para>
 <screen>&prompt.cephuser;ceph daemon osd.0 config show</screen>
     <para>
-     View only non-default settings:
+     To view only non-default settings:
     </para>
 <screen>&prompt.cephuser;ceph daemon osd.0 config diff</screen>
     <para>
-     Inspect a specific option:
+     To inspect a specific option:
     </para>
 <screen>&prompt.cephuser;ceph daemon osd.0 config get debug_osd</screen>
    </sect3>

--- a/xml/runtime_config.xml
+++ b/xml/runtime_config.xml
@@ -235,7 +235,7 @@
    <sect3 xml:id="cha-ceph-configuration-db-runtime-view">
     <title>Viewing Runtime Settings</title>
     <para>
-     View all options set for a daemon:
+     To view all options set for a daemon:
     </para>
 <screen>&prompt.cephuser;ceph config show-with-defaults osd.0</screen>
     <para>

--- a/xml/runtime_config.xml
+++ b/xml/runtime_config.xml
@@ -17,7 +17,7 @@
   This chapter describes how to configure the &ceph; cluster by means of
   configuration options.
  </para>
- <sect1 xml:id="cha-ceph-configuration-ceph_conf">
+ <sect1 xml:id="cha-ceph-configuration-ceph-conf">
   <title>The <filename>ceph.conf</filename> File</title>
 
   <para>

--- a/xml/runtime_config.xml
+++ b/xml/runtime_config.xml
@@ -239,7 +239,7 @@
     </para>
 <screen>&prompt.cephuser;ceph config show-with-defaults osd.0</screen>
     <para>
-     View all non-default options set for a daemon:
+     To view all non-default options set for a daemon:
     </para>
 <screen>&prompt.cephuser;ceph config show osd.0</screen>
     <para>

--- a/xml/runtime_config.xml
+++ b/xml/runtime_config.xml
@@ -10,60 +10,153 @@
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:editurl>https://github.com/SUSE/doc-ses/edit/master/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
-   <dm:release>SES 6</dm:release>
+   <dm:release>SES 7</dm:release>
   </dm:docmanager>
  </info>
  <para>
-  This chapter provides a list of important &ceph; cluster settings and their
-  description. The settings are sorted by topic.
+  This chapter describes how to configure the &ceph; cluster by means of
+  configuration options.
  </para>
- <sect1 xml:id="ceph-config-runtime">
-  <title>Runtime Configuration</title>
+ <sect1 xml:id="cha-ceph-configuration-ceph_conf">
+  <title>The <filename>ceph.conf</filename> File</title>
 
   <para>
-   The actual cluster behavior is determined not by the current state of the
-   <filename>ceph.conf</filename> file but by the configuration of the running
-   &ceph; daemons, which is stored in memory.
+   &cephadm; uses a minimized <filename>ceph.conf</filename> file that only
+   contains a minimal set of options for connecting to MONs, authenticating,
+   and fetching configuration information. In most cases this is limited to the
+   <option>mon_host</option> option (although this can be avoided through the
+   use of DNS SRV records).
   </para>
 
-  <para>
-   You can query an individual &ceph; daemon for a particular configuration
-   setting using the <emphasis>admin socket</emphasis> on the node where the
-   daemon is running. For example, the following command gets the value of the
-   <option>osd_max_write_size</option> configuration parameter from the daemon
-   named <literal>osd.0</literal>:
-  </para>
-
-<screen>&prompt.cephuser;ceph --admin-daemon /var/run/ceph/ceph-osd.0.asok \
-config get osd_max_write_size
-{
-  "osd_max_write_size": "90"
-}</screen>
-
-  <para>
-   You can also <emphasis>change</emphasis> the daemons' settings at runtime.
-   Remember that this change is temporary and will be lost after the next
-   daemon restart. For example, the following command changes the
-   <option>osd_max_write_size</option> parameter to '50' for all OSDs in the
-   cluster:
-  </para>
-
-<screen>&prompt.cephuser;ceph tell osd.* injectargs --osd_max_write_size 50</screen>
-
-  <warning>
-   <title><command>injectargs</command> Is Not Reliable</title>
+  <important>
    <para>
-    Unfortunately, changing the cluster settings with the
-    <command>injectargs</command> command is not 100% reliable. If you need to
-    be sure that the changed parameter is active, change it in the
-    configuration files on all cluster nodes and restart all daemons in the
-    cluster.
+    The <filename>ceph.conf</filename> file no longer serves as a central place
+    for storing cluster configuration in favor of the configuration database
+    (see <xref linkend="cha-ceph-configuration-db"/>).
    </para>
-  </warning>
+   <para>
+    If you still need to change cluster configuration via the
+    <filename>ceph.conf</filename> file, for example, because you use a client
+    that does not support reading options form the configuration database, you
+    need to run the following command and take care of maintaining and
+    distributing the <filename>ceph.conf</filename> file across the whole
+    cluster:
+   </para>
+<screen>&prompt.cephuser;ceph config set mgr mgr/cephadm/manage_etc_ceph_ceph_conf false</screen>
+  </important>
+ </sect1>
+ <sect1 xml:id="cha-ceph-configuration-db">
+  <title>Configuration Database</title>
+
+  <para>
+   &mon;s manage a central database of configuration options that affect the
+   behavior of the whole cluster.
+  </para>
+
+  <sect2 xml:id="cha-ceph-configuration-db-sections">
+   <title>Sections and Masks</title>
+   <para>
+    Configuration options stored by the MON can live in a
+    <emphasis>global</emphasis> section, <emphasis>daemon type</emphasis>
+    section, or a <emphasis>specific daemon</emphasis> section. In addition,
+    options may also have a <emphasis>mask</emphasis> associated with them to
+    further restrict to which daemons or clients the option applies. Masks have
+    two forms:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+      <replaceable>TYPE</replaceable>:<replaceable>LOCATION</replaceable> where
+      <replaceable>TYPE</replaceable> is a CRUSH property such as
+      <literal>rack</literal> or <literal>host</literal>, while
+      <replaceable>LOCATION</replaceable> is a value for that property.
+     </para>
+     <para>
+      For example, <literal>host:example_host</literal> will limit the option
+      only to daemons or clients running on a particular host.
+     </para>
+    </listitem>
+    <para>
+     <replaceable>CLASS</replaceable>:<replaceable>DEVICE_CLASS</replaceable>
+     where <replaceable>DEVICE_CLASS</replaceable> is the name of a CRUSH
+     device class such as <literal>hdd</literal> or <literal>ssd</literal>. For
+     example, <literal>class:ssd</literal> will limit the option only to OSDs
+     backed by SSDs. This mask has no effect for non-OSD daemons or clients.
+    </para>
+   </itemizedlist>
+  </sect2>
+
+  <sect2 xml:id="cha-ceph-configuration-db-commands">
+   <title>Setting and Reading Configuration Options</title>
+   <para>
+    Use the following commands to set or read cluster configuration option. The
+    <replaceable>WHO</replaceable> parameter may be a section name, a mask, or
+    a combination of both separated by a slash (/) character. For example,
+    <literal>osd/rack:foo</literal> represents all OSD daemons in the rack
+    called <literal>foo</literal>.
+   </para>
+   <variablelist>
+    <varlistentry>
+     <term><command>ceph config dump</command></term>
+     <listitem>
+      <para>
+       Dumps the entire configuration database for a cluster.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><command>ceph config get <replaceable>WHO</replaceable></command></term>
+     <listitem>
+      <para>
+       Dumps the configuration for a specific daemon or client (for example,
+       <literal>mds.a</literal>), as stored in the configuration database.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><command>ceph config set <replaceable>WHO</replaceable> <replaceable>OPTION</replaceable> <replaceable>VALUE</replaceable></command></term>
+     <listitem>
+      <para>
+       Sets the configuration option to the specified value in the
+       configuration database.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><command>ceph config show <replaceable>WHO</replaceable></command></term>
+     <listitem>
+      <para>
+       Shows the reported running configuration for a running daemon. These
+       settings may differ from those stored by the monitors if there are also
+       local configuration files in use or options have been overridden on the
+       command line or at run time. The source of the option values is reported
+       as part of the output.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><command>ceph config assimilate-conf -i <replaceable>INPUT_FILE</replaceable> -o <replaceable>OUTPUT_FILE</replaceable></command></term>
+     <listitem>
+      <para>
+       Imports a configuration file specified as
+       <replaceable>INPUT_FILE</replaceable> and stores its valid options into
+       the configuration database. Any settings that are unrecognized, invalid,
+       or cannot be controlled by the monitor will be returned in an
+       abbreviated file stored as <replaceable>OUTPUT_FILE</replaceable>. This
+       command is useful for transitioning from legacy configuration files to
+       centralized monitor-based configuration.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </sect2>
+  <sect2 xml:id="cha-ceph-configuration-db-runtime">
+   <title>Run-time Changes</title>
+   <para>
+   </para>
+  </sect2>
  </sect1>
  <sect1 xml:id="config-osd-and-bluestore">
-<!-- based on http://docs.ceph.com/docs/nautilus/rados/configuration/bluestore-config-ref/#automatic-cache-sizing -->
-
   <title>&osd; and &bluestore;</title>
 
   <sect2 xml:id="config-auto-cache-sizing">
@@ -1038,20 +1131,21 @@ rgw_frontends = beast port=7480
      <varlistentry>
       <term>rgw_dns_name</term>
       <listitem>
-        <para>
-          Allows clients to use <literal>vhost</literal>-style buckets.
-        </para>
-        <para>
-          <literal>vhost</literal>-style access refers to the use of 
-          <replaceable>bucketname</replaceable>.<replaceable>s3-endpoint</replaceable>/<replaceable>object-path</replaceable>.
-          This is in comparison to  <literal>path</literal>-style access: <replaceable>s3-endpoint</replaceable>/<replaceable>bucket</replaceable>/<replaceable>object</replaceable>
-        </para>
-        <para>
-          If the parameter <literal>rgw dns name</literal> is added to
-          <filename>ceph.conf</filename>, make sure that the S3 client is
-          configured to direct requests to the endpoint specified by <literal>rgw
-          dns name</literal>.
-        </para>
+       <para>
+        Allows clients to use <literal>vhost</literal>-style buckets.
+       </para>
+       <para>
+        <literal>vhost</literal>-style access refers to the use of
+        <replaceable>bucketname</replaceable>.<replaceable>s3-endpoint</replaceable>/<replaceable>object-path</replaceable>.
+        This is in comparison to <literal>path</literal>-style access:
+        <replaceable>s3-endpoint</replaceable>/<replaceable>bucket</replaceable>/<replaceable>object</replaceable>
+       </para>
+       <para>
+        If the parameter <literal>rgw dns name</literal> is added to
+        <filename>ceph.conf</filename>, make sure that the S3 client is
+        configured to direct requests to the endpoint specified by <literal>rgw
+        dns name</literal>.
+       </para>
       </listitem>
      </varlistentry>
     </variablelist>

--- a/xml/runtime_config.xml
+++ b/xml/runtime_config.xml
@@ -150,10 +150,113 @@
     </varlistentry>
    </variablelist>
   </sect2>
+
   <sect2 xml:id="cha-ceph-configuration-db-runtime">
-   <title>Run-time Changes</title>
+   <title>Runtime Changes</title>
    <para>
+    In most cases, &ceph; allows you to make changes to the configuration of a
+    daemon at runtime. This is useful, for example, when you need to increase
+    or decrease the amount of logging output, or when performing runtime
+    cluster optimization.
    </para>
+   <para>
+    You can update the value of configuration options with the following
+    command:
+   </para>
+<screen>ceph config set <replaceable>DAEMON</replaceable> <replaceable>OPTION</replaceable> <replaceable>VALUE</replaceable></screen>
+   <para>
+    For example, to adjust the debugging log level on a specific OSD, run:
+   </para>
+<screen>&prompt.cephuser;ceph config set osd.123 debug_ms 20</screen>
+   <note>
+    <para>
+     If the same option is also customized in a local configuration file, the
+     monitor setting will be ignored because it has lower priority than the
+     configuration file.
+    </para>
+   </note>
+   <sect3 xml:id="cha-ceph-configuration-db-runtime-override">
+    <title>Overriding Values</title>
+    <para>
+     You can temporarily modify an option value using the
+     <command>tell</command> or <command>daemon</command> subcommands. Such
+     modification only affect the running process and is discarded after the
+     daemon or process restarts.
+    </para>
+    <para>
+     There are two ways to override values:
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       Use the <command>tell</command> subcommand to send a message to a
+       specific daemon from any cluster node:
+      </para>
+<screen>ceph tell <replaceable>DAEMON</replaceable> config set <replaceable>OPTION</replaceable> <replaceable>VALUE</replaceable></screen>
+      <para>
+       For example:
+      </para>
+<screen>&prompt.cephuser;ceph tell osd.123 config set debug_osd 20</screen>
+      <tip>
+       <para>
+        The <command>tell</command> subcommand accepts wildcards as daemon
+        identifiers. For example, to adjust the debug level on all OSD daemons,
+        run:
+       </para>
+<screen>&prompt.cephuser;ceph tell osd.* config set debug_osd 20</screen>
+      </tip>
+     </listitem>
+     <listitem>
+      <para>
+       Use the <command>daemon</command> subcommand to connect to a specific
+       daemon process via a socket in <filename>/var/run/ceph</filename> from
+       the node where the process is running:
+      </para>
+<screen>ceph daemon <replaceable>DAEMON</replaceable> config set <replaceable>OPTION</replaceable> <replaceable>VALUE</replaceable></screen>
+      <para>
+       For example:
+      </para>
+<screen>&prompt.cephuser;ceph daemon osd.4 config set debug_osd 20</screen>
+     </listitem>
+    </itemizedlist>
+    <tip>
+     <para>
+      When viewing runtime settings with the <command>ceph config
+      show</command> command (see
+      <xref linkend="cha-ceph-configuration-db-runtime-view"/>), temporarily
+      overridden values will be shown with a source
+      <literal>override</literal>.
+     </para>
+    </tip>
+   </sect3>
+   <sect3 xml:id="cha-ceph-configuration-db-runtime-view">
+    <title>Viewing Runtime Settings</title>
+    <para>
+     View all options set for a daemon:
+    </para>
+<screen>&prompt.cephuser;ceph config show-with-defaults osd.0</screen>
+    <para>
+     View all non-default options set for a daemon:
+    </para>
+<screen>&prompt.cephuser;ceph config show osd.0</screen>
+    <para>
+     Inspect a specific option:
+    </para>
+<screen>&prompt.cephuser;ceph config show osd.0 debug_osd</screen>
+    <para>
+     You can also connect to a running daemon from the node where its process
+     is running and observe its configuration:
+    </para>
+<screen>&prompt.cephuser;ceph daemon osd.0 config show</screen>
+    <para>
+     View only non-default settings:
+    </para>
+<screen>&prompt.cephuser;ceph daemon osd.0 config diff</screen>
+    <para>
+     Inspect a specific option:
+    </para>
+<screen>&prompt.cephuser;ceph daemon osd.0 config get debug_osd</screen>
+   </sect3>
   </sect2>
  </sect1>
  <sect1 xml:id="config-osd-and-bluestore">

--- a/xml/runtime_config.xml
+++ b/xml/runtime_config.xml
@@ -23,7 +23,7 @@
   <para>
    &cephadm; uses a minimized <filename>ceph.conf</filename> file that only
    contains a minimal set of options for connecting to MONs, authenticating,
-   and fetching configuration information. In most cases this is limited to the
+   and fetching configuration information. In most cases, this is limited to the
    <option>mon_host</option> option (although this can be avoided through the
    use of DNS SRV records).
   </para>
@@ -103,7 +103,7 @@
      <term><command>ceph config dump</command></term>
      <listitem>
       <para>
-       Dumps the entire configuration database for a cluster.
+       Dumps the entire configuration database for a whole cluster.
       </para>
      </listitem>
     </varlistentry>
@@ -142,7 +142,7 @@
      <listitem>
       <para>
        Imports a configuration file specified as
-       <replaceable>INPUT_FILE</replaceable> and stores its valid options into
+       <replaceable>INPUT_FILE</replaceable> and stores any valid options into
        the configuration database. Any settings that are unrecognized, invalid,
        or cannot be controlled by the monitor will be returned in an
        abbreviated file stored as <replaceable>OUTPUT_FILE</replaceable>. This
@@ -163,7 +163,7 @@
     cluster optimization.
    </para>
    <para>
-    You can update the value of configuration options with the following
+    You can update the values of configuration options with the following
     command:
    </para>
 <screen>ceph config set <replaceable>DAEMON</replaceable> <replaceable>OPTION</replaceable> <replaceable>VALUE</replaceable></screen>

--- a/xml/runtime_config.xml
+++ b/xml/runtime_config.xml
@@ -243,7 +243,7 @@
     </para>
 <screen>&prompt.cephuser;ceph config show osd.0</screen>
     <para>
-     Inspect a specific option:
+     To inspect a specific option:
     </para>
 <screen>&prompt.cephuser;ceph config show osd.0 debug_osd</screen>
     <para>


### PR DESCRIPTION
This PR introduces new way of setting config options via a configuration database.
Rendered PDF is attached, section 19.1. & 19.2. are affected, the rest is not relevant now
[cha-ceph-configuration_color_en.pdf](https://github.com/SUSE/doc-ses/files/5122316/cha-ceph-configuration_color_en.pdf)
