### PR TITLE
Matching disk devices with drivegroups. Closes 364.

### DIFF
--- a/xml/admin_saltcluster.xml
+++ b/xml/admin_saltcluster.xml
@@ -289,16 +289,15 @@ model: <replaceable>DISK_MODEL_STRING</replaceable>
       <para>
        By a disk vendor:
       </para>
+<screen>
+vendor: <replaceable>DISK_VENDOR_STRING</replaceable>
+</screen>
       <tip>
-       <title>Lowercase Vendor String</title>
        <para>
         Always enter the <replaceable>DISK_VENDOR_STRING</replaceable> in lower
         case.
        </para>
       </tip>
-<screen>
-vendor: <replaceable>DISK_VENDOR_STRING</replaceable>
-</screen>
       <para>
        To obtain details about disk model and vendor, examine the output of the
        following command:
@@ -306,8 +305,8 @@ vendor: <replaceable>DISK_VENDOR_STRING</replaceable>
 <screen>
 &prompt.cephuser;ceph orch device ls
 HOST     PATH     TYPE  SIZE DEVICE_ID                  MODEL            VENDOR
-ses-min1 /dev/sdb ssd  29.8G SATA_SSD_AF34075704240015  SATA SSD         ATA   
-ses-min2 /dev/sda ssd   223G Micron_5200_MTFDDAK240TDN  Micron_5200_MTFD ATA   
+ses-min1 /dev/sdb ssd  29.8G SATA_SSD_AF34075704240015  SATA SSD         ATA
+ses-min2 /dev/sda ssd   223G Micron_5200_MTFDDAK240TDN  Micron_5200_MTFD ATA
 [...]
 </screen>
      </listitem>

--- a/xml/admin_saltcluster.xml
+++ b/xml/admin_saltcluster.xml
@@ -289,9 +289,6 @@ model: <replaceable>DISK_MODEL_STRING</replaceable>
       <para>
        By a disk vendor:
       </para>
-<screen>
-vendor: <replaceable>DISK_VENDOR_STRING</replaceable>
-</screen>
       <tip>
        <title>Lowercase Vendor String</title>
        <para>
@@ -299,6 +296,20 @@ vendor: <replaceable>DISK_VENDOR_STRING</replaceable>
         case.
        </para>
       </tip>
+<screen>
+vendor: <replaceable>DISK_VENDOR_STRING</replaceable>
+</screen>
+      <para>
+       To obtain details about disk model and vendor, examine the output of the
+       following command:
+      </para>
+<screen>
+&prompt.cephuser;ceph orch device ls
+HOST     PATH     TYPE  SIZE DEVICE_ID                  MODEL            VENDOR
+ses-min1 /dev/sdb ssd  29.8G SATA_SSD_AF34075704240015  SATA SSD         ATA   
+ses-min2 /dev/sda ssd   223G Micron_5200_MTFDDAK240TDN  Micron_5200_MTFD ATA   
+[...]
+</screen>
      </listitem>
      <listitem>
       <para>
@@ -1352,7 +1363,6 @@ OSD_ID  HOST         STATE                    PG_COUNT  REPLACE  FORCE  STARTED_
    </step>
   </procedure>
  </sect1>
-
  <sect1 xml:id="ceph-cluster-purge">
   <title>Removing an Entire &ceph; Cluster</title>
 


### PR DESCRIPTION
This update adds an updated output of `ceph orch device ls` as a reference of 'MODEL' and 'VENDOR' strings
Closes #364 