### PR TITLE
Adding link to SES4Win.msi

### DIFF
--- a/xml/windows-ceph.xml
+++ b/xml/windows-ceph.xml
@@ -92,7 +92,7 @@
    <title>Installation and Configuration</title>
    <para>
      &ceph; for &mswin; can be easily installed through the <filename>ceph.msi</filename>
-     setup wizard. You can download a beta version of it from https://beta.suse.com/private/SLE15/SP2/download/SES7/ceph4win/.
+     setup wizard. You can download a beta version of it from https://beta.suse.com/private/SLE15/SP2/download/SES7/SES4Win/.
      This wizard performs the following functions:
    </para>
    <itemizedlist>

--- a/xml/windows-ceph.xml
+++ b/xml/windows-ceph.xml
@@ -92,7 +92,8 @@
    <title>Installation and Configuration</title>
    <para>
      &ceph; for &mswin; can be easily installed through the <filename>ceph.msi</filename>
-     setup wizard. This wizard performs the following functions:
+     setup wizard. You can download a beta version of it from https://beta.suse.com/private/SLE15/SP2/download/SES7/ceph4win/.
+     This wizard performs the following functions:
    </para>
    <itemizedlist>
      <listitem>


### PR DESCRIPTION
Adding https://beta.suse.com/private/SLE15/SP2/download/SES7/ceph4win/ the link where beta tester can download SES4Win.msi

BTW the entire doc use ceph.msi but the SES Team provides a SES4Win.msi. This need to be clarified.