### PR TITLE
Update name of installer (ceph.msi - SES4Win.msi)

### DIFF
--- a/xml/windows-appendix.xml
+++ b/xml/windows-appendix.xml
@@ -21,19 +21,30 @@
      <filename>C:\ProgramData\ceph\ceph.conf</filename>
    </para>
 <screen>
-[global] log to stderr = true run dir = C:/ProgramData/ceph/out crash dir = C:/ProgramData/ceph/out [client]
-keyring = C:/ProgramData/ceph/keyring log file = C:/ProgramData/ceph/out/$name.$pid.log admin
-socket = C:/ProgramData/ceph/out/$name.$pid.asok [global] ;
-pecify IP addresses for monitor nodes as in the following example: ;
-mon host = [v2:10.1.1.1:3300,v1:10.1.1.1:6789] [v2:10.1.1.2:3300,v1:10.1.1.2:6789] [v2:10.1.1.3:3300,v1:1.1.1.3:6789]
+[global]
+     log to stderr = true
+     run dir = C:/ProgramData/ceph
+     crash dir = C:/ProgramData/ceph
+[client]
+     keyring = C:/ProgramData/ceph/keyring
+     log file = C:/ProgramData/ceph/$name.$pid.log
+     admin socket = C:/ProgramData/ceph/$name.$pid.asok
+[global]
+     ; Specify IP addresses for monitor nodes as in the following example: ;
+     mon host = [v2:10.1.1.1:3300,v1:10.1.1.1:6789] [v2:10.1.1.2:3300,v1:10.1.1.2:6789] [v2:10.1.1.3:3300,v1:1.1.1.3:6789]
 </screen>
    <para>
      <filename>C:\ProgramData\ceph\ceph.client.admin.keyring</filename>
    </para>
 <screen>
 ; This file should be copied directly from /etc/ceph/ceph.client.admin.keyring
-; The contents should be similar to the following example: [client.admin] key
-= ADCyl77eBBAAABDDjX72tAljOwv04m121v/7yA== caps mds = "allow *" caps mon = "allow *" caps osd = "allow *" caps mgr = "allow *"
+; The contents should be similar to the following example:
+[client.admin]
+    key = ADCyl77eBBAAABDDjX72tAljOwv04m121v/7yA==
+    caps mds = "allow *"
+    caps mon = "allow *"
+    caps osd = "allow *"
+    caps mgr = "allow *"
 </screen>
  </sect1>
  <sect1 xml:id="windows-appendix-b">

--- a/xml/windows-ceph.xml
+++ b/xml/windows-ceph.xml
@@ -91,7 +91,7 @@
  <section xml:id="install-config">
    <title>Installation and Configuration</title>
    <para>
-     &ceph; for &mswin; can be easily installed through the <filename>ceph.msi</filename>
+     &ceph; for &mswin; can be easily installed through the <filename>SES4Win.msi</filename>
      setup wizard. You can download a beta version of it from https://beta.suse.com/private/SLE15/SP2/download/SES7/SES4Win/.
      This wizard performs the following functions:
    </para>


### PR DESCRIPTION
Also, remove the 'out' directory from samples conf files, to simplify installs for customers.

Signed-off-by: Mike Latimer <mlatimer@suse.com>