### PR TITLE
Bootstrap minion no longer required to have admin role

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -509,20 +509,6 @@ Value set.
 &prompt.smaster;ceph-salt config /ceph_cluster/roles/bootstrap ls
 o- bootstrap ..................................... [ses-min1.example.com]
 </screen>
-    <important>
-     <para>
-      The minion that will bootstrap the cluster needs to have the admin
-      keyring as well:
-     </para>
-<screen>
-&prompt.smaster;ceph-salt config /ceph_cluster/roles/admin add ses-min1.example.com
-1 minion added.
-&prompt.smaster;ceph-salt config /ceph_cluster/roles/admin ls
-o- admin ................................................... [Minions: 2]
-  o- ses-master.example.com ............................ [Other roles: cephadm]
-  o- ses-min1.example.com ...................... [Other roles: cephadm, bootstrap]
-</screen>
-    </important>
    </sect3>
    <sect3 xml:id="deploy-cephadm-configure-ssh">
     <title>Generate SSH Key Pair</title>


### PR DESCRIPTION
If https://github.com/ceph/ceph-salt/pull/383 is merged, bootstrap minion will no longer be required to have the admin role.

Signed-off-by: Ricardo Marques <rimarques@suse.com>