### PR TITLE
admin_nfsganesha.xml: update to replace usage of `showmount`

### DIFF
--- a/xml/admin_nfsganesha.xml
+++ b/xml/admin_nfsganesha.xml
@@ -567,8 +567,8 @@ EXPORT {
   <title>Verifying the Exported NFS Share</title>
 
   <para>
-   NFS v4 will build a list of exports at the root of a pseudo filesystem.
-   You can verify the NFS shares are exported by mounting
+   NFS v4 will build a list of exports at the root of a pseudo file system.
+   You can verify that the NFS shares are exported by mounting
    <filename>/</filename> of the &ganesha; server node:
   </para>
 
@@ -580,9 +580,9 @@ cephfs rgw</screen>
   <note>
    <title>&ganesha; is v4 Only</title>
    <para>
-    By default, <literal>cephadm</literal> will configure an NFS v4 server.
+    By default, &cephadm; will configure an NFS v4 server.
     NFS v4 does not interact with <literal>rpcbind</literal> nor the
-    <literal>mountd daemon</literal>. NFS client tools such as
+    <literal>mountd</literal> daemon. NFS client tools such as
     <command>showmount</command> will not show any configured exports.
    </para>
  </note>

--- a/xml/admin_nfsganesha.xml
+++ b/xml/admin_nfsganesha.xml
@@ -567,12 +567,26 @@ EXPORT {
   <title>Verifying the Exported NFS Share</title>
 
   <para>
-   When using NFS v3, you can verify whether the NFS shares are exported on the
-   &ganesha; server node:
+   NFS v4 will build a list of exports at the root of a pseudo filesystem.
+   You can verify the NFS shares are exported by mounting
+   <filename>/</filename> of the &ganesha; server node:
   </para>
 
-<screen>&prompt.sminion;<command>showmount</command> -e
-/ (everything)</screen>
+<screen>&prompt.root;<command>mount</command> -t nfs -o rw,noatime,sync \
+ <replaceable>nfs_ganesha_server_hostname:/ /path/to/local/mountpoint</replaceable>
+&prompt.root;<command>ls</command> <replaceable>/path/to/local/mountpoint</replaceable>
+cephfs rgw</screen>
+
+  <note>
+   <title>&ganesha; is v4 Only</title>
+   <para>
+    By default, <literal>cephadm</literal> will configure an NFS v4 server.
+    NFS v4 does not interact with <literal>rpcbind</literal> nor the
+    <literal>mountd daemon</literal>. NFS client tools such as
+    <command>showmount</command> will not show any configured exports.
+   </para>
+ </note>
+
  </sect1>
  <sect1 xml:id="ceph-nfsganesha-mount">
   <title>Mounting the Exported NFS Share</title>


### PR DESCRIPTION
NFSv4 does not advertise exports via rpcbind/mountd. Instead these can
be enumerated by a client from the root of the pseudo NFSv4 filesystem

Signed-off-by: Michael Fritch <mfritch@suse.com>