### PR TITLE
admin_saltcluster.xml: fix "encryption:" tag

### DIFF
--- a/xml/admin_saltcluster.xml
+++ b/xml/admin_saltcluster.xml
@@ -268,7 +268,7 @@ wal_devices:
 block_wal_size: '5G'  # (optional, unit suffixes permitted)
 block_db_size: '5G'   # (optional, unit suffixes permitted)
 <!-- osds_per_device: 1   # number of osd daemons per device -->
-encryption:           # 'True' or 'False' (defaults to 'False')
+encrypted:           # 'True' or 'False' (defaults to 'False')
 </screen>
    </sect3>
    <sect3>
@@ -964,7 +964,7 @@ placement:
   host_pattern: '*'
 data_devices:
   model: SSD-123-foo
-encryption: True
+encrypted: True
 </screen>
      <para>
       One HDD will remain as the file is being parsed from top to bottom.


### PR DESCRIPTION
"encryption:" tag in DriveGroups definition is wrong. "encrypted:" is correct.