### PR TITLE
admin_nfsganesha.xml: `roles` -> `clusters`

### DIFF
--- a/xml/admin_nfsganesha.xml
+++ b/xml/admin_nfsganesha.xml
@@ -430,28 +430,27 @@ EXPORT {
   </sect2>
  </sect1>
  <sect1 xml:id="ceph-nfsganesha-customrole">
-  <title>Custom &ganesha; Roles</title>
+  <title>Multiple &ganesha; Clusters</title>
 
   <para>
-   Custom &ganesha; roles for cluster nodes can be defined. The roles
-   allow for:
+   Multiple &ganesha; clusters can be defined. This allows for:
   </para>
 
   <itemizedlist>
    <listitem>
     <para>
-     Separated &ganesha; nodes for accessing &ogw; and &cephfs;.
+     Separated &ganesha; clusters for accessing &ogw; and &cephfs;.
     </para>
    </listitem>
    <listitem>
     <para>
-     Assigning different &ogw; users to &ganesha; nodes.
+     Assigning different &ogw; users to &ganesha; clusters.
     </para>
    </listitem>
   </itemizedlist>
 
   <para>
-   Having different &ogw; users enables &ganesha; nodes to access different S3
+   Having different &ogw; users enables &ganesha; clusters to access different S3
    buckets. S3 buckets can be used for access control. Note: S3 buckets are not
    to be confused with &ceph; buckets used in the &crushmap;.
   </para>

--- a/xml/admin_nfsganesha.xml
+++ b/xml/admin_nfsganesha.xml
@@ -485,7 +485,7 @@ EXPORT {
       <emphasis>Only full, sequential write I/O is supported.</emphasis>
       All write operations should be treated as an upload. Many typical I/O
       operations, such as editing files in place, will fail because they
-      perform non-sequential stores. There are file utilities that preform
+      perform non-sequential stores. There are file utilities that perform
       writes sequentially (for example, some versions of GNU
       <command>tar</command>), but may fail because of infrequent
       non-sequential stores. When mounting via NFS, an application's sequential

--- a/xml/admin_nfsganesha.xml
+++ b/xml/admin_nfsganesha.xml
@@ -456,7 +456,7 @@ EXPORT {
   </para>
 
   <sect2 xml:id="ganesha-rgw-supported-operations">
-   <title>Supported Operations</title>
+   <title>Supported &ogw; Operations</title>
    <para>
     The RGW NFS interface supports most operations on files and directories,
     with the following restrictions:
@@ -483,10 +483,10 @@ EXPORT {
     <listitem>
      <para>
       <emphasis>Only full, sequential write I/O is supported.</emphasis>
-      Therefore, write operations are forced to be uploads. Many typical I/O
-      operations, such as editing files in place, will necessarily fail as they
-      perform non-sequential stores. There are file utilities that apparently
-      write sequentially (for example, some versions of GNU
+      All write operations should be treated as an upload. Many typical I/O
+      operations, such as editing files in place, will fail because they
+      perform non-sequential stores. There are file utilities that preform
+      writes sequentially (for example, some versions of GNU
       <command>tar</command>), but may fail because of infrequent
       non-sequential stores. When mounting via NFS, an application's sequential
       I/O can generally be forced to perform sequential writes to the NFS


### PR DESCRIPTION
DeepSea had the concept of `roles` to configure each ganesha daemon
according to pre-defined templates

Multiple cephadm NFS clusters should be be created as a replacement.

```
$ ceph orch apply nfs foo --pool nfs-ganesha --namespace foo
$ ceph orch apply nfs bar --pool nfs-ganesha --namespace bar
$ ceph orch apply nfs baz --pool nfs-ganesha --namespace baz
```

Signed-off-by: Michael Fritch <mfritch@suse.com>