### PR TITLE
Update admin_ceph_cephfs.xml

### DIFF
--- a/xml/admin_ceph_cephfs.xml
+++ b/xml/admin_ceph_cephfs.xml
@@ -34,8 +34,8 @@
   <sect2 xml:id="cephfs-client-preparation">
    <title>Client Preparation</title>
    <para>
-    If the client host is running &sle; 12 SP2 or SP3, you can skip this
-    section as the system is ready to mount &cephfs; 'out of the box'.
+    If the client host is running &sle; 12 SP2 or later, the system is ready to
+    mount &cephfs; 'out of the box'.
    </para>
    <para>
     If the client host is running &sle; 12 SP1, you need to apply all the
@@ -485,7 +485,8 @@ setfattr -n ceph.dir.pin -v 0 a/b # "a/b" is now pinned to rank 0
        Linux kernel clients 4.17 and higher support &cephfs; quotas on
        &productname; &productnumber; clusters. Kernel clients (even recent
        versions) will fail to handle quotas on older clusters, even if they are
-       able to set the quotas extended attributes.
+       able to set the quotas extended attributes.  SLE12-SP3 (and later)
+       kernels already include the required backports to handle quotas.
       </para>
      </listitem>
     </varlistentry>
@@ -606,13 +607,16 @@ setfattr -n ceph.dir.pin -v 0 a/b # "a/b" is now pinned to rank 0
     After you enable snapshots, all directories in the &cephfs; will have a
     special <filename>.snap</filename> subdirectory.
    </para>
-   <para>
-    &cephfs; kernel clients have a limitation: they cannot handle more than 400
-    snapshots in a directory tree. The number of snapshots should always be
-    kept below this limit, regardless of which client you are using. If using
-    older &cephfs; clients, such as SLE12-SP3, keep in mind that going above
-    400 snapshots is harmful to operations as the client will crash.
-   </para>
+   <important>
+    <title>Kernel clients limitation</title>
+    <para>
+     &cephfs; kernel clients have a limitation: they cannot handle more than 400
+     snapshots in a filesystem. The number of snapshots should always be
+     kept below this limit, regardless of which client you are using. If using
+     older &cephfs; clients, such as SLE12-SP3, keep in mind that going above
+     400 snapshots is harmful to operations as the client will crash.
+    </para>
+   </important>
    <tip>
     <title>Custom Snapshot Subdirectory Name</title>
     <para>


### PR DESCRIPTION
A few documentation suggestions:

- "13.1.1 Client Preparation": there was no mention to SLE15* clients, so just
  use 'or later' instead of enumerating every single release.

- "13.6.1 Limitations": mention that SLE12-SP3 already has the required
  backports to handle cephfs quotas

- "13.7.1 Creating Snapshots": the kernel clients limitation to 400 snapshots is
  per-filesystem.  Also promoted this info to an 'important' box.