### PR TITLE
rename `registry.suse.de` -> `registry.suse.com`

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -300,8 +300,8 @@ drwx------ 9 root root 4.0K Sep 8 03:23 ..
            Confirm the &ganesha; daemon is running on the host:
          </para>
 <screen>&prompt.cephuser;ceph orch ps --daemon_type nfs
-NAME           HOST   STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                                                            IMAGE ID      CONTAINER ID
-nfs.foo.node2  node2  running (26m)  8m ago     27m  3.3      registry.suse.de/devel/storage/7.0/containers/ses/7/ceph/ceph:latest  8b4be7c42abd  c8b75d7c8f0d</screen>
+NAME           HOST   STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                                IMAGE ID      CONTAINER ID
+nfs.foo.node2  node2  running (26m)  8m ago     27m  3.3      registry.suse.com/ses/7/ceph/ceph:latest  8b4be7c42abd  c8b75d7c8f0d</screen>
        </step>
      </procedure>
      <para>


### PR DESCRIPTION
NFS example in admin guide should reference `registry.suse.com` instead
of `registry.suse.de`

Signed-off-by: Michael Fritch <mfritch@suse.com>