### PR TITLE
keep image link consistent is update section

### DIFF
--- a/xml/admin_saltcluster.xml
+++ b/xml/admin_saltcluster.xml
@@ -1254,7 +1254,7 @@ OSD_ID  HOST         STATE                    PG_COUNT  REPLACE  FORCE  STARTED_
 <screen>&prompt.cephuser;ceph -s
 [...]
   progress:
-    Upgrade to docker.io/ceph/ceph:v15.2.1 (00h 20m 12s)
+    Upgrade to registry.suse.com/ses/7/ceph/ceph:latest (00h 20m 12s)
       [=======.....................] (time remaining: 01h 43m 31s)</screen>
    <para>
     You can also watch the &cephadm; log:


### PR DESCRIPTION
In the `ceph orch upgrade start` example we use a suse link. Lets use the same link in the status example.