### PR TITLE
helm3 install should be run from a node with access to k8s

### DIFF
--- a/xml/deploy_caasp.xml
+++ b/xml/deploy_caasp.xml
@@ -100,7 +100,7 @@
      </step>
      <step>
        <para>
-         On the master node, execute the following:
+         On a node with access to the Kubernetes cluster, execute the following:
        </para>
 <screen>&prompt.user;export HELM_EXPERIMENTAL_OCI=1</screen>
      </step>

--- a/xml/deploy_caasp.xml
+++ b/xml/deploy_caasp.xml
@@ -100,7 +100,7 @@
      </step>
      <step>
        <para>
-         On a node with access to the Kubernetes cluster, execute the following:
+         On a node with access to the &kube; cluster, execute the following:
        </para>
 <screen>&prompt.user;export HELM_EXPERIMENTAL_OCI=1</screen>
      </step>


### PR DESCRIPTION
(e.g. a client configured with a kubeconfig file)

```
export KUBECONFIG=<path to the kubeconfig file>
```

Signed-off-by: Michael Fritch <mfritch@suse.com>