### PR TITLE
Proposing removal of cepham prompt to ceph

### DIFF
--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -2,7 +2,7 @@
 <!--                   SES/Ceph related                            -->
 <!-- ============================================================= -->
 
-<!ENTITY cephuser.plain 'cephadm'>
+<!ENTITY cephuser.plain 'ceph'>
 <!ENTITY cephuser       '<systemitem class="username" xmlns="http://docbook.org/ns/docbook">&cephuser.plain;</systemitem>'>
 <!ENTITY prompt.cephuser "<prompt xmlns='http://docbook.org/ns/docbook'>&cephuser.plain;@adm &gt; </prompt>">
 <!ENTITY prompt.kubeuser "<prompt xmlns='http://docbook.org/ns/docbook'>kubectl@adm &gt; </prompt>">

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -2,7 +2,7 @@
 <!--                   SES/Ceph related                            -->
 <!-- ============================================================= -->
 
-<!ENTITY cephuser.plain 'ceph'>
+<!ENTITY cephuser.plain 'cephuser'>
 <!ENTITY cephuser       '<systemitem class="username" xmlns="http://docbook.org/ns/docbook">&cephuser.plain;</systemitem>'>
 <!ENTITY prompt.cephuser "<prompt xmlns='http://docbook.org/ns/docbook'>&cephuser.plain;@adm &gt; </prompt>">
 <!ENTITY prompt.kubeuser "<prompt xmlns='http://docbook.org/ns/docbook'>kubectl@adm &gt; </prompt>">


### PR DESCRIPTION
We currently use the ceph-salt tool (meaning the commands are `ceph-salt BLAH` to deploy our Ceph cluster instead of the upstream `cephadm bootstrap`. I propose removing the mention of cephadm in the entities in favor of simply using `cephuser`. The `cephadm` command is used a total of once in the deployment guide, and I believe this is misleading. We don't want customers to confuse the options, and think they can operate the SES cluster with Ceph commands. If you use the upstream commands, you will get an upstream container instead, and the cluster will be unsupported.