### PR TITLE
RBD mirror prompts fixed, minor fixes to text done (#677)

### DIFF
--- a/xml/admin_rbd.xml
+++ b/xml/admin_rbd.xml
@@ -947,56 +947,75 @@ data blocks changed from 2097152 to 2560000</screen>
        peer bootstrap create</command> command, a pool name, along with an optional
        friendly site name to describe the <literal>local</literal> cluster:
      </para>
-<screen>&prompt.cephuser;rbd mirror pool peer bootstrap create [--site-name <replaceable>LOCAL_SITE_NAME</replaceable>] <replaceable>POOL_NAME</replaceable></screen>
+<screen>&prompt.cephuser.local;rbd mirror pool peer bootstrap create \
+ [--site-name <replaceable>LOCAL_SITE_NAME</replaceable>] <replaceable>POOL_NAME</replaceable></screen>
      <para>
        The output of <command>mirror pool peer bootstrap create</command> will be a token that
        should be provided to the <command>mirror pool peer bootstrap import</command> command.
-       For example, on <literal>local</literal>:
+       For example, on the <literal>local</literal> cluster:
      </para>
-<screen>&prompt.cephuser;rbd --cluster local mirror pool peer bootstrap create --site-name local image-pool
+<screen>&prompt.cephuser.local;rbd --cluster local mirror pool peer bootstrap create --site-name local image-pool
 eyJmc2lkIjoiOWY1MjgyZGItYjg5OS00NTk2LTgwOTgtMzIwYzFmYzM5NmYzIiwiY2xpZW50X2lkIjoicmJkLW1pcnJvci1wZWVyIiwia2V5I \
 joiQVFBUnczOWQwdkhvQmhBQVlMM1I4RmR5dHNJQU50bkFTZ0lOTVE9PSIsIm1vbl9ob3N0IjoiW3YyOjE5Mi4xNjguMS4zOjY4MjAsdjE6MTkyLjE2OC4xLjM6NjgyMV0ifQ==</screen>
      <para>
        To manually import the bootstrap token created by another cluster with the
-       <command>rbd</command> command, specify the following:
+       <command>rbd</command> command, use the following syntax:
      </para>
-     <itemizedlist>
-       <listitem>
-         <para>
-           <command>mirror pool peer bootstrap import</command>
-         </para>
-       </listitem>
-       <listitem>
-         <para>
-           The pool name
-         </para>
-       </listitem>
-       <listitem>
-         <para>
-           A file path to the created token (or <literal>-</literal> to read it from the standard input)
-         </para>
-       </listitem>
-       <listitem>
-         <para>
-           An optional friendly site name to describe the <literal>local</literal> cluster
-         </para>
-       </listitem>
-       <listitem>
-         <para>
-           A mirroring direction (defaults to <literal>rx-tx</literal> for
-           bidirectional mirroring, but can also be set to <literal>rx-only</literal>
-           for unidirectional mirroring)
-         </para>
-       </listitem>
-     </itemizedlist>
-<screen>&prompt.cephuser;rbd mirror pool peer bootstrap import [--site-name {local-site-name}] [--direction {rx-only or rx-tx}] {pool-name} {token-path}</screen>
+<screen>
+rbd mirror pool peer bootstrap import \
+ [--site-name <replaceable>LOCAL_SITE_NAME</replaceable>] \
+ [--direction <replaceable>DIRECTION</replaceable> \
+ <replaceable>POOL_NAME</replaceable> <replaceable>TOKEN_PATH</replaceable>
+</screen>
      <para>
-       For example, on <literal>remote</literal>:
+      Where:
      </para>
-<screen>&prompt.cephuser;cat &lt;&lt;EOF &gt; token
+     <variablelist>
+      <varlistentry>
+       <term><replaceable>LOCAL_SITE_NAME</replaceable></term>
+       <listitem>
+        <para>
+         An optional friendly site name to describe the
+         <literal>local</literal> cluster.
+        </para>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><replaceable>DIRECTION</replaceable></term>
+       <listitem>
+        <para>
+         A mirroring direction. Defaults to <literal>rx-tx</literal> for
+         bidirectional mirroring, but can also be set to
+         <literal>rx-only</literal> for unidirectional mirroring.
+        </para>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><replaceable>POOL_NAME</replaceable></term>
+       <listitem>
+        <para>
+         Name of the pool.
+        </para>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><replaceable>TOKEN_PATH</replaceable></term>
+       <listitem>
+        <para>
+         A file path to the created token (or <literal>-</literal> to read it
+         from the standard input).
+        </para>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     <para>
+       For example, on the <literal>remote</literal> cluster:
+     </para>
+<screen>&prompt.cephuser.remote;cat &lt;&lt;EOF &gt; token
 eyJmc2lkIjoiOWY1MjgyZGItYjg5OS00NTk2LTgwOTgtMzIwYzFmYzM5NmYzIiwiY2xpZW50X2lkIjoicmJkLW1pcnJvci1wZWVyIiwia2V5IjoiQVFBUnczOWQwdkhvQmhBQVlMM1I4RmR5dHNJQU50bkFTZ0lOTVE9PSIsIm1vbl9ob3N0IjoiW3YyOjE5Mi4xNjguMS4zOjY4MjAsdjE6MTkyLjE2OC4xLjM6NjgyMV0ifQ==
 EOF</screen>
-<screen>&prompt.cephuser;rbd --cluster remote mirror pool peer bootstrap import --site-name remote image-pool token</screen>
+<screen>&prompt.cephuser;rbd --cluster remote mirror pool peer bootstrap import \
+ --site-name remote image-pool token</screen>
    </sect3>
 
    <sect3>
@@ -1007,8 +1026,10 @@ EOF</screen>
      mirroring peer cluster, specify the <command>mirror pool peer
      add</command> subcommand, the pool name, and a cluster specification:
     </para>
-<screen>&prompt.cephuser;rbd --cluster local mirror pool peer add <replaceable>POOL_NAME</replaceable> client.remote@remote
-&prompt.cephuser;rbd --cluster remote mirror pool peer add <replaceable>POOL_NAME</replaceable> client.local@local</screen>
+<screen>
+&prompt.cephuser;rbd --cluster local mirror pool peer add <replaceable>POOL_NAME</replaceable> client.remote@remote
+&prompt.cephuser;rbd --cluster remote mirror pool peer add <replaceable>POOL_NAME</replaceable> client.local@local
+</screen>
    </sect3>
    <sect3>
     <title>Remove Cluster Peer</title>
@@ -1017,10 +1038,12 @@ EOF</screen>
      remove</command> subcommand, the pool name, and the peer UUID (available
      from the <command>rbd mirror pool info</command> command):
     </para>
-<screen>&prompt.cephuser;rbd --cluster local mirror pool peer remove <replaceable>POOL_NAME</replaceable> \
+<screen>
+&prompt.cephuser;rbd --cluster local mirror pool peer remove <replaceable>POOL_NAME</replaceable> \
  55672766-c02b-4729-8567-f13a66893445
 &prompt.cephuser;rbd --cluster remote mirror pool peer remove <replaceable>POOL_NAME</replaceable> \
- 60c0e299-b38f-4234-91f6-eed0a367be08</screen>
+ 60c0e299-b38f-4234-91f6-eed0a367be08
+</screen>
    </sect3>
    <sect3>
      <title>Data Pools</title>
@@ -1077,7 +1100,8 @@ EOF</screen>
      mirroring for a specific image with <command>rbd</command>, specify the <command>mirror image
      enable</command> subcommand along with the pool and image name:
     </para>
-<screen>&prompt.cephuser;rbd --cluster local mirror image enable <replaceable>POOL_NAME</replaceable>/<replaceable>IMAGE_NAME</replaceable></screen>
+<screen>&prompt.cephuser;rbd --cluster local mirror image enable \
+ <replaceable>POOL_NAME</replaceable>/<replaceable>IMAGE_NAME</replaceable></screen>
     <para>
       The mirror image mode can either be <literal>journal</literal> or <literal>snapshot</literal>:
     </para>
@@ -1130,7 +1154,8 @@ EOF</screen>
      <command>feature enable</command> subcommand, the pool and image name, and
      the feature name:
     </para>
-<screen>&prompt.cephuser;rbd --cluster local feature enable <replaceable>POOL_NAME</replaceable>/<replaceable>IMAGE_NAME</replaceable> journaling</screen>
+<screen>&prompt.cephuser;rbd --cluster local feature enable \
+ <replaceable>POOL_NAME</replaceable>/<replaceable>IMAGE_NAME</replaceable> journaling</screen>
     <note>
      <title>Option Dependency</title>
      <para>
@@ -1328,7 +1353,7 @@ SCHEDULE TIME       IMAGE
     </para>
     <important>
       <para>
-        Each <command>rbd-mirror</command> daemon requires the ability to connect
+        Each <systemitem class="daemon">rbd-mirror</systemitem> daemon requires the ability to connect
         to both clusters simultaneously.
       </para>
     </important>
@@ -1342,7 +1367,7 @@ SCHEDULE TIME       IMAGE
       The <systemitem class="daemon">rbd-mirror</systemitem> daemon can be managed by &systemd; by
       specifying the user ID as the daemon instance. To identify the
       unique FSID of the cluster, run <command>ceph fsid</command>. To identify
-      the &ogw; daemon name, run <command>ceph orch ps ---hostname <replaceable>HOSTNAME</replaceable></command>.
+      the <systemitem class="daemon">rbd-mirror</systemitem> daemon name, run <command>ceph orch ps ---hostname <replaceable>HOSTNAME</replaceable></command>.
     </para>
 <screen>&prompt.sminion;systemctl enable ceph-<replaceable>FSID</replaceable>@<replaceable>DAEMON_NAME</replaceable></screen>
     <para>
@@ -1373,8 +1398,7 @@ SCHEDULE TIME       IMAGE
 <screen>&prompt.cephuser;ceph config set client rbd_cache true</screen>
 
   <para>
-   to the <literal>[client]</literal> section of your
-   <filename>ceph.conf</filename> file. By default,
+   By default,
    <systemitem>librbd</systemitem> does not perform any caching. Writes and
    reads go directly to the storage cluster, and writes return only when the
    data is on disk on all replicas. With caching enabled, writes return

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -5,6 +5,10 @@
 <!ENTITY cephuser.plain 'cephuser'>
 <!ENTITY cephuser       '<systemitem class="username" xmlns="http://docbook.org/ns/docbook">&cephuser.plain;</systemitem>'>
 <!ENTITY prompt.cephuser "<prompt xmlns='http://docbook.org/ns/docbook'>&cephuser.plain;@adm &gt; </prompt>">
+<!ENTITY prompt.cephuser.primary "<prompt xmlns='http://docbook.org/ns/docbook'>&cephuser.plain;@primary &gt; </prompt>">
+<!ENTITY prompt.cephuser.secondary "<prompt xmlns='http://docbook.org/ns/docbook'>&cephuser.plain;@secondary &gt; </prompt>">
+<!ENTITY prompt.cephuser.local "<prompt xmlns='http://docbook.org/ns/docbook'>&cephuser.plain;@local &gt; </prompt>">
+<!ENTITY prompt.cephuser.remote "<prompt xmlns='http://docbook.org/ns/docbook'>&cephuser.plain;@remote &gt; </prompt>">
 <!ENTITY prompt.kubeuser "<prompt xmlns='http://docbook.org/ns/docbook'>kubectl@adm &gt; </prompt>">
 <!ENTITY prompt.cephuser.mon "<prompt xmlns='http://docbook.org/ns/docbook'>&cephuser.plain;@mon &gt; </prompt>">
 <!ENTITY prompt.cephuser.osd "<prompt xmlns='http://docbook.org/ns/docbook'>&cephuser.plain;@osd &gt; </prompt>">


### PR DESCRIPTION
Replaced neutral prompts with '@local', '@remote' suffixes for RBD mirroring content.
@trociny @denisok if you find another occurrence worth updating, make a list and let me know please

closes #677 