### PR TITLE
Add para/remark elements to avoid future problems

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -609,14 +609,17 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
 
   <sect2 xml:id="upgrade-mds">
    <title>Upgrade the &mds;</title>
+   <para><remark>TBD</remark></para>
   </sect2>
 
   <sect2 xml:id="upgrade-igw">
    <title>Upgrade the &igw;</title>
+   <para><remark>TBD</remark></para>
   </sect2>
 
   <sect2 xml:id="upgrade-ogw">
    <title>Upgrade the &ogw;</title>
+   <para><remark>TBD</remark></para>
   </sect2>
 
   <sect2 xml:id="upgrade-ganesha">

--- a/xml/manager_modules.xml
+++ b/xml/manager_modules.xml
@@ -250,8 +250,8 @@
     <para>
      To add a contact and description to the report:
     </para>
-<screen>&prompt.cephuser;ceph config set mgr mgr/telemetry/contact ‘John Doe <literal>john.doe@example.com</literal>’
-&prompt.cephuser;ceph config set mgr mgr/telemetry/description ‘My first Ceph cluster’</screen>
+<screen>&prompt.cephuser;ceph config set mgr mgr/telemetry/contact John Doe john.doe@example.com
+&prompt.cephuser;ceph config set mgr mgr/telemetry/description 'My first Ceph cluster'</screen>
    </step>
    <step>
     <para>

--- a/xml/troubleshooting_caasp_debugging_rook.xml
+++ b/xml/troubleshooting_caasp_debugging_rook.xml
@@ -101,5 +101,6 @@
  </sect1>
  <sect1 xml:id="debugging-rook-methods">
    <title>Debugging Rook</title>
+   <para><remark>TBD</remark></para>
  </sect1>
 </chapter>


### PR DESCRIPTION
This PR contains the following change:

It was an oversight to allow "empty" sections in GeekoDoc. To avoid validation issues in the future, this commit introduces
para/remark lines.

Also remove literal in screen as it is useless. ;)