### PR TITLE
Convert RST Manpages into DocBook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+manpages/
 *.bak
 *.swp
 *.*~

--- a/DC-ses-man
+++ b/DC-ses-man
@@ -1,0 +1,22 @@
+## --------------------------------------------------------
+## Doc Config File for SES
+## Manpages
+## --------------------------------------------------------
+##
+## Basics
+# DC-ses-manpages
+MAIN="art-storage-man.xml"
+
+## Profiling
+PROFOS="sles"
+
+## stylesheet location
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+
+### Sort the glossary
+XSLTPARAM="--param glossary.sort=1"
+
+#XSLTPARAM="--param hyphenate.verbatim 0"
+
+##do not show remarks directly in the (PDF) text
+#XSLTPARAM="--param use.xep.annotate.pdf 0"

--- a/convert-manpages.sh
+++ b/convert-manpages.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+#
+# Purpose:
+#   Convert manpages from upstream source
+#
+# First source: https://github.com/ceph/ceph/blob/octopus/doc/man/8/ceph-volume.rst
+#
+# Second source: https://github.com/nfs-ganesha/nfs-ganesha/tree/V3.3/src/doc/man
+#  (all of theseeee)
+#
+# Author: Tom Schraitle
+# Date:  October 2020
+
+ME=${0##*/}
+THISDIR=${0%/*}
+
+# Sources of manpages in RST format to convert to DocBook5:
+GITHUB_URL="https://github.com/nfs-ganesha/nfs-ganesha.git"
+ADDITIONAL_URL="https://github.com/ceph/ceph/raw/octopus/doc/man/8/ceph-volume.rst"
+
+# Template directory, used by mktemp
+TEMPDIR_PATH="/tmp/nfs-ganesha-XXXXX"
+
+# Real directory, filled after calling mktemp or passing it through -g/--gitdir option:
+TEMPDIR=""
+
+# Relative source path from the cloned GitHub repo:
+SRC_MANPAGE_DIR="src/doc/man"
+
+# Relative destination path to write all results:
+DEST_MANPAGE_DIR="manpages"
+
+# Helper stylesheet to fine-tune raw XML from pandoc:
+XSLT="xslt/fix-manpages.xsl"
+
+# Verbosity level:
+VERBOSE=0
+
+function exit_on_error {
+    echo -e "ERROR: $1" >&2
+    exit 1;
+}
+
+function dump {
+    if [[ "$VERBOSE" -ne 0 ]]; then
+        echo "$1"
+    fi
+    # echo "$1" 2>&1
+}
+
+function usage {
+    cat <<EOF_helptext
+Usage: $ME [OPTIONS] OUTPUTDIR
+
+Converts RST manpages into DocBook5 files. These sources are investigated:
+
+* $GITHUB_URL
+* $ADDITIONAL_URL
+
+The script does the following steps:
+
+  1. Check if all necessary programs are installed. If not, show help text.
+  2. Clone the repository (or use the directory from last run).
+  3. Download additional manpages.
+  4. Remove any ":orphan:" lines from RST (this complicates the conversion process).
+  5. Convert RST to DocBook5 with pandoc.
+  6. Fix the raw XML file from pandoc, write it to result directory.
+
+Done! :)
+
+Options:
+  -h, --help     Shows this help text
+  -v, -verbose   Makes output more verbose
+  -g, --gitdir   Use cloned GH directory from previous run
+
+Arguments:
+  OUTPUTDIR      Directory where result is written (use "manpages")
+
+Author: Thomas Schraitle, October 2020
+EOF_helptext
+}
+
+function prerequisites() {
+    # Check assumptions
+    #
+    local PROGRAMS="git pandoc xsltproc"
+    dump " Checking if $PROGRAMS are available."
+    for prog in $PROGRAMS; do
+        which $prog 2>&1
+        [[ 0 -ne $? ]] && exit_on_error "Program $prog not found. Try 'cnf $prog' and install the package."
+    done
+}
+
+function clone-repo() {
+    # Clone the GitHub repo into a temporary path
+    #
+    TEMPDIR=$(mktemp --directory ${TEMPDIR_PATH})
+    dump "  Clone GitHub repo and download additional RST file"
+    git clone $GITHUB_URL $TEMPDIR
+    wget --directory-prefix=$TEMPDIR/$SRC_MANPAGE_DIR $ADDITIONAL_URL
+}
+
+function rm-orphan-line() {
+    # Remove .. orphan in first line
+    # Synopsis:
+    #   rm-orphan-line FILE
+    #
+    local FILE="$1"
+    dump "  Remove any :orphan: lines"
+    sed -i 's/:orphan://g' ${FILE}
+}
+
+function add-ns() {
+    # Add XLink namespace into first root element
+    # Synopsis:
+    #  add-ns FILE
+    #
+    local FILE="$1"
+    dump "  Add XLink namespace"
+    sed -i 's#<section #<section xmlns:xlink="http://www.w3.org/1999/xlink" #' ${FILE}
+}
+
+function convert-to-docbook5() {
+    # Convert a single RST file into DocBook5
+    # Synopsis:
+    #   convert-to-docbook5 INPUT_RST OUTPUT_XML
+    #
+    # Requisite: No :orphan: is available in RST
+    local FILE="$1"
+    local BASE="${1##*/}"
+    local DIR="${1}"
+    local OUTDIR="${2}"
+    local OUT="$OUTDIR/${BASE%*.rst}.xml"
+    dump "  Convert RST into DocBook"
+    pandoc --from=rst --to=docbook5 ${FILE} -o ${OUT}
+}
+
+function fix-manpage() {
+    # Fix issue after converting with pandoc
+    # Synopsis:
+    #  fix-manpage XML_FROM_RST  OUTPUTDIR
+    #
+    local FILE="$1"
+    local BASE="${1##*/}"
+    local DIR="${1}"
+    local OUTDIR="${2}"
+    local OUTFILE="$OUTDIR/$BASE"
+    dump "  Fix raw DocBook document from pandoc..."
+    xsltproc -o "$OUTFILE" "$THISDIR/$XSLT" "$FILE"
+}
+
+export POSIXLY_CORRECT=1
+ARGS=$(getopt -o "hvg:" -l "help,verbose,gitdir:" -n "$ME" -- "$@")
+
+eval set -- "$ARGS"
+
+while true; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 1
+            ;;
+        -v|--verbose)
+            VERBOSE=1
+            shift
+            ;;
+        -g|--gitdir)
+            TEMPDIR="$2"
+            shift 2
+            ;;
+        --)
+            shift
+            break;;
+        *) exit_on_error "Internal error!" ;;
+    esac
+done
+
+unset POSIXLY_CORRECT
+
+## Check for errors
+if [[ $# -eq 0 ]]; then
+    usage
+    exit 1
+fi
+
+
+[[ -d $THISDIR/$DEST_MANPAGE_DIR ]] || mkdir $THISDIR/$DEST_MANPAGE_DIR
+
+prerequisites
+
+if [[ -e "$TEMPDIR" ]]; then
+    dump "* Using $TEMPDIR from previous run."
+else
+    dump "* Cloning GitHub reposity..."
+    clone-repo
+fi
+
+dump "* Looking into $TEMPDIR/$SRC_MANPAGE_DIR for RST files..."
+for file in $TEMPDIR/$SRC_MANPAGE_DIR/*.rst; do
+  dump "- $file"
+  rm-orphan-line $file
+  convert-to-docbook5 $file $TEMPDIR/$SRC_MANPAGE_DIR || exit_on_error "Problems with RST -> DB conversion with $file"
+  add-ns "${file%*.rst}.xml"
+  fix-manpage "${file%*.rst}.xml" $THISDIR/$DEST_MANPAGE_DIR
+done
+
+echo "Done"
+echo "Find your results in '$DEST_MANPAGE_DIR'"

--- a/xml/art-storage-man.xml
+++ b/xml/art-storage-man.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+<?provo dirname="storage/"?>
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en" xml:id="book-storage-man">
+ <info>
+  <title>manpages</title><productname>&productname;</productname><productname role="abbrev">SES</productname>
+  <productnumber>&productnumber;</productnumber>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:editurl>https://github.com/SUSE/doc-ses/edit/master/xml/</dm:editurl>
+   <dm:translation>no</dm:translation>
+   <dm:release>SES 7</dm:release>
+  </dm:docmanager>
+</info>
+  <xi:include href="ceph-volume.xml"/>
+  <xi:include href="ganesha-rgw-config.xml"/>
+  <xi:include href="ganesha-rados-grace.xml"/>
+  <xi:include href="ganesha-rados-cluster-design.xml"/>
+  <xi:include href="ganesha-log-config.xml"/>
+  <xi:include href="ganesha-export-config.xml"/>
+  <xi:include href="ganesha-core-config.xml"/>
+  <xi:include href="ganesha-config.xml"/>
+  <xi:include href="ganesha-ceph-config.xml"/>
+  <xi:include href="ganesha-cache-config.xml"/>
+</article>

--- a/xml/ceph-volume.xml
+++ b/xml/ceph-volume.xml
@@ -1,0 +1,660 @@
+<?xml version="1.0"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ceph-volume----ceph-osd-deployment-and-inspection-tool">
+  <title>ceph-volume -- Ceph OSD deployment and inspection tool</title>
+  <para>
+    ceph-volume
+  </para>
+  <section xml:id="synopsis">
+    <title>Synopsis</title>
+<screen><emphasis role="strong">ceph-volume</emphasis> [-h] [--cluster CLUSTER] [--log-level LOG_LEVEL]
+                [--log-path LOG_PATH]</screen>
+    <para>
+      <emphasis role="strong">ceph-volume</emphasis>
+      <emphasis role="strong">inventory</emphasis>
+    </para>
+<screen><emphasis role="strong">ceph-volume</emphasis> <emphasis role="strong">lvm</emphasis> [ <emphasis>trigger</emphasis> | <emphasis>create</emphasis> | <emphasis>activate</emphasis> | <emphasis>prepare</emphasis>
+<emphasis>zap</emphasis> | <emphasis>list</emphasis> | <emphasis>batch</emphasis>]</screen>
+    <para>
+      <emphasis role="strong">ceph-volume</emphasis>
+      <emphasis role="strong">simple</emphasis> [
+      <emphasis>trigger</emphasis> | <emphasis>scan</emphasis> |
+      <emphasis>activate</emphasis> ]
+    </para>
+  </section>
+  <section xml:id="description">
+    <title>Description</title>
+    <para>
+      <literal>ceph-volume</literal> is a single purpose command line
+      tool to deploy logical volumes as OSDs, trying to maintain a
+      similar API to <literal>ceph-disk</literal> when preparing,
+      activating, and creating OSDs.
+    </para>
+    <para>
+      It deviates from <literal>ceph-disk</literal> by not interacting
+      or relying on the udev rules that come installed for Ceph. These
+      rules allow automatic detection of previously setup devices that
+      are in turn fed into <literal>ceph-disk</literal> to activate
+      them.
+    </para>
+  </section>
+  <section xml:id="commands">
+    <title>Commands</title>
+    <section xml:id="inventory">
+      <title>inventory</title>
+      <para>
+        This subcommand provides information about a host's physical
+        disc inventory and reports metadata about these discs. Among
+        this metadata one can find disc specific data items (like model,
+        size, rotational or solid state) as well as data items specific
+        to ceph using a device, such as if it is available for use with
+        ceph or if logical volumes are present.
+      </para>
+      <para>
+        Examples:
+      </para>
+      <programlisting>
+ceph-volume inventory
+ceph-volume inventory /dev/sda
+ceph-volume inventory --format json-pretty
+</programlisting>
+      <para>
+        Optional arguments:
+      </para>
+      <itemizedlist>
+        <listitem>
+          <para>
+            [-h, --help] show the help message and exit
+          </para>
+        </listitem>
+        <listitem>
+          <variablelist>
+            <varlistentry>
+              <term>
+                [--format] report format, valid values are
+                <literal>plain</literal> (default),
+              </term>
+              <listitem>
+                <para>
+                  <literal>json</literal> and
+                  <literal>json-pretty</literal>
+                </para>
+              </listitem>
+            </varlistentry>
+          </variablelist>
+        </listitem>
+      </itemizedlist>
+    </section>
+    <section xml:id="lvm">
+      <title>lvm</title>
+      <para>
+        By making use of LVM tags, the <literal>lvm</literal>
+        sub-command is able to store and later re-discover and query
+        devices associated with OSDs so that they can later activated.
+      </para>
+      <para>
+        Subcommands:
+      </para>
+      <para>
+        <emphasis role="strong">batch</emphasis> Creates OSDs from a
+        list of devices using a <literal>filestore</literal> or
+        <literal>bluestore</literal> (default) setup. It will create all
+        necessary volume groups and logical volumes required to have a
+        working OSD.
+      </para>
+      <para>
+        Example usage with three devices:
+      </para>
+      <programlisting>
+ceph-volume lvm batch --bluestore /dev/sda /dev/sdb /dev/sdc
+</programlisting>
+      <para>
+        Optional arguments:
+      </para>
+      <itemizedlist spacing="compact">
+        <listitem>
+          <para>
+            [-h, --help] show the help message and exit
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--bluestore] Use the bluestore objectstore (default)
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--filestore] Use the filestore objectstore
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--yes] Skip the report and prompt to continue provisioning
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--prepare] Only prepare OSDs, do not activate
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--dmcrypt] Enable encryption for the underlying OSD devices
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--crush-device-class] Define a CRUSH device class to assign
+            the OSD to
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--no-systemd] Do not enable or create any systemd units
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--osds-per-device] Provision more than 1 (the default) OSD
+            per device
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--report] Report what the potential outcome would be for
+            the current input (requires devices to be passed in)
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--format] Output format when reporting (used along with
+            --report), can be one of 'pretty' (default) or 'json'
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--block-db-size] Set (or override) the
+            "bluestore_block_db_size" value, in bytes
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--journal-size] Override the "osd_journal_size"
+            value, in megabytes
+          </para>
+        </listitem>
+      </itemizedlist>
+      <para>
+        Required positional arguments:
+      </para>
+      <itemizedlist>
+        <listitem>
+          <variablelist>
+            <varlistentry>
+              <term>
+                &lt;DEVICE&gt; Full path to a raw device, like
+                <literal>/dev/sda</literal>. Multiple
+              </term>
+              <listitem>
+                <para>
+                  <literal>&lt;DEVICE&gt;</literal> paths can be passed
+                  in.
+                </para>
+              </listitem>
+            </varlistentry>
+          </variablelist>
+        </listitem>
+      </itemizedlist>
+      <para>
+        <emphasis role="strong">activate</emphasis> Enables a systemd
+        unit that persists the OSD ID and its UUID (also called
+        <literal>fsid</literal> in Ceph CLI tools), so that at boot time
+        it can understand what OSD is enabled and needs to be mounted.
+      </para>
+      <para>
+        Usage:
+      </para>
+      <programlisting>
+ceph-volume lvm activate --bluestore &lt;osd id&gt; &lt;osd fsid&gt;
+</programlisting>
+      <para>
+        Optional Arguments:
+      </para>
+      <itemizedlist spacing="compact">
+        <listitem>
+          <para>
+            [-h, --help] show the help message and exit
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--auto-detect-objectstore] Automatically detect the
+            objectstore by inspecting the OSD
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--bluestore] bluestore objectstore (default)
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--filestore] filestore objectstore
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--all] Activate all OSDs found in the system
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--no-systemd] Skip creating and enabling systemd units and
+            starting of OSD services
+          </para>
+        </listitem>
+      </itemizedlist>
+      <para>
+        Multiple OSDs can be activated at once by using the (idempotent)
+        <literal>--all</literal> flag:
+      </para>
+      <programlisting>
+ceph-volume lvm activate --all
+</programlisting>
+      <para>
+        <emphasis role="strong">prepare</emphasis> Prepares a logical
+        volume to be used as an OSD and journal using a
+        <literal>filestore</literal> or <literal>bluestore</literal>
+        (default) setup. It will not create or modify the logical
+        volumes except for adding extra metadata.
+      </para>
+      <para>
+        Usage:
+      </para>
+      <programlisting>
+ceph-volume lvm prepare --filestore --data &lt;data lv&gt; --journal &lt;journal device&gt;
+</programlisting>
+      <para>
+        Optional arguments:
+      </para>
+      <itemizedlist spacing="compact">
+        <listitem>
+          <para>
+            [-h, --help] show the help message and exit
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--journal JOURNAL] A logical group name, path to a logical
+            volume, or path to a device
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--bluestore] Use the bluestore objectstore (default)
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--block.wal] Path to a bluestore block.wal logical volume
+            or partition
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--block.db] Path to a bluestore block.db logical volume or
+            partition
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--filestore] Use the filestore objectstore
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--dmcrypt] Enable encryption for the underlying OSD devices
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--osd-id OSD_ID] Reuse an existing OSD id
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--osd-fsid OSD_FSID] Reuse an existing OSD fsid
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--crush-device-class] Define a CRUSH device class to assign
+            the OSD to
+          </para>
+        </listitem>
+      </itemizedlist>
+      <para>
+        Required arguments:
+      </para>
+      <itemizedlist spacing="compact">
+        <listitem>
+          <para>
+            --data A logical group name or a path to a logical volume
+          </para>
+        </listitem>
+      </itemizedlist>
+      <para>
+        For encrypting an OSD, the <literal>--dmcrypt</literal> flag
+        must be added when preparing (also supported in the
+        <literal>create</literal> sub-command).
+      </para>
+      <para>
+        <emphasis role="strong">create</emphasis> Wraps the two-step
+        process to provision a new osd (calling
+        <literal>prepare</literal> first and then
+        <literal>activate</literal>) into a single one. The reason to
+        prefer <literal>prepare</literal> and then
+        <literal>activate</literal> is to gradually introduce new OSDs
+        into a cluster, and avoiding large amounts of data being
+        rebalanced.
+      </para>
+      <para>
+        The single-call process unifies exactly what
+        <literal>prepare</literal> and <literal>activate</literal> do,
+        with the convenience of doing it all at once. Flags and general
+        usage are equivalent to those of the <literal>prepare</literal>
+        and <literal>activate</literal> subcommand.
+      </para>
+      <para>
+        <emphasis role="strong">trigger</emphasis> This subcommand is
+        not meant to be used directly, and it is used by systemd so that
+        it proxies input to <literal>ceph-volume lvm activate</literal>
+        by parsing the input from systemd, detecting the UUID and ID
+        associated with an OSD.
+      </para>
+      <para>
+        Usage:
+      </para>
+      <programlisting>
+ceph-volume lvm trigger &lt;SYSTEMD-DATA&gt;
+</programlisting>
+      <para>
+        The systemd "data" is expected to be in the format of:
+      </para>
+      <programlisting>
+&lt;OSD ID&gt;-&lt;OSD UUID&gt;
+</programlisting>
+      <para>
+        The lvs associated with the OSD need to have been prepared
+        previously, so that all needed tags and metadata exist.
+      </para>
+      <para>
+        Positional arguments:
+      </para>
+      <itemizedlist spacing="compact">
+        <listitem>
+          <para>
+            &lt;SYSTEMD_DATA&gt; Data from a systemd unit containing ID
+            and UUID of the OSD.
+          </para>
+        </listitem>
+      </itemizedlist>
+      <para>
+        <emphasis role="strong">list</emphasis> List devices or logical
+        volumes associated with Ceph. An association is determined if a
+        device has information relating to an OSD. This is verified by
+        querying LVM's metadata and correlating it with devices.
+      </para>
+      <para>
+        The lvs associated with the OSD need to have been prepared
+        previously by ceph-volume so that all needed tags and metadata
+        exist.
+      </para>
+      <para>
+        Usage:
+      </para>
+      <programlisting>
+ceph-volume lvm list
+</programlisting>
+      <para>
+        List a particular device, reporting all metadata about it:
+      </para>
+      <programlisting>
+ceph-volume lvm list /dev/sda1
+</programlisting>
+      <para>
+        List a logical volume, along with all its metadata (vg is a
+        volume group, and lv the logical volume name):
+      </para>
+      <programlisting>
+ceph-volume lvm list {vg/lv}
+</programlisting>
+      <para>
+        Positional arguments:
+      </para>
+      <itemizedlist spacing="compact">
+        <listitem>
+          <para>
+            &lt;DEVICE&gt; Either in the form of
+            <literal>vg/lv</literal> for logical volumes,
+            <literal>/path/to/sda1</literal> or
+            <literal>/path/to/sda</literal> for regular devices.
+          </para>
+        </listitem>
+      </itemizedlist>
+      <para>
+        <emphasis role="strong">zap</emphasis> Zaps the given logical
+        volume or partition. If given a path to a logical volume it must
+        be in the format of vg/lv. Any file systems present on the given
+        lv or partition will be removed and all data will be purged.
+      </para>
+      <para>
+        However, the lv or partition will be kept intact.
+      </para>
+      <para>
+        Usage, for logical volumes:
+      </para>
+      <programlisting>
+ceph-volume lvm zap {vg/lv}
+</programlisting>
+      <para>
+        Usage, for logical partitions:
+      </para>
+      <programlisting>
+ceph-volume lvm zap /dev/sdc1
+</programlisting>
+      <para>
+        For full removal of the device use the
+        <literal>--destroy</literal> flag (allowed for all device
+        types):
+      </para>
+      <programlisting>
+ceph-volume lvm zap --destroy /dev/sdc1
+</programlisting>
+      <para>
+        Multiple devices can be removed by specifying the OSD ID and/or
+        the OSD FSID:
+      </para>
+      <programlisting>
+ceph-volume lvm zap --destroy --osd-id 1
+ceph-volume lvm zap --destroy --osd-id 1 --osd-fsid C9605912-8395-4D76-AFC0-7DFDAC315D59
+</programlisting>
+      <para>
+        Positional arguments:
+      </para>
+      <itemizedlist spacing="compact">
+        <listitem>
+          <para>
+            &lt;DEVICE&gt; Either in the form of
+            <literal>vg/lv</literal> for logical volumes,
+            <literal>/path/to/sda1</literal> or
+            <literal>/path/to/sda</literal> for regular devices.
+          </para>
+        </listitem>
+      </itemizedlist>
+    </section>
+    <section xml:id="simple">
+      <title>simple</title>
+      <para>
+        Scan legacy OSD directories or data devices that may have been
+        created by ceph-disk, or manually.
+      </para>
+      <para>
+        Subcommands:
+      </para>
+      <para>
+        <emphasis role="strong">activate</emphasis> Enables a systemd
+        unit that persists the OSD ID and its UUID (also called
+        <literal>fsid</literal> in Ceph CLI tools), so that at boot time
+        it can understand what OSD is enabled and needs to be mounted,
+        while reading information that was previously created and
+        persisted at <literal>/etc/ceph/osd/</literal> in JSON format.
+      </para>
+      <para>
+        Usage:
+      </para>
+      <programlisting>
+ceph-volume simple activate --bluestore &lt;osd id&gt; &lt;osd fsid&gt;
+</programlisting>
+      <para>
+        Optional Arguments:
+      </para>
+      <itemizedlist spacing="compact">
+        <listitem>
+          <para>
+            [-h, --help] show the help message and exit
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--bluestore] bluestore objectstore (default)
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--filestore] filestore objectstore
+          </para>
+        </listitem>
+      </itemizedlist>
+      <para>
+        Note: It requires a matching JSON file with the following
+        format:
+      </para>
+      <programlisting>
+/etc/ceph/osd/&lt;osd id&gt;-&lt;osd fsid&gt;.json
+</programlisting>
+      <para>
+        <emphasis role="strong">scan</emphasis> Scan a running OSD or
+        data device for an OSD for metadata that can later be used to
+        activate and manage the OSD with ceph-volume. The scan method
+        will create a JSON file with the required information plus
+        anything found in the OSD directory as well.
+      </para>
+      <para>
+        Optionally, the JSON blob can be sent to stdout for further
+        inspection.
+      </para>
+      <para>
+        Usage on all running OSDs:
+      </para>
+      <programlisting>
+ceph-volume simple scan
+</programlisting>
+      <para>
+        Usage on data devices:
+      </para>
+      <programlisting>
+ceph-volume simple scan &lt;data device&gt;
+</programlisting>
+      <para>
+        Running OSD directories:
+      </para>
+      <programlisting>
+ceph-volume simple scan &lt;path to osd dir&gt;
+</programlisting>
+      <para>
+        Optional arguments:
+      </para>
+      <itemizedlist spacing="compact">
+        <listitem>
+          <para>
+            [-h, --help] show the help message and exit
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--stdout] Send the JSON blob to stdout
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            [--force] If the JSON file exists at destination, overwrite
+            it
+          </para>
+        </listitem>
+      </itemizedlist>
+      <para>
+        Optional Positional arguments:
+      </para>
+      <itemizedlist spacing="compact">
+        <listitem>
+          <para>
+            &lt;DATA DEVICE or OSD DIR&gt; Actual data partition or a
+            path to the running OSD
+          </para>
+        </listitem>
+      </itemizedlist>
+      <para>
+        <emphasis role="strong">trigger</emphasis> This subcommand is
+        not meant to be used directly, and it is used by systemd so that
+        it proxies input to
+        <literal>ceph-volume simple activate</literal> by parsing the
+        input from systemd, detecting the UUID and ID associated with an
+        OSD.
+      </para>
+      <para>
+        Usage:
+      </para>
+      <programlisting>
+ceph-volume simple trigger &lt;SYSTEMD-DATA&gt;
+</programlisting>
+      <para>
+        The systemd "data" is expected to be in the format of:
+      </para>
+      <programlisting>
+&lt;OSD ID&gt;-&lt;OSD UUID&gt;
+</programlisting>
+      <para>
+        The JSON file associated with the OSD need to have been
+        persisted previously by a scan (or manually), so that all needed
+        metadata can be used.
+      </para>
+      <para>
+        Positional arguments:
+      </para>
+      <itemizedlist spacing="compact">
+        <listitem>
+          <para>
+            &lt;SYSTEMD_DATA&gt; Data from a systemd unit containing ID
+            and UUID of the OSD.
+          </para>
+        </listitem>
+      </itemizedlist>
+    </section>
+  </section>
+  <section xml:id="availability">
+    <title>Availability</title>
+    <para>
+      <literal>ceph-volume</literal> is part of Ceph, a massively
+      scalable, open-source, distributed storage system. Please refer to
+      the documentation at
+      <link xlink:href="http://docs.ceph.com/">http://docs.ceph.com/</link>
+      for more information.
+    </para>
+  </section>
+  <section xml:id="see-also">
+    <title>See also</title>
+    <para>
+      <literal>ceph-osd &lt;ceph-osd&gt;</literal>(8),
+    </para>
+  </section>
+</section>

--- a/xml/ceph-volume.xml
+++ b/xml/ceph-volume.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
-<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ceph-volume----ceph-osd-deployment-and-inspection-tool">
+<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" xml:id="man-ceph-volume-ceph-volume----ceph-osd-deployment-and-inspection-tool">
   <title>ceph-volume -- Ceph OSD deployment and inspection tool</title>
   <para>
     ceph-volume
   </para>
-  <section xml:id="synopsis">
+  <sect2 xml:id="man-ceph-volume-synopsis">
     <title>Synopsis</title>
 <screen><emphasis role="strong">ceph-volume</emphasis> [-h] [--cluster CLUSTER] [--log-level LOG_LEVEL]
                 [--log-path LOG_PATH]</screen>
@@ -20,8 +20,8 @@
       <emphasis>trigger</emphasis> | <emphasis>scan</emphasis> |
       <emphasis>activate</emphasis> ]
     </para>
-  </section>
-  <section xml:id="description">
+  </sect2>
+  <sect2 xml:id="man-ceph-volume-description">
     <title>Description</title>
     <para>
       <literal>ceph-volume</literal> is a single purpose command line
@@ -36,10 +36,10 @@
       are in turn fed into <literal>ceph-disk</literal> to activate
       them.
     </para>
-  </section>
-  <section xml:id="commands">
+  </sect2>
+  <sect2 xml:id="man-ceph-volume-commands">
     <title>Commands</title>
-    <section xml:id="inventory">
+    <sect3 xml:id="man-ceph-volume-inventory">
       <title>inventory</title>
       <para>
         This subcommand provides information about a host's physical
@@ -83,8 +83,8 @@ ceph-volume inventory --format json-pretty
           </variablelist>
         </listitem>
       </itemizedlist>
-    </section>
-    <section xml:id="lvm">
+    </sect3>
+    <sect3 xml:id="man-ceph-volume-lvm">
       <title>lvm</title>
       <para>
         By making use of LVM tags, the <literal>lvm</literal>
@@ -491,8 +491,8 @@ ceph-volume lvm zap --destroy --osd-id 1 --osd-fsid C9605912-8395-4D76-AFC0-7DFD
           </para>
         </listitem>
       </itemizedlist>
-    </section>
-    <section xml:id="simple">
+    </sect3>
+    <sect3 xml:id="man-ceph-volume-simple">
       <title>simple</title>
       <para>
         Scan legacy OSD directories or data devices that may have been
@@ -639,9 +639,9 @@ ceph-volume simple trigger &lt;SYSTEMD-DATA&gt;
           </para>
         </listitem>
       </itemizedlist>
-    </section>
-  </section>
-  <section xml:id="availability">
+    </sect3>
+  </sect2>
+  <sect2 xml:id="man-ceph-volume-availability">
     <title>Availability</title>
     <para>
       <literal>ceph-volume</literal> is part of Ceph, a massively
@@ -650,11 +650,11 @@ ceph-volume simple trigger &lt;SYSTEMD-DATA&gt;
       <link xlink:href="http://docs.ceph.com/">http://docs.ceph.com/</link>
       for more information.
     </para>
-  </section>
-  <section xml:id="see-also">
+  </sect2>
+  <sect2 xml:id="man-ceph-volume-see-also">
     <title>See also</title>
     <para>
       <literal>ceph-osd &lt;ceph-osd&gt;</literal>(8),
     </para>
-  </section>
-</section>
+  </sect2>
+</sect1>

--- a/xml/ganesha-cache-config.xml
+++ b/xml/ganesha-cache-config.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0"?>
-<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-cache-config----nfs-ganesha-cache-configuration-file">
+<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" xml:id="man-ganesha-cache-config-ganesha-cache-config----nfs-ganesha-cache-configuration-file">
   <title>ganesha-cache-config -- NFS Ganesha Cache Configuration
   File</title>
   <para>
     ganesha-cache-config
   </para>
-  <section xml:id="synopsis">
+  <sect2 xml:id="man-ganesha-cache-config-synopsis">
     <title>SYNOPSIS</title>
     <para>
       /etc/ganesha/ganesha.conf
     </para>
-  </section>
-  <section xml:id="description">
+  </sect2>
+  <sect2 xml:id="man-ganesha-cache-config-description">
     <title>DESCRIPTION</title>
     <para>
       NFS-Ganesha reads the configuration data from: |
@@ -23,7 +23,7 @@
       used in that block, but it is deprecated and will go away. The
       MDCACHE block takes precidence over the CACHEINODE block.
     </para>
-    <section xml:id="mdcache">
+    <sect3 xml:id="man-ganesha-cache-config-mdcache">
       <title>MDCACHE {}</title>
       <variablelist>
         <varlistentry>
@@ -232,12 +232,12 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-  </section>
-  <section xml:id="see-also">
+    </sect3>
+  </sect2>
+  <sect2 xml:id="man-ganesha-cache-config-see-also">
     <title>See also</title>
     <para>
       <literal>ganesha-config &lt;ganesha-config&gt;</literal>(8)
     </para>
-  </section>
-</section>
+  </sect2>
+</sect1>

--- a/xml/ganesha-cache-config.xml
+++ b/xml/ganesha-cache-config.xml
@@ -1,0 +1,243 @@
+<?xml version="1.0"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-cache-config----nfs-ganesha-cache-configuration-file">
+  <title>ganesha-cache-config -- NFS Ganesha Cache Configuration
+  File</title>
+  <para>
+    ganesha-cache-config
+  </para>
+  <section xml:id="synopsis">
+    <title>SYNOPSIS</title>
+    <para>
+      /etc/ganesha/ganesha.conf
+    </para>
+  </section>
+  <section xml:id="description">
+    <title>DESCRIPTION</title>
+    <para>
+      NFS-Ganesha reads the configuration data from: |
+      /etc/ganesha/ganesha.conf
+    </para>
+    <para>
+      This file lists NFS-Ganesha Cache config options. These options
+      used to be configured in the CACHEINODE block. They may still be
+      used in that block, but it is deprecated and will go away. The
+      MDCACHE block takes precidence over the CACHEINODE block.
+    </para>
+    <section xml:id="mdcache">
+      <title>MDCACHE {}</title>
+      <variablelist>
+        <varlistentry>
+          <term>
+            NParts (uint32, range 1 to 32633, default 7)
+          </term>
+          <listitem>
+            <para>
+              Partitions in the Cache_Inode tree.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Cache_Size(uint32, range 1 to UINT32_MAX, default 32633)
+          </term>
+          <listitem>
+            <para>
+              Per-partition hash table size.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Use_Getattr_Directory_Invalidation(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Use getattr for directory invalidation.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Dir_Chunk(uint32, range 0 to UINT32_MAX, default 128)
+          </term>
+          <listitem>
+            <para>
+              Size of per-directory dirent cache chunks, 0 means
+              directory chunking is not enabled.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Detached_Mult(uint32, range 1 to UINT32_MAX, default 1)
+          </term>
+          <listitem>
+            <para>
+              Max number of detached directory entries expressed as a
+              multiple of the chunk size.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Entries_HWMark(uint32, range 1 to UINT32_MAX, default
+            100000)
+          </term>
+          <listitem>
+            <para>
+              The point at which object cache entries will start being
+              reused.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Entries_Release_Size(uint32, range 0 to UINT32_MAX, default
+            100)
+          </term>
+          <listitem>
+            <para>
+              The number of entries attempted to release each time when
+              the handle cache has exceeded the entries high water mark.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Chunks_HWMark(uint32, range 1 to UINT32_MAX, default 100000)
+          </term>
+          <listitem>
+            <para>
+              The point at which dirent cache chunks will start being
+              reused.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            LRU_Run_Interval(uint32, range 1 to 24 * 3600, default 90)
+          </term>
+          <listitem>
+            <para>
+              Base interval in seconds between runs of the LRU cleaner
+              thread.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            FD_Limit_Percent(uint32, range 0 to 100, default 99)
+          </term>
+          <listitem>
+            <para>
+              The percentage of the system-imposed maximum of file
+              descriptors at which Ganesha will deny requests.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            FD_HWMark_Percent(uint32, range 0 to 100, default 90)
+          </term>
+          <listitem>
+            <para>
+              The percentage of the system-imposed maximum of file
+              descriptors above which Ganesha will make greater efforts
+              at reaping.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            FD_LWMark_Percent(uint32, range 0 to 100, default 50)
+          </term>
+          <listitem>
+            <para>
+              The percentage of the system-imposed maximum of file
+              descriptors below which Ganesha will not reap file
+              descriptors.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Reaper_Work(uint32, range 1 to 2000, default 0)
+          </term>
+          <listitem>
+            <para>
+              Roughly, the amount of work to do on each pass through the
+              thread under normal conditions. (Ideally, a multiple of
+              the number of lanes.) <emphasis>This setting is
+              deprecated. Please use Reaper_Work_Per_Lane</emphasis>
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Reaper_Work_Per_Lane(uint32, range 1 to UINT32_MAX, default
+            50)
+          </term>
+          <listitem>
+            <para>
+              This is the numer of handles per lane to scan when
+              performing LRU maintenance. This task is performed by the
+              Reaper thread.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Biggest_Window(uint32, range 1 to 100, default 40)
+          </term>
+          <listitem>
+            <para>
+              The largest window (as a percentage of the system-imposed
+              limit on FDs) of work that we will do in extremis.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Required_Progress(uint32, range 1 to 50, default 5)
+          </term>
+          <listitem>
+            <para>
+              Percentage of progress toward the high water mark required
+              in in a pass through the thread when in extremis
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Futility_Count(uint32, range 1 to 50, default 8)
+          </term>
+          <listitem>
+            <para>
+              Number of failures to approach the high watermark before
+              we disable caching, when in extremis.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Dirmap_HWMark(uint32, range 1 to UINT32_MAX, default 10000)
+          </term>
+          <listitem>
+            <para>
+              The point at which dirmap entries are reused. This puts a
+              practical limit on the number of simultaneous readdirs
+              that may be in progress on an export for a whence-is-name
+              FSAL (currently only FSAL_RGW)
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+  </section>
+  <section xml:id="see-also">
+    <title>See also</title>
+    <para>
+      <literal>ganesha-config &lt;ganesha-config&gt;</literal>(8)
+    </para>
+  </section>
+</section>

--- a/xml/ganesha-ceph-config.xml
+++ b/xml/ganesha-ceph-config.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0"?>
-<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-ceph-config----nfs-ganesha-ceph-configuration-file">
+<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" xml:id="man-ganesha-ceph-config-ganesha-ceph-config----nfs-ganesha-ceph-configuration-file">
   <title>ganesha-ceph-config -- NFS Ganesha CEPH Configuration
   File</title>
   <para>
     ganesha-ceph-config
   </para>
-  <section xml:id="synopsis">
+  <sect2 xml:id="man-ganesha-ceph-config-synopsis">
     <title>SYNOPSIS</title>
     <para>
       /etc/ganesha/ceph.conf
     </para>
-  </section>
-  <section xml:id="description">
+  </sect2>
+  <sect2 xml:id="man-ganesha-ceph-config-description">
     <title>DESCRIPTION</title>
     <para>
       NFS-Ganesha install config example for CEPH FSAL: |
@@ -20,7 +20,7 @@
     <para>
       This file lists CEPH specific config options.
     </para>
-    <section xml:id="export-fsal">
+    <sect3 xml:id="man-ganesha-ceph-config-export-fsal">
       <title>EXPORT { FSAL {} }</title>
       <variablelist>
         <varlistentry>
@@ -72,8 +72,8 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-    <section xml:id="ceph">
+    </sect3>
+    <sect3 xml:id="man-ganesha-ceph-config-ceph">
       <title>CEPH {}</title>
       <para>
         <emphasis role="strong">Ceph_Conf(path, default
@@ -83,9 +83,9 @@
         <emphasis role="strong">umask(mode, range 0 to 0777, default
         0)</emphasis>
       </para>
-    </section>
-  </section>
-  <section xml:id="see-also">
+    </sect3>
+  </sect2>
+  <sect2 xml:id="man-ganesha-ceph-config-see-also">
     <title>See also</title>
     <para>
       <literal>ganesha-config &lt;ganesha-config&gt;</literal>(8)
@@ -93,5 +93,5 @@
       <literal>ganesha-core-config &lt;ganesha-core-config&gt;</literal>(8)
       <literal>ganesha-export-config &lt;ganesha-export-config&gt;</literal>(8)
     </para>
-  </section>
-</section>
+  </sect2>
+</sect1>

--- a/xml/ganesha-ceph-config.xml
+++ b/xml/ganesha-ceph-config.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-ceph-config----nfs-ganesha-ceph-configuration-file">
+  <title>ganesha-ceph-config -- NFS Ganesha CEPH Configuration
+  File</title>
+  <para>
+    ganesha-ceph-config
+  </para>
+  <section xml:id="synopsis">
+    <title>SYNOPSIS</title>
+    <para>
+      /etc/ganesha/ceph.conf
+    </para>
+  </section>
+  <section xml:id="description">
+    <title>DESCRIPTION</title>
+    <para>
+      NFS-Ganesha install config example for CEPH FSAL: |
+      /etc/ganesha/ceph.conf
+    </para>
+    <para>
+      This file lists CEPH specific config options.
+    </para>
+    <section xml:id="export-fsal">
+      <title>EXPORT { FSAL {} }</title>
+      <variablelist>
+        <varlistentry>
+          <term>
+            Name(string, "Ceph")
+          </term>
+          <listitem>
+            <para>
+              Name of FSAL should always be Ceph.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Filesystem(string, no default)
+          </term>
+          <listitem>
+            <para>
+              Ceph filesystem name string, for mounting an alternate
+              filesystem within the cluster. The default is to mount the
+              default filesystem in the cluster (usually, the first one
+              created).
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            User_Id(string, no default)
+          </term>
+          <listitem>
+            <para>
+              cephx userid used to open the MDS session. This string is
+              what gets appended to "client.". If not set, the
+              ceph client libs will sort this out based on ceph
+              configuration.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Secret_Access_Key(string, no default)
+          </term>
+          <listitem>
+            <para>
+              Key to use for the session (if any). If not set, then it
+              uses the normal search path for cephx keyring files to
+              find a key.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section xml:id="ceph">
+      <title>CEPH {}</title>
+      <para>
+        <emphasis role="strong">Ceph_Conf(path, default
+        "")</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">umask(mode, range 0 to 0777, default
+        0)</emphasis>
+      </para>
+    </section>
+  </section>
+  <section xml:id="see-also">
+    <title>See also</title>
+    <para>
+      <literal>ganesha-config &lt;ganesha-config&gt;</literal>(8)
+      <literal>ganesha-log-config &lt;ganesha-log-config&gt;</literal>(8)
+      <literal>ganesha-core-config &lt;ganesha-core-config&gt;</literal>(8)
+      <literal>ganesha-export-config &lt;ganesha-export-config&gt;</literal>(8)
+    </para>
+  </section>
+</section>

--- a/xml/ganesha-config.xml
+++ b/xml/ganesha-config.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
-<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-config----nfs-ganesha-configuration-file">
+<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" xml:id="man-ganesha-config-ganesha-config----nfs-ganesha-configuration-file">
   <title>ganesha-config -- NFS Ganesha Configuration File</title>
   <para>
     ganesha-config
   </para>
-  <section xml:id="synopsis">
+  <sect2 xml:id="man-ganesha-config-synopsis">
     <title>SYNOPSIS</title>
     <para>
       /etc/ganesha/ganesha.conf
     </para>
-  </section>
-  <section xml:id="description">
+  </sect2>
+  <sect2 xml:id="man-ganesha-config-description">
     <title>DESCRIPTION</title>
     <para>
       NFS-Ganesha obtains configuration data from the configuration
@@ -20,7 +20,7 @@
     <para>
       The configuration file consists of following parts:
     </para>
-    <section xml:id="comments">
+    <sect3 xml:id="man-ganesha-config-comments">
       <title>Comments</title>
       <para>
         Empty lines and lines starting with '#' are comments.:
@@ -29,8 +29,8 @@
 # This whole line is a comment
 Protocol = TCP; # The rest of this line is a comment
 </programlisting>
-    </section>
-    <section xml:id="blocks">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-blocks">
       <title>Blocks</title>
       <para>
         Related options are grouped together into "blocks". A
@@ -51,8 +51,8 @@ EXPORT
         NOTE: FSAL is a sub block. Refer to <literal>BLOCKS</literal>
         section for list of blocks and options.
       </para>
-    </section>
-    <section xml:id="options">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-options">
       <title>Options</title>
       <para>
         Configuration options can be of following types.
@@ -81,8 +81,8 @@ mask = ~0xff; # Equivalent to 0xffffff00 (for 32 bit integers)
         contain a list of possible applicable values. Protocols = 3, 4,
         9p;
       </para>
-    </section>
-    <section xml:id="including-other-config-files">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-including-other-config-files">
       <title>Including other config files</title>
       <para>
         Additional files can be referenced in a configuration using
@@ -109,14 +109,14 @@ mask = ~0xff; # Equivalent to 0xffffff00 (for 32 bit integers)
         In the case of rados:// URLs, providing a two-component URL
         indicates that the default namespace should be used.
       </para>
-    </section>
-  </section>
-  <section xml:id="blocks-1">
+    </sect3>
+  </sect2>
+  <sect2 xml:id="man-ganesha-config-blocks-1">
     <title>BLOCKS</title>
     <para>
       NFS-Ganesha supports the following blocks:
     </para>
-    <section xml:id="export">
+    <sect3 xml:id="man-ganesha-config-export">
       <title>EXPORT {}</title>
       <para>
         Along with its configuration options, the
@@ -126,88 +126,88 @@ mask = ~0xff; # Equivalent to 0xffffff00 (for 32 bit integers)
         <literal>ganesha-export-config &lt;ganesha-export-config&gt;</literal>(8)
         for usage of this block and its sub-blocks.
       </para>
-    </section>
-    <section xml:id="export_defaults">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-export_defaults">
       <title>EXPORT_DEFAULTS {}</title>
       <para>
         Refer to
         <literal>ganesha-export-config &lt;ganesha-export-config&gt;</literal>(8)
         for usage
       </para>
-    </section>
-    <section xml:id="mdcache">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-mdcache">
       <title>MDCACHE {}</title>
       <para>
         Refer to
         <literal>ganesha-cache-config &lt;ganesha-cache-config&gt;</literal>(8)
         for usage
       </para>
-    </section>
-    <section xml:id="nfs_core_param">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-nfs_core_param">
       <title>NFS_CORE_PARAM {}</title>
       <para>
         Refer to
         <literal>ganesha-core-config &lt;ganesha-core-config&gt;</literal>(8)
         for usage
       </para>
-    </section>
-    <section xml:id="nfs_ip_name">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-nfs_ip_name">
       <title>NFS_IP_NAME {}</title>
       <para>
         Refer to
         <literal>ganesha-core-config &lt;ganesha-core-config&gt;</literal>(8)
         for usage
       </para>
-    </section>
-    <section xml:id="nfs_krb5">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-nfs_krb5">
       <title>NFS_KRB5 {}</title>
       <para>
         Refer to
         <literal>ganesha-core-config &lt;ganesha-core-config&gt;</literal>(8)
         for usage
       </para>
-    </section>
-    <section xml:id="nfsv4">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-nfsv4">
       <title>NFSv4 {}</title>
       <para>
         Refer to
         <literal>ganesha-core-config &lt;ganesha-core-config&gt;</literal>(8)
         for usage
       </para>
-    </section>
-    <section xml:id="ceph">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-ceph">
       <title>CEPH {}</title>
       <para>
         Refer to
         <literal>ganesha-ceph-config &lt;ganesha-ceph-config&gt;</literal>(8)
         for usage
       </para>
-    </section>
-    <section xml:id="p">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-p">
       <title>9P {}</title>
       <para>
         Refer to
         <literal>ganesha-9p-config &lt;ganesha-9p-config&gt;</literal>(8)
         for usage
       </para>
-    </section>
-    <section xml:id="gluster">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-gluster">
       <title>GLUSTER {}</title>
       <para>
         Refer to
         <literal>ganesha-gluster-config &lt;ganesha-gluster-config&gt;</literal>(8)
         for usage
       </para>
-    </section>
-    <section xml:id="gpfs">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-gpfs">
       <title>GPFS {}</title>
       <para>
         Refer to
         <literal>ganesha-gpfs-config &lt;ganesha-gpfs-config&gt;</literal>(8)
         for usage
       </para>
-    </section>
-    <section xml:id="log">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-log">
       <title>LOG {}</title>
       <para>
         Refer to
@@ -218,49 +218,49 @@ mask = ~0xff; # Equivalent to 0xffffff00 (for 32 bit integers)
         1.<emphasis role="strong">LOG { FACILITY {} }</emphasis>
         2.<emphasis role="strong">LOG { FORMAT {} }</emphasis>
       </para>
-    </section>
-    <section xml:id="proxy_v4">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-proxy_v4">
       <title>PROXY_V4 {}</title>
       <para>
         Refer to
         <literal>ganesha-proxy-config &lt;ganesha-proxy-v4-config&gt;</literal>(8)
         for usage
       </para>
-    </section>
-    <section xml:id="proxy_v3">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-proxy_v3">
       <title>PROXY_V3 {}</title>
       <para>
         Refer to
         <literal>ganesha-proxy-v3-config &lt;ganesha-proxy-v3-config&gt;</literal>(8)
         for usage
       </para>
-    </section>
-    <section xml:id="rgw">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-rgw">
       <title>RGW {}</title>
       <para>
         Refer to
         <literal>ganesha-rgw-config &lt;ganesha-rgw-config&gt;</literal>(8)
         for usage
       </para>
-    </section>
-    <section xml:id="vfs">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-vfs">
       <title>VFS {}</title>
       <para>
         Refer to
         <literal>ganesha-vfs-config &lt;ganesha-vfs-config&gt;</literal>(8)
         for usage
       </para>
-    </section>
-    <section xml:id="xfs">
+    </sect3>
+    <sect3 xml:id="man-ganesha-config-xfs">
       <title>XFS {}</title>
       <para>
         Refer to
         <literal>ganesha-xfs-config &lt;ganesha-xfs-config&gt;</literal>(8)
         for usage
       </para>
-    </section>
-  </section>
-  <section xml:id="example">
+    </sect3>
+  </sect2>
+  <sect2 xml:id="man-ganesha-config-example">
     <title>EXAMPLE</title>
     <para>
       Along with "ganesha.conf", for each installed FSAL, a
@@ -269,8 +269,8 @@ mask = ~0xff; # Equivalent to 0xffffff00 (for 32 bit integers)
     <para>
       /etc/ganesha
     </para>
-  </section>
-  <section xml:id="see-also">
+  </sect2>
+  <sect2 xml:id="man-ganesha-config-see-also">
     <title>See also</title>
     <para>
       <literal>ganesha-log-config &lt;ganesha-log-config&gt;</literal>(8)
@@ -287,5 +287,5 @@ mask = ~0xff; # Equivalent to 0xffffff00 (for 32 bit integers)
       <literal>ganesha-core-config &lt;ganesha-core-config&gt;</literal>(8)
       <literal>ganesha-export-config &lt;ganesha-export-config&gt;</literal>(8)
     </para>
-  </section>
-</section>
+  </sect2>
+</sect1>

--- a/xml/ganesha-config.xml
+++ b/xml/ganesha-config.xml
@@ -1,0 +1,291 @@
+<?xml version="1.0"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-config----nfs-ganesha-configuration-file">
+  <title>ganesha-config -- NFS Ganesha Configuration File</title>
+  <para>
+    ganesha-config
+  </para>
+  <section xml:id="synopsis">
+    <title>SYNOPSIS</title>
+    <para>
+      /etc/ganesha/ganesha.conf
+    </para>
+  </section>
+  <section xml:id="description">
+    <title>DESCRIPTION</title>
+    <para>
+      NFS-Ganesha obtains configuration data from the configuration
+      file:
+    </para>
+    <screen>/etc/ganesha/ganesha.conf</screen>
+    <para>
+      The configuration file consists of following parts:
+    </para>
+    <section xml:id="comments">
+      <title>Comments</title>
+      <para>
+        Empty lines and lines starting with '#' are comments.:
+      </para>
+      <programlisting>
+# This whole line is a comment
+Protocol = TCP; # The rest of this line is a comment
+</programlisting>
+    </section>
+    <section xml:id="blocks">
+      <title>Blocks</title>
+      <para>
+        Related options are grouped together into "blocks". A
+        block is a name followed by parameters enclosed between
+        "{" and "}". A block can contain other sub
+        blocks as well.:
+      </para>
+      <programlisting>
+EXPORT
+{
+    Export_ID = 1;
+    FSAL {
+        Name = VFS:
+    }
+}
+</programlisting>
+      <para>
+        NOTE: FSAL is a sub block. Refer to <literal>BLOCKS</literal>
+        section for list of blocks and options.
+      </para>
+    </section>
+    <section xml:id="options">
+      <title>Options</title>
+      <para>
+        Configuration options can be of following types.
+      </para>
+      <para>
+        1. <emphasis role="strong">Numeric.</emphasis> Numeric options
+        can be defined in octal, decimal, or hexadecimal. The format
+        follows ANSI C syntax. eg.:
+      </para>
+      <programlisting>
+mode = 0755;  # This is octal 0755, 493 (decimal)
+</programlisting>
+      <para>
+        Numeric values can also be negated or logical NOT'd. eg.:
+      </para>
+      <programlisting>
+anonymousuid = -2; # this is a negative
+mask = ~0xff; # Equivalent to 0xffffff00 (for 32 bit integers)
+</programlisting>
+      <para>
+        2. <emphasis role="strong">Boolean.</emphasis> Possible values
+        are true, false, yes and no. 1 and 0 are not acceptable.
+      </para>
+      <para>
+        3. <emphasis role="strong">List.</emphasis> The option can
+        contain a list of possible applicable values. Protocols = 3, 4,
+        9p;
+      </para>
+    </section>
+    <section xml:id="including-other-config-files">
+      <title>Including other config files</title>
+      <para>
+        Additional files can be referenced in a configuration using
+        '%include' and '%url' directives.:
+      </para>
+      <programlisting>
+%include &lt;filename&gt;
+%url &lt;url, e.g., rados://mypool/mynamespace/myobject&gt;
+</programlisting>
+      <para>
+        The included file is inserted into the configuration text in
+        place of the %include or %url line. Sub-inclusions may be to any
+        depth. Filenames and URLs may optionally use '"':
+      </para>
+      <programlisting>
+%include base.conf
+%include "base.conf"
+%url rados://mypool/mynamespace/myobject
+%url "rados://mypool/mynamespace/myobject"
+%url rados://mypool/myobject
+%url "rados://mypool/myobject"
+</programlisting>
+      <para>
+        In the case of rados:// URLs, providing a two-component URL
+        indicates that the default namespace should be used.
+      </para>
+    </section>
+  </section>
+  <section xml:id="blocks-1">
+    <title>BLOCKS</title>
+    <para>
+      NFS-Ganesha supports the following blocks:
+    </para>
+    <section xml:id="export">
+      <title>EXPORT {}</title>
+      <para>
+        Along with its configuration options, the
+        <emphasis role="strong">EXPORT</emphasis> block supports
+        <emphasis role="strong">FSAL</emphasis> and
+        <emphasis role="strong">CLIENT</emphasis> sub-blocks. See
+        <literal>ganesha-export-config &lt;ganesha-export-config&gt;</literal>(8)
+        for usage of this block and its sub-blocks.
+      </para>
+    </section>
+    <section xml:id="export_defaults">
+      <title>EXPORT_DEFAULTS {}</title>
+      <para>
+        Refer to
+        <literal>ganesha-export-config &lt;ganesha-export-config&gt;</literal>(8)
+        for usage
+      </para>
+    </section>
+    <section xml:id="mdcache">
+      <title>MDCACHE {}</title>
+      <para>
+        Refer to
+        <literal>ganesha-cache-config &lt;ganesha-cache-config&gt;</literal>(8)
+        for usage
+      </para>
+    </section>
+    <section xml:id="nfs_core_param">
+      <title>NFS_CORE_PARAM {}</title>
+      <para>
+        Refer to
+        <literal>ganesha-core-config &lt;ganesha-core-config&gt;</literal>(8)
+        for usage
+      </para>
+    </section>
+    <section xml:id="nfs_ip_name">
+      <title>NFS_IP_NAME {}</title>
+      <para>
+        Refer to
+        <literal>ganesha-core-config &lt;ganesha-core-config&gt;</literal>(8)
+        for usage
+      </para>
+    </section>
+    <section xml:id="nfs_krb5">
+      <title>NFS_KRB5 {}</title>
+      <para>
+        Refer to
+        <literal>ganesha-core-config &lt;ganesha-core-config&gt;</literal>(8)
+        for usage
+      </para>
+    </section>
+    <section xml:id="nfsv4">
+      <title>NFSv4 {}</title>
+      <para>
+        Refer to
+        <literal>ganesha-core-config &lt;ganesha-core-config&gt;</literal>(8)
+        for usage
+      </para>
+    </section>
+    <section xml:id="ceph">
+      <title>CEPH {}</title>
+      <para>
+        Refer to
+        <literal>ganesha-ceph-config &lt;ganesha-ceph-config&gt;</literal>(8)
+        for usage
+      </para>
+    </section>
+    <section xml:id="p">
+      <title>9P {}</title>
+      <para>
+        Refer to
+        <literal>ganesha-9p-config &lt;ganesha-9p-config&gt;</literal>(8)
+        for usage
+      </para>
+    </section>
+    <section xml:id="gluster">
+      <title>GLUSTER {}</title>
+      <para>
+        Refer to
+        <literal>ganesha-gluster-config &lt;ganesha-gluster-config&gt;</literal>(8)
+        for usage
+      </para>
+    </section>
+    <section xml:id="gpfs">
+      <title>GPFS {}</title>
+      <para>
+        Refer to
+        <literal>ganesha-gpfs-config &lt;ganesha-gpfs-config&gt;</literal>(8)
+        for usage
+      </para>
+    </section>
+    <section xml:id="log">
+      <title>LOG {}</title>
+      <para>
+        Refer to
+        <literal>ganesha-log-config &lt;ganesha-log-config&gt;</literal>(8)
+        for usage
+      </para>
+      <para>
+        1.<emphasis role="strong">LOG { FACILITY {} }</emphasis>
+        2.<emphasis role="strong">LOG { FORMAT {} }</emphasis>
+      </para>
+    </section>
+    <section xml:id="proxy_v4">
+      <title>PROXY_V4 {}</title>
+      <para>
+        Refer to
+        <literal>ganesha-proxy-config &lt;ganesha-proxy-v4-config&gt;</literal>(8)
+        for usage
+      </para>
+    </section>
+    <section xml:id="proxy_v3">
+      <title>PROXY_V3 {}</title>
+      <para>
+        Refer to
+        <literal>ganesha-proxy-v3-config &lt;ganesha-proxy-v3-config&gt;</literal>(8)
+        for usage
+      </para>
+    </section>
+    <section xml:id="rgw">
+      <title>RGW {}</title>
+      <para>
+        Refer to
+        <literal>ganesha-rgw-config &lt;ganesha-rgw-config&gt;</literal>(8)
+        for usage
+      </para>
+    </section>
+    <section xml:id="vfs">
+      <title>VFS {}</title>
+      <para>
+        Refer to
+        <literal>ganesha-vfs-config &lt;ganesha-vfs-config&gt;</literal>(8)
+        for usage
+      </para>
+    </section>
+    <section xml:id="xfs">
+      <title>XFS {}</title>
+      <para>
+        Refer to
+        <literal>ganesha-xfs-config &lt;ganesha-xfs-config&gt;</literal>(8)
+        for usage
+      </para>
+    </section>
+  </section>
+  <section xml:id="example">
+    <title>EXAMPLE</title>
+    <para>
+      Along with "ganesha.conf", for each installed FSAL, a
+      sample config file is added at:
+    </para>
+    <para>
+      /etc/ganesha
+    </para>
+  </section>
+  <section xml:id="see-also">
+    <title>See also</title>
+    <para>
+      <literal>ganesha-log-config &lt;ganesha-log-config&gt;</literal>(8)
+      <literal>ganesha-rgw-config &lt;ganesha-rgw-config&gt;</literal>(8)
+      <literal>ganesha-vfs-config &lt;ganesha-vfs-config&gt;</literal>(8)
+      <literal>ganesha-lustre-config &lt;ganesha-lustre-config&gt;</literal>(8)
+      <literal>ganesha-xfs-config &lt;ganesha-xfs-config&gt;</literal>(8)
+      <literal>ganesha-gpfs-config &lt;ganesha-gpfs-config&gt;</literal>(8)
+      <literal>ganesha-gluster-config &lt;ganesha-gluster-config&gt;</literal>(8)
+      <literal>ganesha-9p-config &lt;ganesha-9p-config&gt;</literal>(8)
+      <literal>ganesha-proxy-config &lt;ganesha-proxy-config&gt;</literal>(8)
+      <literal>ganesha-proxy-v3-config &lt;ganesha-proxy-v3-config&gt;</literal>(8)
+      <literal>ganesha-ceph-config &lt;ganesha-ceph-config&gt;</literal>(8)
+      <literal>ganesha-core-config &lt;ganesha-core-config&gt;</literal>(8)
+      <literal>ganesha-export-config &lt;ganesha-export-config&gt;</literal>(8)
+    </para>
+  </section>
+</section>

--- a/xml/ganesha-core-config.xml
+++ b/xml/ganesha-core-config.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0"?>
-<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-core-config----nfs-ganesha-core-configuration-file">
+<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" xml:id="man-ganesha-core-config-ganesha-core-config----nfs-ganesha-core-configuration-file">
   <title>ganesha-core-config -- NFS Ganesha Core Configuration
   File</title>
   <para>
     ganesha-core-config
   </para>
-  <section xml:id="synopsis">
+  <sect2 xml:id="man-ganesha-core-config-synopsis">
     <title>SYNOPSIS</title>
     <para>
       /etc/ganesha/ganesha.conf
     </para>
-  </section>
-  <section xml:id="description">
+  </sect2>
+  <sect2 xml:id="man-ganesha-core-config-description">
     <title>DESCRIPTION</title>
     <para>
       NFS-Ganesha reads the configuration data from: |
@@ -20,7 +20,7 @@
     <para>
       This file lists NFS related core config options.
     </para>
-    <section xml:id="nfs_core_param">
+    <sect3 xml:id="man-ganesha-core-config-nfs_core_param">
       <title>NFS_CORE_PARAM {}</title>
       <para>
         Core parameters:
@@ -381,8 +381,8 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-    <section xml:id="parameters-controlling-tcp-drc-behavior">
+    </sect3>
+    <sect3 xml:id="man-ganesha-core-config-parameters-controlling-tcp-drc-behavior">
       <title>Parameters controlling TCP DRC behavior:</title>
       <variablelist>
         <varlistentry>
@@ -473,8 +473,8 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-    <section xml:id="parameters-controlling-udp-drc-behavior">
+    </sect3>
+    <sect3 xml:id="man-ganesha-core-config-parameters-controlling-udp-drc-behavior">
       <title>Parameters controlling UDP DRC behavior:</title>
       <variablelist>
         <varlistentry>
@@ -531,8 +531,8 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-    <section xml:id="parameters-affecting-the-relation-with-tirpc">
+    </sect3>
+    <sect3 xml:id="man-ganesha-core-config-parameters-affecting-the-relation-with-tirpc">
       <title>Parameters affecting the relation with TIRPC:</title>
       <variablelist>
         <varlistentry>
@@ -618,8 +618,8 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-    <section xml:id="parameters-for-tcp">
+    </sect3>
+    <sect3 xml:id="man-ganesha-core-config-parameters-for-tcp">
       <title>Parameters for TCP:</title>
       <variablelist>
         <varlistentry>
@@ -667,8 +667,8 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-    <section xml:id="nfs_ip_name">
+    </sect3>
+    <sect3 xml:id="man-ganesha-core-config-nfs_ip_name">
       <title>NFS_IP_NAME {}</title>
       <variablelist>
         <varlistentry>
@@ -692,8 +692,8 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-    <section xml:id="nfs_krb5">
+    </sect3>
+    <sect3 xml:id="man-ganesha-core-config-nfs_krb5">
       <title>NFS_KRB5 {}</title>
       <para>
         <emphasis role="strong">PrincipalName(string, default
@@ -732,8 +732,8 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-    <section xml:id="nfsv4">
+    </sect3>
+    <sect3 xml:id="man-ganesha-core-config-nfsv4">
       <title>NFSv4 {}</title>
       <variablelist>
         <varlistentry>
@@ -932,8 +932,8 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-    <section xml:id="rados_kv">
+    </sect3>
+    <sect3 xml:id="man-ganesha-core-config-rados_kv">
       <title>RADOS_KV {}</title>
       <variablelist>
         <varlistentry>
@@ -998,8 +998,8 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-    <section xml:id="rados_urls">
+    </sect3>
+    <sect3 xml:id="man-ganesha-core-config-rados_urls">
       <title>RADOS_URLS {}</title>
       <variablelist>
         <varlistentry>
@@ -1036,6 +1036,6 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-  </section>
-</section>
+    </sect3>
+  </sect2>
+</sect1>

--- a/xml/ganesha-core-config.xml
+++ b/xml/ganesha-core-config.xml
@@ -1,0 +1,1041 @@
+<?xml version="1.0"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-core-config----nfs-ganesha-core-configuration-file">
+  <title>ganesha-core-config -- NFS Ganesha Core Configuration
+  File</title>
+  <para>
+    ganesha-core-config
+  </para>
+  <section xml:id="synopsis">
+    <title>SYNOPSIS</title>
+    <para>
+      /etc/ganesha/ganesha.conf
+    </para>
+  </section>
+  <section xml:id="description">
+    <title>DESCRIPTION</title>
+    <para>
+      NFS-Ganesha reads the configuration data from: |
+      /etc/ganesha/ganesha.conf
+    </para>
+    <para>
+      This file lists NFS related core config options.
+    </para>
+    <section xml:id="nfs_core_param">
+      <title>NFS_CORE_PARAM {}</title>
+      <para>
+        Core parameters:
+      </para>
+      <variablelist>
+        <varlistentry>
+          <term>
+            NFS_Port (uint16, range 0 to UINT16_MAX, default 2049)
+          </term>
+          <listitem>
+            <para>
+              Port number used by NFS Protocol.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            MNT_Port (uint16, range 0 to UINT16_MAX, default 0)
+          </term>
+          <listitem>
+            <para>
+              Port number used by MNT Protocol.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            NLM_Port (uint16, range 0 to UINT16_MAX, default 0)
+          </term>
+          <listitem>
+            <para>
+              Port number used by NLM Protocol.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Rquota_Port (uint16, range 0 to UINT16_MAX, default 875)
+          </term>
+          <listitem>
+            <para>
+              Port number used by Rquota Protocol.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Bind_addr(IPv4 or IPv6 addr, default 0.0.0.0)
+          </term>
+          <listitem>
+            <para>
+              The address to which to bind for our listening port.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            NFS_Program(uint32, range 1 to INT32_MAX, default 100003)
+          </term>
+          <listitem>
+            <para>
+              RPC program number for NFS.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            MNT_Program(uint32, range 1 to INT32_MAX, default 100005)
+          </term>
+          <listitem>
+            <para>
+              RPC program number for MNT.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            NLM_Program(uint32, range 1 to INT32_MAX, default 100021)
+          </term>
+          <listitem>
+            <para>
+              RPC program number for NLM.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Drop_IO_Errors(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              For NFSv3, whether to drop rather than reply to requests
+              yielding I/O errors. It results in client retry.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Drop_Inval_Errors(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              For NFSv3, whether to drop rather than reply to requests
+              yielding invalid argument errors. False by default and
+              settable with Drop_Inval_Errors.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Drop_Delay_Errors(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              For NFSv3, whether to drop rather than reply to requests
+              yielding delay errors. False by default and settable with
+              Drop_Delay_Errors.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Plugins_Dir(path, default "/usr/lib64/ganesha")
+          </term>
+          <listitem>
+            <para>
+              Path to the directory containing server specific modules
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Enable_NFS_Stats(bool, default true)
+          </term>
+          <listitem>
+            <para>
+              Whether to collect perfomance statistics. By default the
+              perfomance counting is enabled. Enable_NFS_Stats can be
+              enabled or disabled dynamically via ganesha_stats.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Enable_Fast_Stats(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Whether to use fast stats. If enabled this will skip
+              statistics counters collection for per client and per
+              export.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Enable_FSAL_Stats(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Whether to count and collect FSAL specific performance
+              statistics. Enable_FSAL_Stats can be enabled or disabled
+              dynamically via ganesha_stats
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Enable_FULLV3_Stats(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Whether to count and collect "detailed
+              statistics" for NFSv3. Enable_FULLV3_Stats can be
+              enabled or disabled dynamically via ganesha_stats.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Enable_FULLV4_Stats(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Whether to count and collect "detailed
+              statistics" for NFSv4. Enable_FULLV4_Stats can be
+              enabled or disabled dynamically via ganesha_stats.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Enable_CLNT_AllOps_Stats(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Whether to count and collect statistics for all NFS
+              operations requested by NFS clients.
+              Enable_CLNT_AllOps_Stats can be enabled or disabled
+              dynamically via ganesha_stats.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Short_File_Handle(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Whether to use short NFS file handle to accommodate VMware
+              NFS client. Enable this if you have a VMware NFSv3 client.
+              VMware NFSv3 client has a max limit of 56 byte file
+              handles.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Manage_Gids_Expiration(int64, range 0 to 7*24*60*60, default
+            30*60)
+          </term>
+          <listitem>
+            <para>
+              How long the server will trust information it got by
+              calling getgroups() when "Manage_Gids = TRUE" is
+              used in a export entry.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            heartbeat_freq(uint32, range 0 to 5000 default 1000)
+          </term>
+          <listitem>
+            <para>
+              Frequency of dbus health heartbeat in ms.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Enable_NLM(bool, default true)
+          </term>
+          <listitem>
+            <para>
+              Whether to support the Network Lock Manager protocol.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Blocked_Lock_Poller_Interval(int64, range 0 to 180, default
+            10)
+          </term>
+          <listitem>
+            <para>
+              Polling interval for blocked lock polling thread
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Protocols(enum list, default [3,4,9P])
+          </term>
+          <listitem>
+            <variablelist>
+              <varlistentry>
+                <term>
+                  Possible values:
+                </term>
+                <listitem>
+                  <para>
+                    3, 4, NFS3, NFS4, V3, V4, NFSv3, NFSv4, 9P
+                  </para>
+                </listitem>
+              </varlistentry>
+            </variablelist>
+            <para>
+              The protocols that Ganesha will listen for. This is a hard
+              limit, as this list determines which sockets are opened.
+              This list can be restricted per export, but cannot be
+              expanded.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            NSM_Use_Caller_Name(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Whether to use the supplied name rather than the IP
+              address in NSM operations.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Clustered(bool, default true)
+          </term>
+          <listitem>
+            <para>
+              Whether this Ganesha is part of a cluster of Ganeshas. Its
+              vendor specific option.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            fsid_device(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Whether to use device major/minor for fsid.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            mount_path_pseudo(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Whether to use Pseudo (true) or Path (false) for NFS v3
+              and 9P mounts.
+            </para>
+            <para>
+              This option defaults to false for backward compatibility,
+              however, for new setups, it's strongly recommended to be
+              set true since it then means the same server path for the
+              mount is used for both v3 and v4.x.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Dbus_Name_Prefix
+          </term>
+          <listitem>
+            <para>
+              DBus name prefix. Required if one wants to run multiple
+              ganesha instances on single host. The prefix should be
+              different for every ganesha instance. If this is set, the
+              dbus name will be &lt;prefix&gt;.org.ganesha.nfsd
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Enable_UDP(bool, default true)
+          </term>
+          <listitem>
+            <para>
+              Whether to create UDP listeners for NFS, NLM, RQUOTA, and
+              register them with portmapper. Set to false, e.g., to run
+              as non-root.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section xml:id="parameters-controlling-tcp-drc-behavior">
+      <title>Parameters controlling TCP DRC behavior:</title>
+      <variablelist>
+        <varlistentry>
+          <term>
+            DRC_Disabled(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Whether to disable the DRC entirely.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            TCP_Npart(uint32, range 1 to 20, default 1)
+          </term>
+          <listitem>
+            <para>
+              Number of partitions in the tree for the TCP DRC.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            DRC_TCP_Size(uint32, range 1 to 32767, default 1024)
+          </term>
+          <listitem>
+            <para>
+              Maximum number of requests in a transport's DRC.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            DRC_TCP_Cachesz(uint32, range 1 to 255, default 127)
+          </term>
+          <listitem>
+            <para>
+              Number of entries in the O(1) front-end cache to a TCP
+              Duplicate Request Cache.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            DRC_TCP_Hiwat(uint32, range 1 to 256, default 64)
+          </term>
+          <listitem>
+            <para>
+              High water mark for a TCP connection's DRC at which to
+              start retiring entries if we can.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            DRC_TCP_Recycle_Npart(uint32, range 1 to 20, default 7)
+          </term>
+          <listitem>
+            <para>
+              Number of partitions in the recycle tree that holds
+              per-connection DRCs so they can be used on reconnection
+              (or recycled.)
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            DRC_TCP_Recycle_Expire_S(uint32, range 0 to 60*60, default
+            600)
+          </term>
+          <listitem>
+            <para>
+              How long to wait (in seconds) before freeing the DRC of a
+              disconnected client.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            DRC_TCP_Checksum(bool, default true)
+          </term>
+          <listitem>
+            <para>
+              Whether to use a checksum to match requests as well as the
+              XID
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section xml:id="parameters-controlling-udp-drc-behavior">
+      <title>Parameters controlling UDP DRC behavior:</title>
+      <variablelist>
+        <varlistentry>
+          <term>
+            DRC_UDP_Npart(uint32, range 1 to 100, default 7)
+          </term>
+          <listitem>
+            <para>
+              Number of partitions in the tree for the UDP DRC.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            DRC_UDP_Size(uint32, range 512, to 32768, default 32768)
+          </term>
+          <listitem>
+            <para>
+              Maximum number of requests in the UDP DRC.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            DRC_UDP_Cachesz(uint32, range 1 to 2047, default 599)
+          </term>
+          <listitem>
+            <para>
+              Number of entries in the O(1) front-end cache to the UDP
+              Duplicate Request Cache.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            DRC_UDP_Hiwat(uint32, range 1 to 32768, default 16384)
+          </term>
+          <listitem>
+            <para>
+              High water mark for the UDP DRC at which to start retiring
+              entries if we can
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            DRC_UDP_Checksum(bool, default true)
+          </term>
+          <listitem>
+            <para>
+              Whether to use a checksum to match requests as well as the
+              XID.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section xml:id="parameters-affecting-the-relation-with-tirpc">
+      <title>Parameters affecting the relation with TIRPC:</title>
+      <variablelist>
+        <varlistentry>
+          <term>
+            RPC_Max_Connections(uint32, range 1 to 10000, default 1024)
+          </term>
+          <listitem>
+            <para>
+              Maximum number of connections for TIRPC.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            RPC_Idle_Timeout_S(uint32, range 0 to 60*60, default 300)
+          </term>
+          <listitem>
+            <para>
+              Idle timeout (seconds). Default to 300 seconds.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            MaxRPCSendBufferSize(uint32, range 1 to 1048576*9, default
+            1048576)
+          </term>
+          <listitem>
+            <para>
+              Size of RPC send buffer.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            MaxRPCRecvBufferSize(uint32, range 1 to 1048576*9, default
+            1048576)
+          </term>
+          <listitem>
+            <para>
+              Size of RPC receive buffer.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            RPC_Ioq_ThrdMax(uint32, range 1 to 1024*128 default 200)
+          </term>
+          <listitem>
+            <para>
+              TIRPC ioq max simultaneous io threads
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            RPC_GSS_Npart(uint32, range 1 to 1021, default 13)
+          </term>
+          <listitem>
+            <para>
+              Partitions in GSS ctx cache table
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            RPC_GSS_Max_Ctx(uint32, range 1 to 1048576, default 16384)
+          </term>
+          <listitem>
+            <para>
+              Max GSS contexts in cache. Default 16k
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            RPC_GSS_Max_Gc(uint32, range 1 to 1048576, default 200)
+          </term>
+          <listitem>
+            <para>
+              Max entries to expire in one idle check
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section xml:id="parameters-for-tcp">
+      <title>Parameters for TCP:</title>
+      <variablelist>
+        <varlistentry>
+          <term>
+            Enable_TCP_keepalive(bool, default true)
+          </term>
+          <listitem>
+            <para>
+              Whether tcp sockets should use SO_KEEPALIVE
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            TCP_KEEPCNT(UINT32, range 0 to 255, default 0 -&gt; use
+            system defaults)
+          </term>
+          <listitem>
+            <para>
+              Maximum number of TCP probes before dropping the
+              connection
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            TCP_KEEPIDLE(UINT32, range 0 to 65535, default 0 -&gt; use
+            system defautls)
+          </term>
+          <listitem>
+            <para>
+              Idle time before TCP starts to send keepalive probes
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            TCP_KEEPINTVL(INT32, range 0 to 65535, default 0 -&gt; use
+            system defaults)
+          </term>
+          <listitem>
+            <para>
+              Time between each keepalive probe
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section xml:id="nfs_ip_name">
+      <title>NFS_IP_NAME {}</title>
+      <variablelist>
+        <varlistentry>
+          <term>
+            Index_Size(uint32, range 1 to 51, default 17)
+          </term>
+          <listitem>
+            <para>
+              Configuration for hash table for NFS Name/IP map.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Expiration_Time(uint32, range 1 to 60*60*24, default 3600)
+          </term>
+          <listitem>
+            <para>
+              Expiration time for ip-name mappings.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section xml:id="nfs_krb5">
+      <title>NFS_KRB5 {}</title>
+      <para>
+        <emphasis role="strong">PrincipalName(string, default
+        "nfs")</emphasis>
+      </para>
+      <variablelist>
+        <varlistentry>
+          <term>
+            KeytabPath(path, default "")
+          </term>
+          <listitem>
+            <para>
+              Kerberos keytab.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            CCacheDir(path, default "/var/run/ganesha")
+          </term>
+          <listitem>
+            <para>
+              The ganesha credential cache.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Active_krb5(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Whether to activate Kerberos 5. Defaults to true (if
+              Kerberos support is compiled in)
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section xml:id="nfsv4">
+      <title>NFSv4 {}</title>
+      <variablelist>
+        <varlistentry>
+          <term>
+            Graceless(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Whether to disable the NFSv4 grace period.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Lease_Lifetime(uint32, range 0 to 120, default 60)
+          </term>
+          <listitem>
+            <para>
+              The NFSv4 lease lifetime.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Grace_Period(uint32, range 0 to 180, default 90)
+          </term>
+          <listitem>
+            <para>
+              The NFS grace period.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            DomainName(string, default "localdomain")
+          </term>
+          <listitem>
+            <para>
+              Domain to use if we aren't using the nfsidmap.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            IdmapConf(path, default "/etc/idmapd.conf")
+          </term>
+          <listitem>
+            <para>
+              Path to the idmap configuration file.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            UseGetpwnam(bool, default false if using idmap, true
+            otherwise)
+          </term>
+          <listitem>
+            <para>
+              Whether to use local password (PAM, on Linux) rather than
+              nfsidmap.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Allow_Numeric_Owners(bool, default true)
+          </term>
+          <listitem>
+            <para>
+              Whether to allow bare numeric IDs in NFSv4 owner and group
+              identifiers.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Only_Numeric_Owners(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Whether to ONLY use bare numeric IDs in NFSv4 owner and
+              group identifiers.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Delegations(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Whether to allow delegations.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Deleg_Recall_Retry_Delay(uint32_t, range 0 to 10, default 1)
+          </term>
+          <listitem>
+            <para>
+              Delay after which server will retry a recall in case of
+              failures
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            pnfs_mds(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Whether this a pNFS MDS server. For FSAL Gluster, if this
+              is true, set pnfs_mds in gluster block as well.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            pnfs_ds(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Whether this a pNFS DS server.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            RecoveryBackend(path, default "fs")
+          </term>
+          <listitem>
+            <para>
+              Use different backend for client info:
+            </para>
+            <itemizedlist spacing="compact">
+              <listitem>
+                <para>
+                  fs : filesystem
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  fs_ng: filesystem (better resiliency)
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  rados_kv : rados key-value
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  rados_ng : rados key-value (better resiliency)
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  rados_cluster: clustered rados backend (active/active)
+                </para>
+              </listitem>
+            </itemizedlist>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Minor_Versions(enum list, values [0, 1, 2], default [0, 1,
+            2])
+          </term>
+          <listitem>
+            <para>
+              List of supported NFSV4 minor version numbers.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Slot_Table_Size(uint32, range 1 to 1024, default 64)
+          </term>
+          <listitem>
+            <para>
+              Size of the NFSv4.1 slot table
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Enforce_UTF8_Validation(bool, default false)
+          </term>
+          <listitem>
+            <para>
+              Set true to enforce valid UTF-8 for path components and
+              compound tags
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section xml:id="rados_kv">
+      <title>RADOS_KV {}</title>
+      <variablelist>
+        <varlistentry>
+          <term>
+            ceph_conf(string, no default)
+          </term>
+          <listitem>
+            <para>
+              Connection to ceph cluster, should be file path for ceph
+              configuration.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            userid(path, no default)
+          </term>
+          <listitem>
+            <para>
+              User ID to ceph cluster.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            namespace(string, default NULL)
+          </term>
+          <listitem>
+            <para>
+              RADOS Namespace in which to store objects
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            pool(string, default "nfs-ganesha")
+          </term>
+          <listitem>
+            <para>
+              Pool for client info.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            grace_oid(string, default "grace")
+          </term>
+          <listitem>
+            <para>
+              Name of the object containing the rados_cluster grace DB
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            nodeid(string, default result of gethostname())
+          </term>
+          <listitem>
+            <para>
+              Unique node identifier within rados_cluster
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section xml:id="rados_urls">
+      <title>RADOS_URLS {}</title>
+      <variablelist>
+        <varlistentry>
+          <term>
+            ceph_conf(string, no default)
+          </term>
+          <listitem>
+            <para>
+              Connection to ceph cluster, should be file path for ceph
+              configuration.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            userid(path, no default)
+          </term>
+          <listitem>
+            <para>
+              User ID to ceph cluster.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            watch_url(url, no default)
+          </term>
+          <listitem>
+            <para>
+              rados:// URL to watch for notifications of config changes.
+              When a notification is received, the server will issue a
+              SIGHUP to itself.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+  </section>
+</section>

--- a/xml/ganesha-export-config.xml
+++ b/xml/ganesha-export-config.xml
@@ -1,0 +1,403 @@
+<?xml version="1.0"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-export-config----nfs-ganesha-export-configuration-file">
+  <title>ganesha-export-config -- NFS Ganesha Export Configuration
+  File</title>
+  <para>
+    ganesha-export-config
+  </para>
+  <section xml:id="synopsis">
+    <title>SYNOPSIS</title>
+    <screen>/etc/ganesha/ganesha.conf</screen>
+  </section>
+  <section xml:id="description">
+    <title>DESCRIPTION</title>
+    <para>
+      NFS-Ganesha obtains configuration data from the configuration
+      file:
+    </para>
+    <screen>/etc/ganesha/ganesha.conf</screen>
+    <para>
+      This file lists NFS-Ganesha Export block config options.
+    </para>
+    <section xml:id="export_defaults">
+      <title>EXPORT_DEFAULTS {}</title>
+      <para>
+        These options are all "export permissions" options,
+        and will be repeated in the EXPORT {} and EXPORT { CLIENT {} }
+        blocks.
+      </para>
+      <para>
+        These options will all be dynamically updateable.
+      </para>
+      <variablelist>
+        <varlistentry>
+          <term>
+            Access_Type(enum, default None)
+          </term>
+          <listitem>
+            <variablelist>
+              <varlistentry>
+                <term>
+                  Possible values:
+                </term>
+                <listitem>
+                  <para>
+                    None, RW, RO, MDONLY, MDONLY_RO
+                  </para>
+                </listitem>
+              </varlistentry>
+            </variablelist>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Protocols(enum list, default [3,4])
+          </term>
+          <listitem>
+            <variablelist>
+              <varlistentry>
+                <term>
+                  Possible values:
+                </term>
+                <listitem>
+                  <para>
+                    3, 4, NFS3, NFS4, V3, V4, NFSv3, NFSv4, 9P
+                  </para>
+                </listitem>
+              </varlistentry>
+            </variablelist>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+      <para>
+        Transports(enum list, values [UDP, TCP, RDMA], default [UDP,
+        TCP])
+      </para>
+      <para>
+        Anonymous_uid(anonid, range INT32_MIN to UINT32_MAX, default -2)
+      </para>
+      <para>
+        Anonymous_gid(anonid, range INT32_MIN to UINT32_MAX, default -2)
+      </para>
+      <variablelist>
+        <varlistentry>
+          <term>
+            SecType(enum list, default [none, sys])
+          </term>
+          <listitem>
+            <variablelist>
+              <varlistentry>
+                <term>
+                  Possible values:
+                </term>
+                <listitem>
+                  <para>
+                    none, sys, krb5, krb5i, krb5p
+                  </para>
+                </listitem>
+              </varlistentry>
+            </variablelist>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+      <para>
+        PrivilegedPort(bool, default false)
+      </para>
+      <para>
+        Manage_Gids(bool, default false)
+      </para>
+      <variablelist>
+        <varlistentry>
+          <term>
+            Squash(enum, default root_sqaush)
+          </term>
+          <listitem>
+            <variablelist>
+              <varlistentry>
+                <term>
+                  Possible values:
+                </term>
+                <listitem>
+                  <para>
+                    root, root_squash, rootsquash, rootid,
+                    root_id_squash, rootidsquash, all, all_squash,
+                    allsquash, all_anomnymous, allanonymous,
+                    no_root_squash, none, noidsquash
+                  </para>
+                </listitem>
+              </varlistentry>
+            </variablelist>
+            <para>
+              Each line of defaults above are synonyms
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+      <para>
+        <emphasis role="strong">NFS_Commit(bool, default
+        false)</emphasis>
+      </para>
+      <variablelist>
+        <varlistentry>
+          <term>
+            Delegations(enum, default None)
+          </term>
+          <listitem>
+            <variablelist>
+              <varlistentry>
+                <term>
+                  Possible values:
+                </term>
+                <listitem>
+                  <para>
+                    None, read, write, readwrite, r, w, rw
+                  </para>
+                </listitem>
+              </varlistentry>
+            </variablelist>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+      <para>
+        <emphasis role="strong">Attr_Expiration_Time(int32, range -1 to
+        INT32_MAX, default 60)</emphasis>
+      </para>
+    </section>
+    <section xml:id="export">
+      <title>EXPORT {}</title>
+      <variablelist>
+        <varlistentry>
+          <term>
+            Export_id (required):
+          </term>
+          <listitem>
+            <para>
+              An identifier for the export, must be unique and betweem 0
+              and 65535. If Export_Id 0 is specified, Pseudo must be the
+              root path (/).
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Path (required)
+          </term>
+          <listitem>
+            <para>
+              The directory in the exported file system this export is
+              rooted on (may be ignored for some FSALs). It need not be
+              unique if Pseudo and/or Tag are specified.
+            </para>
+            <para>
+              Note that if it is not unique, and the core option
+              mount_path_pseudo is not set true, a v3 mount using the
+              path will ONLY be able to access the first export
+              configured. To access other exports the Tag option would
+              need to be used.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Pseudo (required v4)
+          </term>
+          <listitem>
+            <para>
+              This option specifies the position in the Pseudo FS this
+              export occupies if this is an NFS v4 export. It must be
+              unique. By using different Pseudo options, the same Path
+              may be exported multiple times.
+            </para>
+            <para>
+              This option is used to place the export within the NFS v4
+              Pseudo Filesystem. This creates a single name space for
+              NFS v4. Clients may mount the root of the Pseudo
+              Filesystem and navigate to exports. Note that the Path and
+              Tag options are not at all visible to NFS v4 clients.
+            </para>
+            <para>
+              Export id 0 is automatically created to provide the root
+              and any directories necessary to navigate to exports if
+              there is no other export specified with Pseudo = /;. Note
+              that if an export is specified with Pseudo = /;, it need
+              not be export id 0. Specifying such an export with FSAL {
+              name = PSEUDO; } may be used to create a Pseudo FS with
+              specific options. Such an export may also use other FSALs
+              (though directories to reach exports will ONLY be
+              automatically created on FSAL PSEUDO exports).
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            Tag (no default)
+          </term>
+          <listitem>
+            <para>
+              This option allows an alternative access for NFS v3
+              mounts. The option MUST not have a leading /. Clients may
+              not mount subdirectories (i.e. if Tag = foo, the client
+              may not mount foo/baz). By using different Tag options,
+              the same Path may be exported multiple times.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            MaxRead (64*1024*1024)
+          </term>
+          <listitem>
+            <para>
+              The maximum read size on this export
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            MaxWrite (64*1024*1024)
+          </term>
+          <listitem>
+            <para>
+              The maximum write size on this export
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            PrefRead (64*1024*1024)
+          </term>
+          <listitem>
+            <para>
+              The preferred read size on this export
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            PrefWrite (64*1024*1024)
+          </term>
+          <listitem>
+            <para>
+              The preferred write size on this export
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            PrefReaddir (16384)
+          </term>
+          <listitem>
+            <para>
+              The preferred readdir size on this export
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            MaxOffsetWrite (INT64_MAX)
+          </term>
+          <listitem>
+            <para>
+              Maximum file offset that may be written Range is 512 to
+              UINT64_MAX
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            MaxOffsetRead (INT64_MAX)
+          </term>
+          <listitem>
+            <para>
+              Maximum file offset that may be read Range is 512 to
+              UINT64_MAX
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            CLIENT (optional)
+          </term>
+          <listitem>
+            <para>
+              See the <literal>EXPORT { CLIENT  {} }</literal> block.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            FSAL (required)
+          </term>
+          <listitem>
+            <para>
+              See the <literal>EXPORT { FSAL  {} }</literal> block.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section xml:id="export-client">
+      <title>EXPORT { CLIENT {} }</title>
+      <para>
+        Take all the "export permissions" options from
+        EXPORT_DEFAULTS. The client lists are dynamically updateable.
+      </para>
+      <variablelist>
+        <varlistentry>
+          <term>
+            Clients(client list, empty)
+          </term>
+          <listitem>
+            <para>
+              Client list entries can take on one of the following
+              forms: Match any client:
+            </para>
+            <programlisting>
+@name       Netgroup name
+x.x.x.x/y   IPv4 network address
+wildcarded  If the string contains at least one ? or *
+            character (and is not simply "*"), the string is
+            used to pattern match host names. Note that [] may
+            also be used, but the pattern MUST have at least one
+            ? or *
+hostname    Match a single client (match is by IP address, all
+            addresses returned by getaddrinfo will match, the
+            getaddrinfo call is made at config parsing time)
+IP address  Match a single client
+</programlisting>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section xml:id="export-fsal">
+      <title>EXPORT { FSAL {} }</title>
+      <para>
+        NFS-Ganesha supports the following FSALs:
+        <emphasis role="strong">Ceph</emphasis>
+        <emphasis role="strong">Gluster</emphasis>
+        <emphasis role="strong">GPFS</emphasis>
+        <emphasis role="strong">Proxy</emphasis>
+        <emphasis role="strong">RGW</emphasis>
+        <emphasis role="strong">VFS</emphasis>
+        <emphasis role="strong">LUSTRE</emphasis>
+      </para>
+      <para>
+        Refer to individual FSAL config file for list of config options.
+      </para>
+    </section>
+  </section>
+  <section xml:id="see-also">
+    <title>See also</title>
+    <para>
+      <literal>ganesha-config &lt;ganesha-config&gt;</literal>(8)
+      <literal>ganesha-rgw-config &lt;ganesha-rgw-config&gt;</literal>(8)
+      <literal>ganesha-vfs-config &lt;ganesha-vfs-config&gt;</literal>(8)
+      <literal>ganesha-lustre-config &lt;ganesha-lustre-config&gt;</literal>(8)
+      <literal>ganesha-xfs-config &lt;ganesha-xfs-config&gt;</literal>(8)
+      <literal>ganesha-gpfs-config &lt;ganesha-gpfs-config&gt;</literal>(8)
+      <literal>ganesha-9p-config &lt;ganesha-9p-config&gt;</literal>(8)
+      <literal>ganesha-proxy-config &lt;ganesha-proxy-config&gt;</literal>(8)
+      <literal>ganesha-ceph-config &lt;ganesha-ceph-config&gt;</literal>(8)
+    </para>
+  </section>
+</section>

--- a/xml/ganesha-export-config.xml
+++ b/xml/ganesha-export-config.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
-<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-export-config----nfs-ganesha-export-configuration-file">
+<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" xml:id="man-ganesha-export-config-ganesha-export-config----nfs-ganesha-export-configuration-file">
   <title>ganesha-export-config -- NFS Ganesha Export Configuration
   File</title>
   <para>
     ganesha-export-config
   </para>
-  <section xml:id="synopsis">
+  <sect2 xml:id="man-ganesha-export-config-synopsis">
     <title>SYNOPSIS</title>
     <screen>/etc/ganesha/ganesha.conf</screen>
-  </section>
-  <section xml:id="description">
+  </sect2>
+  <sect2 xml:id="man-ganesha-export-config-description">
     <title>DESCRIPTION</title>
     <para>
       NFS-Ganesha obtains configuration data from the configuration
@@ -19,7 +19,7 @@
     <para>
       This file lists NFS-Ganesha Export block config options.
     </para>
-    <section xml:id="export_defaults">
+    <sect3 xml:id="man-ganesha-export-config-export_defaults">
       <title>EXPORT_DEFAULTS {}</title>
       <para>
         These options are all "export permissions" options,
@@ -162,8 +162,8 @@
         <emphasis role="strong">Attr_Expiration_Time(int32, range -1 to
         INT32_MAX, default 60)</emphasis>
       </para>
-    </section>
-    <section xml:id="export">
+    </sect3>
+    <sect3 xml:id="man-ganesha-export-config-export">
       <title>EXPORT {}</title>
       <variablelist>
         <varlistentry>
@@ -335,8 +335,8 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-    <section xml:id="export-client">
+    </sect3>
+    <sect3 xml:id="man-ganesha-export-config-export-client">
       <title>EXPORT { CLIENT {} }</title>
       <para>
         Take all the "export permissions" options from
@@ -368,8 +368,8 @@ IP address  Match a single client
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-    <section xml:id="export-fsal">
+    </sect3>
+    <sect3 xml:id="man-ganesha-export-config-export-fsal">
       <title>EXPORT { FSAL {} }</title>
       <para>
         NFS-Ganesha supports the following FSALs:
@@ -384,9 +384,9 @@ IP address  Match a single client
       <para>
         Refer to individual FSAL config file for list of config options.
       </para>
-    </section>
-  </section>
-  <section xml:id="see-also">
+    </sect3>
+  </sect2>
+  <sect2 xml:id="man-ganesha-export-config-see-also">
     <title>See also</title>
     <para>
       <literal>ganesha-config &lt;ganesha-config&gt;</literal>(8)
@@ -399,5 +399,5 @@ IP address  Match a single client
       <literal>ganesha-proxy-config &lt;ganesha-proxy-config&gt;</literal>(8)
       <literal>ganesha-ceph-config &lt;ganesha-ceph-config&gt;</literal>(8)
     </para>
-  </section>
-</section>
+  </sect2>
+</sect1>

--- a/xml/ganesha-log-config.xml
+++ b/xml/ganesha-log-config.xml
@@ -1,0 +1,246 @@
+<?xml version="1.0"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-log-config----nfs-ganesha-log-configuration-file">
+  <title>ganesha-log-config -- NFS Ganesha Log Configuration
+  File</title>
+  <para>
+    ganesha-log-config
+  </para>
+  <section xml:id="synopsis">
+    <title>SYNOPSIS</title>
+    <para>
+      /etc/ganesha/ganesha.conf
+    </para>
+  </section>
+  <section xml:id="description">
+    <title>DESCRIPTION</title>
+    <para>
+      NFS-Ganesha reads the configuration data from: |
+      /etc/ganesha/ganesha.conf
+    </para>
+    <para>
+      This file lists NFS-Ganesha Log config options.
+    </para>
+    <section xml:id="log">
+      <title>LOG {}</title>
+      <para>
+        Default_log_level(token,default EVENT)
+      </para>
+      <para>
+        The log levels are:
+      </para>
+      <para>
+        NULL, FATAL, MAJ, CRIT, WARN, EVENT, INFO, DEBUG, MID_DEBUG,
+        M_DBG, FULL_DEBUG, F_DBG
+      </para>
+      <variablelist>
+        <varlistentry>
+          <term>
+            RPC_Debug_Flags(uint32, range 0 to UINT32_MAX, default 7)
+          </term>
+          <listitem>
+            <para>
+              Debug flags for TIRPC (default 7 matches log level default
+              EVENT).
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section xml:id="log-components">
+      <title>LOG { COMPONENTS {} }</title>
+      <variablelist>
+        <varlistentry>
+          <term>
+            <emphasis role="strong">Default_log_level(token,default
+            EVENT)</emphasis>
+          </term>
+          <listitem>
+            <variablelist>
+              <varlistentry>
+                <term>
+                  These entries are of the form:
+                </term>
+                <listitem>
+                  <para>
+                    COMPONENT = LEVEL;
+                  </para>
+                </listitem>
+              </varlistentry>
+              <varlistentry>
+                <term>
+                  The components are:
+                </term>
+                <listitem>
+                  <para>
+                    ALL, LOG, LOG_EMERG, MEMLEAKS, FSAL, NFSPROTO,
+                    NFS_V4, EXPORT, FILEHANDLE, DISPATCH, CACHE_INODE,
+                    CACHE_INODE_LRU, HASHTABLE, HASHTABLE_CACHE, DUPREQ,
+                    INIT, MAIN, IDMAPPER, NFS_READDIR, NFS_V4_LOCK,
+                    CONFIG, CLIENTID, SESSIONS, PNFS, RW_LOCK, NLM, RPC,
+                    NFS_CB, THREAD, NFS_V4_ACL, STATE, 9P, 9P_DISPATCH,
+                    FSAL_UP, DBUS
+                  </para>
+                </listitem>
+              </varlistentry>
+              <varlistentry>
+                <term>
+                  Some synonyms are:
+                </term>
+                <listitem>
+                  <para>
+                    FH = FILEHANDLE HT = HASHTABLE INODE_LRU =
+                    CACHE_INODE_LRU INODE = CACHE_INODE DISP = DISPATCH
+                    LEAKS = MEMLEAKS NFS3 = NFSPROTO NFS4 = NFS_V4
+                    HT_CACHE = HASHTABLE_CACHE NFS_STARTUP = INIT
+                    NFS4_LOCK = NFS_V4_LOCK NFS4_ACL = NFS_V4_ACL
+                    9P_DISP = 9P_DISPATCH
+                  </para>
+                </listitem>
+              </varlistentry>
+              <varlistentry>
+                <term>
+                  The log levels are:
+                </term>
+                <listitem>
+                  <para>
+                    NULL, FATAL, MAJ, CRIT, WARN, EVENT, INFO, DEBUG,
+                    MID_DEBUG, M_DBG, FULL_DEBUG, F_DBG
+                  </para>
+                  <para>
+                    default EVENT
+                  </para>
+                </listitem>
+              </varlistentry>
+            </variablelist>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section xml:id="log-facility">
+      <title>LOG { FACILITY {} }</title>
+      <para>
+        <emphasis role="strong">name(string, no default)</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">destination(string, no default, must be
+        supplied)</emphasis>
+      </para>
+      <variablelist>
+        <varlistentry>
+          <term>
+            <emphasis role="strong">max_level(token,default
+            FULL_DEBUG)</emphasis>
+          </term>
+          <listitem>
+            <para>
+              The log levels are:
+            </para>
+            <screen>NULL, FATAL, MAJ, CRIT, WARN, EVENT, INFO, DEBUG, MID_DEBUG, M_DBG, FULL_DEBUG, F_DBG</screen>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+      <para>
+        <emphasis role="strong">headers(token, values [none, component,
+        all], default all)</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">enable(token, values [idle, active,
+        default], default idle)</emphasis>
+      </para>
+    </section>
+    <section xml:id="log-format">
+      <title>LOG { FORMAT {} }</title>
+      <variablelist>
+        <varlistentry>
+          <term>
+            date_format(enum,default ganesha)
+          </term>
+          <listitem>
+            <variablelist>
+              <varlistentry>
+                <term>
+                  Possible values:
+                </term>
+                <listitem>
+                  <para>
+                    ganesha, true, local, 8601, ISO-8601, ISO 8601, ISO,
+                    syslog, syslog_usec, false, none, user_defined
+                  </para>
+                </listitem>
+              </varlistentry>
+            </variablelist>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            time_format(enum,default ganesha)
+          </term>
+          <listitem>
+            <variablelist>
+              <varlistentry>
+                <term>
+                  Possible values:
+                </term>
+                <listitem>
+                  <para>
+                    ganesha, true, local, 8601, ISO-8601, ISO 8601, ISO,
+                    syslog, syslog_usec, false, none, user_defined
+                  </para>
+                </listitem>
+              </varlistentry>
+            </variablelist>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+      <para>
+        <emphasis role="strong">user_date_format(string, no
+        default)</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">user_time_format(string, no
+        default)</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">EPOCH(bool, default true)</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">CLIENTIP(bool, default false)</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">HOSTNAME(bool, default true)</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">PROGNAME(bool, default true)</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">PID(bool, default true)</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">THREAD_NAME(bool, default
+        true)</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">FILE_NAME(bool, default true)</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">LINE_NUM(bool, default true)</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">FUNCTION_NAME(bool, default
+        true)</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">COMPONENT(bool, default true)</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">LEVEL(bool, default true)</emphasis>
+      </para>
+    </section>
+  </section>
+  <section xml:id="see-also">
+    <title>See also</title>
+    <para>
+      <literal>ganesha-config &lt;ganesha-config&gt;</literal>(8)
+    </para>
+  </section>
+</section>

--- a/xml/ganesha-log-config.xml
+++ b/xml/ganesha-log-config.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0"?>
-<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-log-config----nfs-ganesha-log-configuration-file">
+<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" xml:id="man-ganesha-log-config-ganesha-log-config----nfs-ganesha-log-configuration-file">
   <title>ganesha-log-config -- NFS Ganesha Log Configuration
   File</title>
   <para>
     ganesha-log-config
   </para>
-  <section xml:id="synopsis">
+  <sect2 xml:id="man-ganesha-log-config-synopsis">
     <title>SYNOPSIS</title>
     <para>
       /etc/ganesha/ganesha.conf
     </para>
-  </section>
-  <section xml:id="description">
+  </sect2>
+  <sect2 xml:id="man-ganesha-log-config-description">
     <title>DESCRIPTION</title>
     <para>
       NFS-Ganesha reads the configuration data from: |
@@ -20,7 +20,7 @@
     <para>
       This file lists NFS-Ganesha Log config options.
     </para>
-    <section xml:id="log">
+    <sect3 xml:id="man-ganesha-log-config-log">
       <title>LOG {}</title>
       <para>
         Default_log_level(token,default EVENT)
@@ -45,8 +45,8 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-    <section xml:id="log-components">
+    </sect3>
+    <sect3 xml:id="man-ganesha-log-config-log-components">
       <title>LOG { COMPONENTS {} }</title>
       <variablelist>
         <varlistentry>
@@ -115,8 +115,8 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-    <section xml:id="log-facility">
+    </sect3>
+    <sect3 xml:id="man-ganesha-log-config-log-facility">
       <title>LOG { FACILITY {} }</title>
       <para>
         <emphasis role="strong">name(string, no default)</emphasis>
@@ -147,8 +147,8 @@
         <emphasis role="strong">enable(token, values [idle, active,
         default], default idle)</emphasis>
       </para>
-    </section>
-    <section xml:id="log-format">
+    </sect3>
+    <sect3 xml:id="man-ganesha-log-config-log-format">
       <title>LOG { FORMAT {} }</title>
       <variablelist>
         <varlistentry>
@@ -235,12 +235,12 @@
       <para>
         <emphasis role="strong">LEVEL(bool, default true)</emphasis>
       </para>
-    </section>
-  </section>
-  <section xml:id="see-also">
+    </sect3>
+  </sect2>
+  <sect2 xml:id="man-ganesha-log-config-see-also">
     <title>See also</title>
     <para>
       <literal>ganesha-config &lt;ganesha-config&gt;</literal>(8)
     </para>
-  </section>
-</section>
+  </sect2>
+</sect1>

--- a/xml/ganesha-rados-cluster-design.xml
+++ b/xml/ganesha-rados-cluster-design.xml
@@ -1,0 +1,341 @@
+<?xml version="1.0"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-rados-cluster-design----clustered-rados-recovery-backend-design">
+  <title>ganesha-rados-cluster-design -- Clustered RADOS Recovery
+  Backend Design</title>
+  <section xml:id="overview">
+    <title>Overview</title>
+    <para>
+      This document aims to explain the theory and design behind the
+      rados_cluster recovery backend, which coordinates grace period
+      enforcement among multiple, independent NFS servers.
+    </para>
+    <para>
+      In order to understand the clustered recovery backend, it's first
+      necessary to understand how recovery works with a single server:
+    </para>
+  </section>
+  <section xml:id="singleton-server-recovery">
+    <title>Singleton Server Recovery</title>
+    <para>
+      NFSv4 is a lease-based protocol. Clients set up a relationship to
+      the server and must periodically renew their lease in order to
+      maintain their ephemeral state (open files, locks, delegations or
+      layouts).
+    </para>
+    <para>
+      When a singleton NFS server is restarted, any ephemeral state is
+      lost. When the server comes comes back online, NFS clients detect
+      that the server has been restarted and will reclaim the ephemeral
+      state that they held at the time of their last contact with the
+      server.
+    </para>
+  </section>
+  <section xml:id="singleton-grace-period">
+    <title>Singleton Grace Period</title>
+    <para>
+      In order to ensure that we don't end up with conflicts, clients
+      are barred from acquiring any new state while in the Recovery
+      phase. Only reclaim operations are allowed.
+    </para>
+    <para>
+      This period of time is called the <emphasis role="strong">grace
+      period</emphasis>. Most NFS servers have a grace period that lasts
+      around two lease periods, however nfs-ganesha can and will lift
+      the grace period early if it determines that no more clients will
+      be allowed to recover.
+    </para>
+    <para>
+      Once the grace period ends, the server will move into its Normal
+      operation state. During this period, no more recovery is allowed
+      and new state can be acquired by NFS clients.
+    </para>
+  </section>
+  <section xml:id="reboot-epochs">
+    <title>Reboot Epochs</title>
+    <para>
+      The lifecycle of a singleton NFS server can be considered to be a
+      series of transitions from the Recovery period to Normal operation
+      and back. In the remainder of this document we'll consider such a
+      period to be an <emphasis role="strong">epoch</emphasis>, and
+      assign each a number beginning with 1.
+    </para>
+    <para>
+      Visually, we can represent it like this, such that each Normal
+      -&gt; Recovery transition is marked by a change in the epoch
+      value:
+    </para>
+    <programlisting>
++-------+-------+-------+---------------+-------+
+| State | R | N | R | N | R | R | R | N | R | N |
++-------+-------+-------+---------------+-------+
+| Epoch |   1   |   2   |       3       |   4   |
++-------+-------+-------+---------------+-------+
+</programlisting>
+    <para>
+      Note that it is possible to restart during the grace period (as
+      shown above during epoch 3). That just serves to extend the
+      recovery period and the epoch. A new epoch is only declared during
+      a Recovery -&gt; Normal transition.
+    </para>
+  </section>
+  <section xml:id="client-recovery-database">
+    <title>Client Recovery Database</title>
+    <para>
+      There are some potential edge cases that can occur involving
+      network partitions and multiple reboots. In order to prevent
+      those, the server must maintain a list of clients that hold state
+      on the server at any given time. This list must be maintained on
+      stable storage. If a client sends a request to reclaim some state,
+      then the server must check to make sure it's on that list before
+      allowing the request.
+    </para>
+    <para>
+      Thus when the server allows reclaim requests it must always gate
+      it against the recovery database from the previous epoch. As
+      clients come in to reclaim, we establish records for them in a new
+      database associated with the current epoch.
+    </para>
+    <para>
+      The transition from recovery to normal operation should perform an
+      atomic switch of recovery databases. A recovery database only
+      becomes legitimate on a recovery to normal transition. Until that
+      point, the recovery database from the previous epoch is the
+      canonical one.
+    </para>
+  </section>
+  <section xml:id="exporting-a-clustered-filesystem">
+    <title>Exporting a Clustered Filesystem</title>
+    <para>
+      Let's consider a set of independent NFS servers, all serving out
+      the same content from a clustered backend filesystem of any
+      flavor. Each NFS server in this case can itself be considered a
+      clustered FS client. This means that the NFS server is really just
+      a proxy for state on the clustered filesystem.
+    </para>
+    <para>
+      The filesystem must make some guarantees to the NFS server. First
+      filesystem guarantee:
+    </para>
+    <orderedlist numeration="arabic" spacing="compact">
+      <listitem>
+        <para>
+          The filesystem ensures that the NFS servers (aka the FS
+          clients) cannot obtain state that conflicts with that of
+          another NFS server.
+        </para>
+      </listitem>
+    </orderedlist>
+    <para>
+      This is somewhat obvious and is what we expect from any clustered
+      filesystem outside of any requirements of NFS. If the clustered
+      filesystem can provide this, then we know that conflicting state
+      during normal operations cannot be granted.
+    </para>
+    <para>
+      The recovery period has a different set of rules. If an NFS server
+      crashes and is restarted, then we have a window of time when that
+      NFS server does not know what state was held by its clients.
+    </para>
+    <para>
+      If the state held by the crashed NFS server is immediately
+      released after the crash, another NFS server could hand out
+      conflicting state before the original NFS client has a chance to
+      recover it.
+    </para>
+    <para>
+      This <emphasis>must</emphasis> be prevented. Second filesystem
+      guarantee:
+    </para>
+    <orderedlist numeration="arabic" spacing="compact">
+      <listitem override="2">
+        <para>
+          The filesystem must not release state held by a server during
+          the previous epoch until all servers in the cluster are
+          enforcing the grace period.
+        </para>
+      </listitem>
+    </orderedlist>
+    <para>
+      In practical terms, we want the filesystem to provide a way for an
+      NFS server to tell it when it's safe to release state held by a
+      previous instance of itself. The server should do this once it
+      knows that all of its siblings are enforcing the grace period.
+    </para>
+    <para>
+      Note that we do not require that all servers restart and allow
+      reclaim at that point. It's sufficient for them to simply begin
+      grace period enforcement as soon as possible once one server needs
+      it.
+    </para>
+  </section>
+  <section xml:id="clustered-grace-period-database">
+    <title>Clustered Grace Period Database</title>
+    <para>
+      At this point the cluster siblings are no longer completely
+      independent, and the grace period has become a cluster-wide
+      property. This means that we must track the current epoch on some
+      sort of shared storage that the servers can all access.
+    </para>
+    <para>
+      Additionally we must also keep track of whether a cluster-wide
+      grace period is in effect. Any running nodes should all be
+      informed when either of this info changes, so they can take
+      appropriate steps when it occurs.
+    </para>
+    <para>
+      In the rados_cluster backend, we track these using two epoch
+      values:
+    </para>
+    <variablelist>
+      <varlistentry>
+        <term>
+          <emphasis role="strong">C</emphasis>: is the current epoch.
+          This represents the current epoch value
+        </term>
+        <listitem>
+          <para>
+            of the cluster
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
+          <emphasis role="strong">R</emphasis>: is the recovery epoch.
+          This represents the epoch from which
+        </term>
+        <listitem>
+          <para>
+            clients are allowed to recover. A non-zero value here means
+            that a cluster-wide grace period is in effect. Setting this
+            to 0 ends that grace period.
+          </para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+    <para>
+      In order to decide when to make grace period transitions, each
+      server must also advertise its state to the other nodes.
+      Specifically, each server must be able to determine these two
+      things about each of its siblings:
+    </para>
+    <orderedlist numeration="arabic" spacing="compact">
+      <listitem>
+        <para>
+          Does this server have clients from the previous epoch that
+          will require recovery? (NEED)
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Is this server enforcing the grace period by refusing
+          non-reclaim locks? (ENFORCING)
+        </para>
+      </listitem>
+    </orderedlist>
+    <para>
+      We do this with a pair of flags per sibling (NEED and ENFORCING).
+      Each server typically manages its own flags.
+    </para>
+    <para>
+      The rados_cluster backend stores all of this information in a
+      single RADOS object that is modified using read/modify/write
+      cycles. Typically we'll read the whole object, modify it, and then
+      attept to write it back. If something changes between the read and
+      write, we redo the read and try it again.
+    </para>
+  </section>
+  <section xml:id="clustered-client-recovery-databases">
+    <title>Clustered Client Recovery Databases</title>
+    <para>
+      In rados_cluster the client recovery databases are stored as RADOS
+      objects. Each NFS server has its own set of them and they are
+      given names that have the current epoch (C) embedded in it. This
+      ensures that recovery databases are specific to a particular
+      epoch.
+    </para>
+    <para>
+      In general, it's safe to delete any recovery database that
+      precedes R when R is non-zero, and safe to remove any recovery
+      database except for the current one (the one with C in the name)
+      when the grace period is not in effect (R==0).
+    </para>
+  </section>
+  <section xml:id="establishing-a-new-grace-period">
+    <title>Establishing a New Grace Period</title>
+    <para>
+      When a server restarts and wants to allow clients to reclaim their
+      state, it must establish a new epoch by incrementing the current
+      epoch to declare a new grace period (R=C; C=C+1).
+    </para>
+    <para>
+      The exception to this rule is when the cluster is already in a
+      grace period. Servers can just join an in-progress grace period
+      instead of establishing a new one if one is already active.
+    </para>
+    <para>
+      In either case, the server should also set its NEED and ENFORCING
+      flags at the same time.
+    </para>
+    <para>
+      The other surviving cluster siblings should take steps to begin
+      grace period enforcement as soon as possible. This entails
+      "draining off" any in-progress state morphing operations
+      and then blocking the acquisition of any new state (usually with a
+      return of NFS4ERR_GRACE to clients that attempt it). Again, there
+      is no need for the survivors from the previous epoch to allow
+      recovery here.
+    </para>
+    <para>
+      The surviving servers must however establish a new client recovery
+      database at this point to ensure that their clients can do
+      recovery in the event of a crash afterward.
+    </para>
+    <para>
+      Once all of the siblings are enforcing the grace period, the
+      recovering server can then request that the filesystem release the
+      old state, and allow clients to begin reclaiming their state. In
+      the rados_cluster backend driver, we do this by stalling server
+      startup until all hosts in the cluster are enforcing the grace
+      period.
+    </para>
+  </section>
+  <section xml:id="lifting-the-grace-period">
+    <title>Lifting the Grace Period</title>
+    <para>
+      Transitioning from recovery to normal operation really consists of
+      two different steps:
+    </para>
+    <orderedlist numeration="arabic" spacing="compact">
+      <listitem>
+        <para>
+          the server decides that it no longer requires a grace period,
+          either due to it timing out or there not being any clients
+          that would be allowed to reclaim.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          the server stops enforcing the grace period and transitions to
+          normal operation
+        </para>
+      </listitem>
+    </orderedlist>
+    <para>
+      These concepts are often conflated in singleton servers, but in a
+      cluster we must consider them independently.
+    </para>
+    <para>
+      When a server is finished with its own local recovery period, it
+      should clear its NEED flag. That server should continue enforcing
+      the grace period however until the grace period is fully lifted.
+      The server must not permit reclaims after clearing its NEED flag,
+      however.
+    </para>
+    <para>
+      If the servers' own NEED flag is the last one set, then it can
+      lift the grace period (by setting R=0). At that point, all servers
+      in the cluster can end grace period enforcement, and communicate
+      that fact to the others by clearing their ENFORCING flags.
+    </para>
+  </section>
+</section>

--- a/xml/ganesha-rados-cluster-design.xml
+++ b/xml/ganesha-rados-cluster-design.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
-<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-rados-cluster-design----clustered-rados-recovery-backend-design">
+<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" xml:id="man-ganesha-rados-cluster-design-ganesha-rados-cluster-design----clustered-rados-recovery-backend-design">
   <title>ganesha-rados-cluster-design -- Clustered RADOS Recovery
   Backend Design</title>
-  <section xml:id="overview">
+  <sect2 xml:id="man-ganesha-rados-cluster-design-overview">
     <title>Overview</title>
     <para>
       This document aims to explain the theory and design behind the
@@ -13,8 +13,8 @@
       In order to understand the clustered recovery backend, it's first
       necessary to understand how recovery works with a single server:
     </para>
-  </section>
-  <section xml:id="singleton-server-recovery">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-cluster-design-singleton-server-recovery">
     <title>Singleton Server Recovery</title>
     <para>
       NFSv4 is a lease-based protocol. Clients set up a relationship to
@@ -29,8 +29,8 @@
       state that they held at the time of their last contact with the
       server.
     </para>
-  </section>
-  <section xml:id="singleton-grace-period">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-cluster-design-singleton-grace-period">
     <title>Singleton Grace Period</title>
     <para>
       In order to ensure that we don't end up with conflicts, clients
@@ -49,8 +49,8 @@
       operation state. During this period, no more recovery is allowed
       and new state can be acquired by NFS clients.
     </para>
-  </section>
-  <section xml:id="reboot-epochs">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-cluster-design-reboot-epochs">
     <title>Reboot Epochs</title>
     <para>
       The lifecycle of a singleton NFS server can be considered to be a
@@ -77,8 +77,8 @@
       recovery period and the epoch. A new epoch is only declared during
       a Recovery -&gt; Normal transition.
     </para>
-  </section>
-  <section xml:id="client-recovery-database">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-cluster-design-client-recovery-database">
     <title>Client Recovery Database</title>
     <para>
       There are some potential edge cases that can occur involving
@@ -102,8 +102,8 @@
       point, the recovery database from the previous epoch is the
       canonical one.
     </para>
-  </section>
-  <section xml:id="exporting-a-clustered-filesystem">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-cluster-design-exporting-a-clustered-filesystem">
     <title>Exporting a Clustered Filesystem</title>
     <para>
       Let's consider a set of independent NFS servers, all serving out
@@ -167,8 +167,8 @@
       grace period enforcement as soon as possible once one server needs
       it.
     </para>
-  </section>
-  <section xml:id="clustered-grace-period-database">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-cluster-design-clustered-grace-period-database">
     <title>Clustered Grace Period Database</title>
     <para>
       At this point the cluster siblings are no longer completely
@@ -243,8 +243,8 @@
       attept to write it back. If something changes between the read and
       write, we redo the read and try it again.
     </para>
-  </section>
-  <section xml:id="clustered-client-recovery-databases">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-cluster-design-clustered-client-recovery-databases">
     <title>Clustered Client Recovery Databases</title>
     <para>
       In rados_cluster the client recovery databases are stored as RADOS
@@ -259,8 +259,8 @@
       database except for the current one (the one with C in the name)
       when the grace period is not in effect (R==0).
     </para>
-  </section>
-  <section xml:id="establishing-a-new-grace-period">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-cluster-design-establishing-a-new-grace-period">
     <title>Establishing a New Grace Period</title>
     <para>
       When a server restarts and wants to allow clients to reclaim their
@@ -298,8 +298,8 @@
       startup until all hosts in the cluster are enforcing the grace
       period.
     </para>
-  </section>
-  <section xml:id="lifting-the-grace-period">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-cluster-design-lifting-the-grace-period">
     <title>Lifting the Grace Period</title>
     <para>
       Transitioning from recovery to normal operation really consists of
@@ -337,5 +337,5 @@
       in the cluster can end grace period enforcement, and communicate
       that fact to the others by clearing their ENFORCING flags.
     </para>
-  </section>
-</section>
+  </sect2>
+</sect1>

--- a/xml/ganesha-rados-grace.xml
+++ b/xml/ganesha-rados-grace.xml
@@ -1,0 +1,261 @@
+<?xml version="1.0"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-rados-grace----manipulate-the-shared-grace-management-database">
+  <title>ganesha-rados-grace -- manipulate the shared grace management
+  database</title>
+  <section xml:id="synopsis">
+    <title>SYNOPSIS</title>
+    <para>
+      ganesha-rados-grace [ --cephconf /path/to/ceph.conf ] [--ns
+      namespace] [ --oid obj_id ] [ --pool pool_id ] [ --userid cephuser
+      ] dumpstartliftenforcemember [ nodeid ... ]
+    </para>
+  </section>
+  <section xml:id="description">
+    <title>DESCRIPTION</title>
+    <para>
+      This tool allows the administrator to directly manipulate the
+      database used by the rados_cluster recovery backend. Cluster nodes
+      use that database to indicate their current state in order to
+      coordinate a cluster-wide grace period.
+    </para>
+    <para>
+      The first argument should be a command to execute against the
+      database. Any remaining arguments represent the nodeids of nodes
+      in the cluster that should be acted upon.
+    </para>
+    <para>
+      Most commands will just fail if the grace database is not present.
+      The exception to this rule is the
+      <emphasis role="strong">add</emphasis> command which will create
+      the pool, database and namespace if they do not already exist.
+    </para>
+    <para>
+      Note that this program does not consult ganesha.conf. If you use
+      non-default values for
+      <emphasis role="strong">ceph_conf</emphasis>,
+      <emphasis role="strong">userid</emphasis>,
+      <emphasis role="strong">grace_oid</emphasis>,
+      <emphasis role="strong">namespace</emphasis> or
+      <emphasis role="strong">pool</emphasis> in your RADOS_KV config
+      block, then they will need to passed in via command-line options.
+    </para>
+  </section>
+  <section xml:id="options">
+    <title>OPTIONS</title>
+    <para>
+      <emphasis role="strong">--cephconf</emphasis>
+    </para>
+    <para>
+      Specify the ceph.conf configuration that should be used (default
+      is to use the normal search path to find one)
+    </para>
+    <para>
+      <emphasis role="strong">--ns</emphasis>
+    </para>
+    <para>
+      Set the RADOS namespace to use within the pool (default is NULL)
+    </para>
+    <para>
+      <emphasis role="strong">--oid</emphasis>
+    </para>
+    <para>
+      Set the object id of the grace database RADOS object (default is
+      "grace")
+    </para>
+    <para>
+      <emphasis role="strong">--pool</emphasis>
+    </para>
+    <para>
+      Set the RADOS poolid in which the grace database object resides
+      (default is "nfs-ganesha")
+    </para>
+    <para>
+      <emphasis role="strong">--userid</emphasis>
+    </para>
+    <para>
+      Set the cephx user ID to use when contacting the cluster (default
+      is NULL)
+    </para>
+  </section>
+  <section xml:id="commands">
+    <title>COMMANDS</title>
+    <para>
+      <emphasis role="strong">dump</emphasis>
+    </para>
+    <para>
+      Dump the current status of the grace period database to stdout.
+      This will show the current and recovery epoch serial numbers, as
+      well as a list of hosts currently in the cluster and what flags
+      they have set in their individual records.
+    </para>
+    <para>
+      <emphasis role="strong">add</emphasis>
+    </para>
+    <para>
+      Add the specified hosts to the cluster. This must be done before
+      the given hosts can take part in the cluster. Attempts to modify
+      the database by cluster hosts that have not yet been added will
+      generally fail. New hosts are added with the enforcing flag set,
+      as they are unable to hand out new state until their own grace
+      period has been lifted.
+    </para>
+    <para>
+      <emphasis role="strong">start</emphasis>
+    </para>
+    <para>
+      Start a new grace period. This will begin a new grace period in
+      the cluster if one is not already active and set the record for
+      the listed cluster hosts as both needing a grace period and
+      enforcing the grace period. If a grace period is already active,
+      then this is equivalent to
+      <emphasis role="strong">join</emphasis>.
+    </para>
+    <para>
+      <emphasis role="strong">join</emphasis>
+    </para>
+    <para>
+      Attempt to join an existing grace period. This works like
+      <emphasis role="strong">start</emphasis>, but only if there is
+      already an existing grace period in force.
+    </para>
+    <para>
+      <emphasis role="strong">lift</emphasis>
+    </para>
+    <para>
+      Attempt to lift the current grace period. This will clear the need
+      grace flags for the listed hosts. If there are no more hosts in
+      the cluster that require a grace period, then it will be fully
+      lifted and the cluster will transition to normal operations.
+    </para>
+    <para>
+      <emphasis role="strong">remove</emphasis>
+    </para>
+    <para>
+      Remove one or more existing hosts from the cluster. This will
+      remove the listed hosts from the grace database, possibly lifting
+      the current grace period if there are no more hosts that need one.
+    </para>
+    <para>
+      <emphasis role="strong">enforce</emphasis>
+    </para>
+    <para>
+      Set the flag for the given hosts that indicates that they are
+      currently enforcing the grace period; not allowing the acquisition
+      of new state by clients.
+    </para>
+    <para>
+      <emphasis role="strong">noenforce</emphasis>
+    </para>
+    <para>
+      Clear the enforcing flag for the given hosts, meaning that those
+      hosts are now allowing clients to acquire new state.
+    </para>
+    <para>
+      <emphasis role="strong">member</emphasis>
+    </para>
+    <para>
+      Test whether the given hosts are members of the cluster. Returns
+      an error if any of the hosts are not present in the grace db omap.
+    </para>
+  </section>
+  <section xml:id="flags">
+    <title>FLAGS</title>
+    <para>
+      When the <emphasis role="strong">dump</emphasis> command is
+      issued, ganesha-rados-grace will display a list of all of the
+      nodes in the grace database, and any flags they have set. The
+      flags are as follows:
+    </para>
+    <para>
+      <emphasis role="strong">E (Enforcing)</emphasis>
+    </para>
+    <para>
+      The node is currently enforcing the grace period by rejecting
+      requests from clients to acquire new state.
+    </para>
+    <para>
+      <emphasis role="strong">N (Need Grace)</emphasis>
+    </para>
+    <para>
+      The node currently requires a grace period. Generally, this means
+      that the node has clients that need to perform recovery.
+    </para>
+  </section>
+  <section xml:id="nodeid-assignment">
+    <title>NODEID ASSIGNMENT</title>
+    <para>
+      Each running ganesha daemon requires a
+      <emphasis role="strong">nodeid</emphasis> string that is unique
+      within the cluster. This can be any value as ganesha treats it as
+      an opaque string. By default, the ganesha daemon will use the
+      hostname of the node where it is running.
+    </para>
+    <para>
+      This may not be suitable when running under certain HA clustering
+      infrastructure, so it's generally recommended to manually assign
+      nodeid values to the hosts in the
+      <emphasis role="strong">RADOS_KV</emphasis> config block of
+      <emphasis role="strong">ganesha.conf</emphasis>.
+    </para>
+  </section>
+  <section xml:id="ganesha-configuration">
+    <title>GANESHA CONFIGURATION</title>
+    <para>
+      The ganesha daemon will need to be configured with the
+      RecoveryBackend set to
+      <emphasis role="strong">rados_cluster</emphasis>. If you use a
+      non-default pool, namespace or oid, nodeid then those values will
+      need to be set accordingly in the
+      <emphasis role="strong">RADOS_KV</emphasis> config block as well.
+    </para>
+  </section>
+  <section xml:id="starting-a-new-cluster">
+    <title>STARTING A NEW CLUSTER</title>
+    <para>
+      First, add the given cluster nodes to the grace database. Assuming
+      that the nodes in our cluster will have nodeids ganesha-1 through
+      ganesha-3:
+    </para>
+    <para>
+      <emphasis role="strong">ganesha-rados-grace add ganesha-1
+      ganesha-2 ganesha-3</emphasis>
+    </para>
+    <para>
+      Once this is done, you can start the daemons on each host and they
+      will coordinate to start and lift the grace periods as-needed.
+    </para>
+  </section>
+  <section xml:id="adding-nodes-to-a-running-cluster">
+    <title>ADDING NODES TO A RUNNING CLUSTER</title>
+    <para>
+      After this point, new nodes can then be added to the cluster as
+      needed using the <emphasis role="strong">add</emphasis> command:
+    </para>
+    <para>
+      <emphasis role="strong">ganesha-rados-grace add
+      ganesha-4</emphasis>
+    </para>
+    <para>
+      After the node has been added, ganesha.nfsd can then be started.
+      It will then request a new grace period as-needed.
+    </para>
+  </section>
+  <section xml:id="removing-a-node-from-the-cluster">
+    <title>REMOVING A NODE FROM THE CLUSTER</title>
+    <para>
+      To remove a node from the cluster, first unmount any clients that
+      have that node mounted (possibly moving them to other servers).
+      Then execute the remove command with the nodeids to be removed
+      from the cluster. For example:
+    </para>
+    <para>
+      <emphasis role="strong">ganesha-rados-grace remove
+      ganesha-4</emphasis>
+    </para>
+    <para>
+      This will remove the ganesha-4's record from the database, and
+      possibly lift the current grace period if one is active and it was
+      the last one to need it.
+    </para>
+  </section>
+</section>

--- a/xml/ganesha-rados-grace.xml
+++ b/xml/ganesha-rados-grace.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
-<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-rados-grace----manipulate-the-shared-grace-management-database">
+<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" xml:id="man-ganesha-rados-grace-ganesha-rados-grace----manipulate-the-shared-grace-management-database">
   <title>ganesha-rados-grace -- manipulate the shared grace management
   database</title>
-  <section xml:id="synopsis">
+  <sect2 xml:id="man-ganesha-rados-grace-synopsis">
     <title>SYNOPSIS</title>
     <para>
       ganesha-rados-grace [ --cephconf /path/to/ceph.conf ] [--ns
       namespace] [ --oid obj_id ] [ --pool pool_id ] [ --userid cephuser
       ] dumpstartliftenforcemember [ nodeid ... ]
     </para>
-  </section>
-  <section xml:id="description">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-grace-description">
     <title>DESCRIPTION</title>
     <para>
       This tool allows the administrator to directly manipulate the
@@ -39,8 +39,8 @@
       <emphasis role="strong">pool</emphasis> in your RADOS_KV config
       block, then they will need to passed in via command-line options.
     </para>
-  </section>
-  <section xml:id="options">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-grace-options">
     <title>OPTIONS</title>
     <para>
       <emphasis role="strong">--cephconf</emphasis>
@@ -76,8 +76,8 @@
       Set the cephx user ID to use when contacting the cluster (default
       is NULL)
     </para>
-  </section>
-  <section xml:id="commands">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-grace-commands">
     <title>COMMANDS</title>
     <para>
       <emphasis role="strong">dump</emphasis>
@@ -157,8 +157,8 @@
       Test whether the given hosts are members of the cluster. Returns
       an error if any of the hosts are not present in the grace db omap.
     </para>
-  </section>
-  <section xml:id="flags">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-grace-flags">
     <title>FLAGS</title>
     <para>
       When the <emphasis role="strong">dump</emphasis> command is
@@ -180,8 +180,8 @@
       The node currently requires a grace period. Generally, this means
       that the node has clients that need to perform recovery.
     </para>
-  </section>
-  <section xml:id="nodeid-assignment">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-grace-nodeid-assignment">
     <title>NODEID ASSIGNMENT</title>
     <para>
       Each running ganesha daemon requires a
@@ -197,8 +197,8 @@
       <emphasis role="strong">RADOS_KV</emphasis> config block of
       <emphasis role="strong">ganesha.conf</emphasis>.
     </para>
-  </section>
-  <section xml:id="ganesha-configuration">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-grace-ganesha-configuration">
     <title>GANESHA CONFIGURATION</title>
     <para>
       The ganesha daemon will need to be configured with the
@@ -208,8 +208,8 @@
       need to be set accordingly in the
       <emphasis role="strong">RADOS_KV</emphasis> config block as well.
     </para>
-  </section>
-  <section xml:id="starting-a-new-cluster">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-grace-starting-a-new-cluster">
     <title>STARTING A NEW CLUSTER</title>
     <para>
       First, add the given cluster nodes to the grace database. Assuming
@@ -224,8 +224,8 @@
       Once this is done, you can start the daemons on each host and they
       will coordinate to start and lift the grace periods as-needed.
     </para>
-  </section>
-  <section xml:id="adding-nodes-to-a-running-cluster">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-grace-adding-nodes-to-a-running-cluster">
     <title>ADDING NODES TO A RUNNING CLUSTER</title>
     <para>
       After this point, new nodes can then be added to the cluster as
@@ -239,8 +239,8 @@
       After the node has been added, ganesha.nfsd can then be started.
       It will then request a new grace period as-needed.
     </para>
-  </section>
-  <section xml:id="removing-a-node-from-the-cluster">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rados-grace-removing-a-node-from-the-cluster">
     <title>REMOVING A NODE FROM THE CLUSTER</title>
     <para>
       To remove a node from the cluster, first unmount any clients that
@@ -257,5 +257,5 @@
       possibly lift the current grace period if one is active and it was
       the last one to need it.
     </para>
-  </section>
-</section>
+  </sect2>
+</sect1>

--- a/xml/ganesha-rgw-config.xml
+++ b/xml/ganesha-rgw-config.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
-<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-rgw-config----nfs-ganesha-rgw-configuration-file">
+<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" xml:id="man-ganesha-rgw-config-ganesha-rgw-config----nfs-ganesha-rgw-configuration-file">
   <title>ganesha-rgw-config -- NFS Ganesha RGW Configuration
   File</title>
   <para>
     ganesha-rgw-config
   </para>
-  <section xml:id="synopsis">
+  <sect2 xml:id="man-ganesha-rgw-config-synopsis">
     <title>SYNOPSIS</title>
     <para>
       /etc/ganesha/rgw.conf
@@ -13,8 +13,8 @@
     <para>
       /etc/ganesha/rgw_bucket.conf
     </para>
-  </section>
-  <section xml:id="description">
+  </sect2>
+  <sect2 xml:id="man-ganesha-rgw-config-description">
     <title>DESCRIPTION</title>
     <para>
       NFS-Ganesha install two config examples for RGW FSAL:
@@ -28,13 +28,13 @@
     <para>
       This file lists RGW specific config options.
     </para>
-    <section xml:id="export">
+    <sect3 xml:id="man-ganesha-rgw-config-export">
       <title>EXPORT { }</title>
       <para>
         RGW supports exporting both the buckets and filesystem.
       </para>
-    </section>
-    <section xml:id="export-fsal">
+    </sect3>
+    <sect3 xml:id="man-ganesha-rgw-config-export-fsal">
       <title>EXPORT { FSAL {} }</title>
       <variablelist>
         <varlistentry>
@@ -59,8 +59,8 @@
         <emphasis role="strong">Secret_Access_Key(string, no
         default)</emphasis>
       </para>
-    </section>
-    <section xml:id="rgw">
+    </sect3>
+    <sect3 xml:id="man-ganesha-rgw-config-rgw">
       <title>RGW {}</title>
       <para>
         The following configuration variables customize the startup of
@@ -120,14 +120,14 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </section>
-  </section>
-  <section xml:id="see-also">
+    </sect3>
+  </sect2>
+  <sect2 xml:id="man-ganesha-rgw-config-see-also">
     <title>See also</title>
     <para>
       <literal>ganesha-log-config &lt;ganesha-log-config&gt;</literal>(8)
       <literal>ganesha-core-config &lt;ganesha-core-config&gt;</literal>(8)
       <literal>ganesha-export-config &lt;ganesha-export-config&gt;</literal>(8)
     </para>
-  </section>
-</section>
+  </sect2>
+</sect1>

--- a/xml/ganesha-rgw-config.xml
+++ b/xml/ganesha-rgw-config.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ganesha-rgw-config----nfs-ganesha-rgw-configuration-file">
+  <title>ganesha-rgw-config -- NFS Ganesha RGW Configuration
+  File</title>
+  <para>
+    ganesha-rgw-config
+  </para>
+  <section xml:id="synopsis">
+    <title>SYNOPSIS</title>
+    <para>
+      /etc/ganesha/rgw.conf
+    </para>
+    <para>
+      /etc/ganesha/rgw_bucket.conf
+    </para>
+  </section>
+  <section xml:id="description">
+    <title>DESCRIPTION</title>
+    <para>
+      NFS-Ganesha install two config examples for RGW FSAL:
+    </para>
+    <para>
+      /etc/ganesha/rgw.conf
+    </para>
+    <para>
+      /etc/ganesha/rgw_bucket.conf
+    </para>
+    <para>
+      This file lists RGW specific config options.
+    </para>
+    <section xml:id="export">
+      <title>EXPORT { }</title>
+      <para>
+        RGW supports exporting both the buckets and filesystem.
+      </para>
+    </section>
+    <section xml:id="export-fsal">
+      <title>EXPORT { FSAL {} }</title>
+      <variablelist>
+        <varlistentry>
+          <term>
+            Name(string, "RGW")
+          </term>
+          <listitem>
+            <para>
+              Name of FSAL should always be RGW.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+      <para>
+        <emphasis role="strong">User_Id(string, no default)</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">Access_Key(string, no
+        default)</emphasis>
+      </para>
+      <para>
+        <emphasis role="strong">Secret_Access_Key(string, no
+        default)</emphasis>
+      </para>
+    </section>
+    <section xml:id="rgw">
+      <title>RGW {}</title>
+      <para>
+        The following configuration variables customize the startup of
+        the FSAL's radosgw instance.
+      </para>
+      <variablelist>
+        <varlistentry>
+          <term>
+            ceph_conf
+          </term>
+          <listitem>
+            <para>
+              optional full-path to the Ceph configuration file
+              (equivalent to passing "-c /path/to/ceph.conf"
+              to any Ceph binary
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            name
+          </term>
+          <listitem>
+            <para>
+              optional instance name (equivalent to passing "--name
+              client.rgw.foohost" to the radosgw binary); the value
+              provided here should be the same as the section name (sans
+              brackets) of the radosgw facility in the Ceph
+              configuration file (which must exist)
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            cluster
+          </term>
+          <listitem>
+            <para>
+              optional cluster name (equivalent to passing
+              "--cluster foo" to any Ceph binary); use of a
+              non-default value for cluster name is uncommon, but can be
+              verified by examining the startup options of Ceph binaries
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            init_args
+          </term>
+          <listitem>
+            <para>
+              additional argument strings which will be passed verbatim
+              to the radosgw instance startup process as if they had
+              been given on the radosgw command line provided for
+              customization in uncommon setups
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+  </section>
+  <section xml:id="see-also">
+    <title>See also</title>
+    <para>
+      <literal>ganesha-log-config &lt;ganesha-log-config&gt;</literal>(8)
+      <literal>ganesha-core-config &lt;ganesha-core-config&gt;</literal>(8)
+      <literal>ganesha-export-config &lt;ganesha-export-config&gt;</literal>(8)
+    </para>
+  </section>
+</section>

--- a/xslt/fix-manpages.xsl
+++ b/xslt/fix-manpages.xsl
@@ -41,12 +41,11 @@
       </xsl:copy>
    </xsl:template>
 
-   <xsl:template match="/*">
-      <xsl:element name="{local-name()}"
-         namespace="http://docbook.org/ns/docbook">
-         <xsl:call-template name="add.root.namespaces"/>
-         <xsl:apply-templates select="@* | node()"/>
-      </xsl:element>
+   <xsl:template match="/section">
+     <sect1>
+      <xsl:call-template name="add.root.namespaces"/>
+      <xsl:apply-templates select="@* | node()"/>
+     </sect1>
    </xsl:template>
 
    <xsl:template match="*">
@@ -70,6 +69,14 @@
     <screen>
       <xsl:value-of select="normalize-space(para/text())"/>
     </screen>
+  </xsl:template>
+
+  <xsl:template match="section">
+    <xsl:variable name="level" select="count(ancestor-or-self::section)"/>
+
+    <xsl:element name="sect{$level}" namespace="http://docbook.org/ns/docbook">
+      <xsl:apply-templates select="node() | @*"/>
+    </xsl:element>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/xslt/fix-manpages.xsl
+++ b/xslt/fix-manpages.xsl
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Purpose:
+      Fix conversion issues from Pandoc
+
+   Input:
+     DocBook document after conversion with pandoc
+
+   Output:
+     Correct DocBook5 document
+
+   Author:    Thomas Schraitle <toms@opensuse.org>
+   Copyright (C) 2020 SUSE Software Solutions Germany GmbH
+
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+   xmlns="http://docbook.org/ns/docbook" xmlns:d="http://docbook.org/ns/docbook"
+   xmlns:xi="http://www.w3.org/2001/XInclude"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:exsl="http://exslt.org/common"
+   exclude-result-prefixes="d exsl">
+
+  <xsl:output indent="yes"/>
+
+   <xsl:template name="add.root.namespaces">
+    <!-- add namespaces to the top output element -->
+    <xsl:variable name="temp">
+      <xi:foo/>
+      <xlink:foo/>
+    </xsl:variable>
+
+    <xsl:variable name="nodes" select="exsl:node-set($temp)"/>
+    <xsl:for-each select="$nodes//*/namespace::*">
+      <xsl:copy-of select="."/>
+    </xsl:for-each>
+  </xsl:template>
+
+   <xsl:template match="node() | @*" name="copy">
+      <xsl:copy>
+         <xsl:apply-templates select="@* | node()"/>
+      </xsl:copy>
+   </xsl:template>
+
+   <xsl:template match="/*">
+      <xsl:element name="{local-name()}"
+         namespace="http://docbook.org/ns/docbook">
+         <xsl:call-template name="add.root.namespaces"/>
+         <xsl:apply-templates select="@* | node()"/>
+      </xsl:element>
+   </xsl:template>
+
+   <xsl:template match="*">
+      <xsl:element name="{local-name()}"
+         namespace="http://docbook.org/ns/docbook">
+         <xsl:apply-templates select="node() | @*"/>
+      </xsl:element>
+   </xsl:template>
+
+  <xsl:template match="literallayout">
+    <screen>
+      <xsl:apply-templates select="@* | node()"/>
+    </screen>
+  </xsl:template>
+
+  <xsl:template match="blockquote[variablelist]">
+    <xsl:apply-templates select="node()"/>
+  </xsl:template>
+
+  <xsl:template match="blockquote[para]">
+    <screen>
+      <xsl:value-of select="normalize-space(para/text())"/>
+    </screen>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/xslt/fix-manpages.xsl
+++ b/xslt/fix-manpages.xsl
@@ -22,6 +22,9 @@
 
   <xsl:output indent="yes"/>
 
+  <xsl:param name="idprefix">man-</xsl:param>
+  <xsl:param name="id"/>
+
    <xsl:template name="add.root.namespaces">
     <!-- add namespaces to the top output element -->
     <xsl:variable name="temp">
@@ -42,7 +45,7 @@
    </xsl:template>
 
    <xsl:template match="/section">
-     <sect1>
+     <sect1 xml:lang="en">
       <xsl:call-template name="add.root.namespaces"/>
       <xsl:apply-templates select="@* | node()"/>
      </sect1>
@@ -77,6 +80,12 @@
     <xsl:element name="sect{$level}" namespace="http://docbook.org/ns/docbook">
       <xsl:apply-templates select="node() | @*"/>
     </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="@xml:id">
+    <xsl:attribute name="xml:id">
+      <xsl:value-of select="concat($idprefix, $id, .)"/>
+    </xsl:attribute>
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
This PR contains the following changes:

* a `convert-manpages.sh` script which downloads and converts all the RST files into DocBook.  Does the following steps:

   1. Check if all necessary programs are installed. If not, show help text.
   2. Clone the repository (or use the directory from last run).
   3. Download additional manpages.
   4. Remove any `:orphan:` lines from RST (this simplifies the conversion process).
   5. Convert RST to DocBook5 with pandoc.
   6. Fix the raw XML file from pandoc, write it to result directory.


* a `xslt/fix-manpages.xsl` XSLT stylesheets which corrects issues from the pandoc conversion

