### PR TITLE
Added RGW specification for SSL access (bsc#1176677)

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -1639,9 +1639,65 @@ spec:
   rgw_realm: <replaceable>RGW_REALM</replaceable>
   rgw_zone: <replaceable>RGW_ZONE</replaceable>
 </screen>
-     <para>
-       If you are deploying with a subcluster, apply the following configuration:
-     </para>
+  <sect4>
+   <title>Using Secure SSL Access</title>
+   <para>
+    To use a secure SSL connection to the &ogw;, you need a pair of valid SSL
+    certificate and key files (see <xref linkend="ceph-rgw-https"/> for more
+    details). Then you need to enable SSL, specify a port number for SSL
+    connection, and SSL certificate and key files.
+   </para>
+   <para>
+				To enable SSL and specify the port number, include the following
+				specification:
+   </para>
+<screen>
+spec:
+  ssl: true
+  rgw_frontend_port: 443
+</screen>
+   <para>
+    To specify the SSL certificate and key, you can paste their content directly
+    to the YAML specification file. The pipe sign '|' at the end of line tells
+    the parser to expect a multiline string as a value:
+   </para>
+<screen>
+spec:
+  ssl: true
+  rgw_frontend_port: 443
+  rgw_frontend_ssl_certificate: |
+   -----BEGIN CERTIFICATE-----
+   MIIFmjCCA4KgAwIBAgIJAIZ2n35bmwXTMA0GCSqGSIb3DQEBCwUAMGIxCzAJBgNV
+   BAYTAkFVMQwwCgYDVQQIDANOU1cxHTAbBgNVBAoMFEV4YW1wbGUgUkdXIFNTTCBp
+   [...]
+   -----END CERTIFICATE-----
+   rgw_frontend_ssl_key: |
+   -----BEGIN PRIVATE KEY-----
+   MIIJRAIBADANBgkqhkiG9w0BAQEFAASCCS4wggkqAgEAAoICAQDLtFwg6LLl2j4Z
+   BDV+iL4AO7VZ9KbmWIt37Ml2W6y2YeKX3Qwf+3eBz7TVHR1dm6iPpCpqpQjXUsT9
+   [...]
+   -----END PRIVATE KEY-----
+</screen>
+   <tip>
+    <para>
+     Instead of pasting the content of SSL certificate and key files, you can
+     upload them to the configuration database:
+    </para>
+<screen>
+&prompt.cephuser;ceph config-key set rgw/cert/<replaceable>REALM_NAME</replaceable>/<replaceable>ZONE_NAME</replaceable>.crt \
+ -i <replaceable>SSL_CERT_FILE</replaceable>
+&prompt.cephuser;ceph config-key set rgw/cert/<replaceable>REALM_NAME</replaceable>/<replaceable>ZONE_NAME</replaceable>.key \
+ -i <replaceable>SSL_KEY_FILE</replaceable>
+</screen>
+   </tip>
+  </sect4>
+  <sect4>
+   <title>Deploying with a Subcluster</title>
+   <para>
+    <emphasis>Subclusters</emphasis> help you organize the nodes in your
+    clusters to isolate workloads and make elastic scaling easier. If you are
+    deploying with a subcluster, apply the following configuration:
+   </para>
 <screen>
 service_type: rgw
 service_id: <replaceable>REALM_NAME</replaceable>.<replaceable>ZONE_NAME</replaceable>.<replaceable>SUBCLUSTER</replaceable>
@@ -1655,12 +1711,7 @@ spec:
   rgw_zone: <replaceable>RGW_ZONE</replaceable>
   subcluster: <replaceable>SUBCLUSTER</replaceable>
 </screen>
-     <note>
-       <para>
-         Subclusters help you organize the nodes in your clusters to isolate
-         workloads and make elastic scaling easier.
-       </para>
-     </note>
+  </sect4>
    </sect3>
    <sect3 xml:id="deploy-cephadm-day2-service-igw">
     <title>Deploy &igw;s</title>

--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -1644,12 +1644,12 @@ spec:
    <para>
     To use a secure SSL connection to the &ogw;, you need a pair of valid SSL
     certificate and key files (see <xref linkend="ceph-rgw-https"/> for more
-    details). Then you need to enable SSL, specify a port number for SSL
-    connection, and SSL certificate and key files.
+    details). You need to enable SSL, specify a port number for SSL
+    connections, and the SSL certificate and key files.
    </para>
    <para>
-				To enable SSL and specify the port number, include the following
-				specification:
+     To enable SSL and specify the port number, include the following in your
+     specification:
    </para>
 <screen>
 spec:
@@ -1657,8 +1657,8 @@ spec:
   rgw_frontend_port: 443
 </screen>
    <para>
-    To specify the SSL certificate and key, you can paste their content directly
-    to the YAML specification file. The pipe sign '|' at the end of line tells
+    To specify the SSL certificate and key, you can paste their contents directly
+    into the YAML specification file. The pipe sign '|' at the end of line tells
     the parser to expect a multiline string as a value:
    </para>
 <screen>

--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -25,14 +25,13 @@
   (CLI) or partially via &dashboard; (GUI).
  </para>
  <important>
-   <para>
-     Note that the &ceph; community documentation uses the
-     <command>cephadm bootstrap</command> command during initial deployment.
-     The &cephsalt; calls the <command>cephadm bootstrap</command> command
-     and should not be run directly. Any &ceph; cluster deployment
-     manually using the <command>cephadm bootstrap</command> will be
-     unsupported.
-   </para>
+  <para>
+   Note that the &ceph; community documentation uses the <command>cephadm
+   bootstrap</command> command during initial deployment. The &cephsalt; calls
+   the <command>cephadm bootstrap</command> command and should not be run
+   directly. Any &ceph; cluster deployment manually using the <command>cephadm
+   bootstrap</command> will be unsupported.
+  </para>
  </important>
  <para>
   To deploy a &ceph; cluster by using &cephadm;, you need to complete the
@@ -264,7 +263,6 @@ minion1:
    </step>
   </procedure>
  </sect1>
-
  <sect1 xml:id="deploy-cephadm-day1">
   <title>Deploying the &ceph; Cluster</title>
 
@@ -307,12 +305,13 @@ minion1:
     properties of the cluster.
    </para>
    <important>
-     <para>
-       The <filename>/etc/ceph/ceph.conf</filename> file is managed by &cephadm;
-       and users <emphasis>should not</emphasis> edit it. &ceph; configuration
-       parameters should be set using the new <command>ceph config</command> command.
-       See <xref linkend="cha-ceph-configuration-db"/> for more information.
-     </para>
+    <para>
+     The <filename>/etc/ceph/ceph.conf</filename> file is managed by &cephadm;
+     and users <emphasis>should not</emphasis> edit it. &ceph; configuration
+     parameters should be set using the new <command>ceph config</command>
+     command. See <xref linkend="cha-ceph-configuration-db"/> for more
+     information.
+    </para>
    </important>
    <sect3 xml:id="deploy-cephadm-configure-shell">
     <title>&cephsalt; Shell</title>
@@ -745,9 +744,9 @@ o- time_server ................................................ [enabled]
     <procedure>
      <step>
       <para>
-       Create a local container registry outside of the &ceph; cluster nodes instead
-       of the default public one as the local registry needs to be accessible
-       from cluster nodes. Use a command similar to the following:
+       Create a local container registry outside of the &ceph; cluster nodes
+       instead of the default public one as the local registry needs to be
+       accessible from cluster nodes. Use a command similar to the following:
       </para>
 <screen>
 &prompt.root;podman run -d --restart=always --net=host --name registry -p 5000:5000 registry:2
@@ -755,7 +754,8 @@ o- time_server ................................................ [enabled]
      </step>
      <step>
       <para>
-       Create the corresponding &systemd; unit file for easier registry operation:
+       Create the corresponding &systemd; unit file for easier registry
+       operation:
       </para>
 <screen>&prompt.root;podman generate systemd registry >  \
  /etc/systemd/system/suse_registry.service</screen>
@@ -795,168 +795,168 @@ o- time_server ................................................ [enabled]
      </step>
     </procedure>
    </sect3>
-
    <sect3 xml:id="deploy-cephadm-inflight-encryption">
-     <title>Data In-Flight Encryption (msgr2)</title>
-     <para>
-       The Messenger v2 protocol (MSGR2) is &ceph;'s on-wire protocol. It provides
-       a security mode that encrypts all data passing over the network, encapsulation
-       of authentication payloads, and the enabling of future integration of
-       new authentication modes (such as Kerberos).
-     </para>
-     <para>
-       &ceph; daemons can bind to multiple ports, allowing both legacy &ceph;
-       clients and new v2-capable clients to connect to the same cluster. By
-       default, MONs now bind to the new IANA-assigned port 3300
-       (CE4h or 0xCE4) for the new v2 protocol, while also binding to the
-       old default port 6789 for the legacy v1 protocol.
-     </para>
-     <para>
-       The v2 protocol (MSGR2) supports two connection modes:
-     </para>
-     <variablelist>
-       <varlistentry>
-         <term>crc mode</term>
-         <listitem>
-           <para>
-             A strong initial authentication when the connection is established
-             and a CRC32C integrity check.
-           </para>
-         </listitem>
-       </varlistentry>
-       <varlistentry>
-         <term>secure mode</term>
-         <listitem>
-           <para>
-             A strong initial authentication when the connection is established
-             and full encryption of all post-authentication traffic, including
-             a cryptographic integrity check.
-           </para>
-         </listitem>
-       </varlistentry>
-     </variablelist>
-     <para>
-       For most connections, there are options that control which modes are used:
-     </para>
-     <variablelist>
-       <varlistentry>
-         <term>ms_cluster_mode</term>
-         <listitem>
-           <para>
-             The connection mode (or permitted modes) used for intra-cluster
-             communication between &ceph; daemons. If multiple modes are listed,
-             the modes listed first are preferred.
-           </para>
-         </listitem>
-       </varlistentry>
-       <varlistentry>
-         <term>ms_service_mode</term>
-         <listitem>
-           <para>
-             A list of permitted modes for clients to use when connecting to
-             the cluster.
-           </para>
-         </listitem>
-       </varlistentry>
-       <varlistentry>
-         <term>ms_client_mode</term>
-         <listitem>
-           <para>
-             A list of connection modes, in order of preference, for clients
-             to use (or allow) when talking to a &ceph; cluster.
-           </para>
-         </listitem>
-       </varlistentry>
-     </variablelist>
-     <para>
-       There are a parallel set of options that apply specifically to monitors,
-       allowing administrators to set different (usually more secure) requirements
-       on communication with the monitors.
-     </para>
-     <variablelist>
-       <varlistentry>
-         <term>ms_mon_cluster_mode</term>
-         <listitem>
-           <para>
-             The connection mode (or permitted modes) to use between monitors.
-           </para>
-         </listitem>
-       </varlistentry>
-       <varlistentry>
-         <term>ms_mon_service_mode</term>
-         <listitem>
-           <para>
-             A list of permitted modes for clients or other &ceph; daemons
-             to use when connecting to monitors.
-           </para>
-         </listitem>
-       </varlistentry>
-       <varlistentry>
-         <term>ms_mon_client_mode</term>
-         <listitem>
-           <para>
-             A list of connection modes, in order of preference, for clients
-             or non-monitor daemons to use when connecting to monitors.
-           </para>
-         </listitem>
-       </varlistentry>
-     </variablelist>
-     <para>
-       In order to enable MSGR2 encryption mode during the deployment, you need
-       to add some configuration options to the &cephsalt; configuration before
-       running <command>ceph-salt apply</command>.
-     </para>
-     <para>
-       To use <literal>secure</literal> mode, run the following commands.
-     </para>
-     <para>
-       Add the global section to <filename>ceph_conf</filename> in the &cephsalt;
-       config tool:
-     </para>
+    <title>Data In-Flight Encryption (msgr2)</title>
+    <para>
+     The Messenger v2 protocol (MSGR2) is &ceph;'s on-wire protocol. It
+     provides a security mode that encrypts all data passing over the network,
+     encapsulation of authentication payloads, and the enabling of future
+     integration of new authentication modes (such as Kerberos).
+    </para>
+    <para>
+     &ceph; daemons can bind to multiple ports, allowing both legacy &ceph;
+     clients and new v2-capable clients to connect to the same cluster. By
+     default, MONs now bind to the new IANA-assigned port 3300 (CE4h or 0xCE4)
+     for the new v2 protocol, while also binding to the old default port 6789
+     for the legacy v1 protocol.
+    </para>
+    <para>
+     The v2 protocol (MSGR2) supports two connection modes:
+    </para>
+    <variablelist>
+     <varlistentry>
+      <term>crc mode</term>
+      <listitem>
+       <para>
+        A strong initial authentication when the connection is established and
+        a CRC32C integrity check.
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>secure mode</term>
+      <listitem>
+       <para>
+        A strong initial authentication when the connection is established and
+        full encryption of all post-authentication traffic, including a
+        cryptographic integrity check.
+       </para>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+    <para>
+     For most connections, there are options that control which modes are used:
+    </para>
+    <variablelist>
+     <varlistentry>
+      <term>ms_cluster_mode</term>
+      <listitem>
+       <para>
+        The connection mode (or permitted modes) used for intra-cluster
+        communication between &ceph; daemons. If multiple modes are listed, the
+        modes listed first are preferred.
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>ms_service_mode</term>
+      <listitem>
+       <para>
+        A list of permitted modes for clients to use when connecting to the
+        cluster.
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>ms_client_mode</term>
+      <listitem>
+       <para>
+        A list of connection modes, in order of preference, for clients to use
+        (or allow) when talking to a &ceph; cluster.
+       </para>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+    <para>
+     There are a parallel set of options that apply specifically to monitors,
+     allowing administrators to set different (usually more secure)
+     requirements on communication with the monitors.
+    </para>
+    <variablelist>
+     <varlistentry>
+      <term>ms_mon_cluster_mode</term>
+      <listitem>
+       <para>
+        The connection mode (or permitted modes) to use between monitors.
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>ms_mon_service_mode</term>
+      <listitem>
+       <para>
+        A list of permitted modes for clients or other &ceph; daemons to use
+        when connecting to monitors.
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>ms_mon_client_mode</term>
+      <listitem>
+       <para>
+        A list of connection modes, in order of preference, for clients or
+        non-monitor daemons to use when connecting to monitors.
+       </para>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+    <para>
+     In order to enable MSGR2 encryption mode during the deployment, you need
+     to add some configuration options to the &cephsalt; configuration before
+     running <command>ceph-salt apply</command>.
+    </para>
+    <para>
+     To use <literal>secure</literal> mode, run the following commands.
+    </para>
+    <para>
+     Add the global section to <filename>ceph_conf</filename> in the &cephsalt;
+     config tool:
+    </para>
 <screen>&prompt.smaster;ceph-salt config /cephadm_bootstrap/ceph_conf add global</screen>
-     <para>
-       Set the following options:
-     </para>
+    <para>
+     Set the following options:
+    </para>
 <screen>&prompt.smaster;ceph-salt config /cephadm_bootstrap/ceph_conf/global set ms_cluster_mode "secure crc"
 &prompt.smaster;ceph-salt config /cephadm_bootstrap/ceph_conf/global set ms_service_mode "secure crc"
 &prompt.smaster;ceph-salt config /cephadm_bootstrap/ceph_conf/global set ms_client_mode "secure crc"
 </screen>
-     <note>
-       <para>
-         Ensure <literal>secure</literal> preceeds <literal>crc</literal>.
-       </para>
-     </note>
+    <note>
      <para>
-       To <emphasis>force</emphasis> <literal>secure</literal> mode, run the following commands:
+      Ensure <literal>secure</literal> preceeds <literal>crc</literal>.
      </para>
+    </note>
+    <para>
+     To <emphasis>force</emphasis> <literal>secure</literal> mode, run the
+     following commands:
+    </para>
 <screen>&prompt.smaster;ceph-salt config /cephadm_bootstrap/ceph_conf/global set ms_cluster_mode secure
 &prompt.smaster;ceph-salt config /cephadm_bootstrap/ceph_conf/global set ms_service_mode secure
 &prompt.smaster;ceph-salt config /cephadm_bootstrap/ceph_conf/global set ms_client_mode secure
 </screen>
-     <tip xml:id="update-inflight-encryption-settings">
-       <title>Updating Settings</title>
-       <para>
-         If you want to change any of the above settings, set
-         the configuration changes in the monitor configuration store. This is
-         achieved using the <command>ceph config set</command> command.
-       </para>
+    <tip xml:id="update-inflight-encryption-settings">
+     <title>Updating Settings</title>
+     <para>
+      If you want to change any of the above settings, set the configuration
+      changes in the monitor configuration store. This is achieved using the
+      <command>ceph config set</command> command.
+     </para>
 <screen>&prompt.smaster;ceph config set global <replaceable>CONNECTION_OPTION</replaceable> <replaceable>CONNECTION_MODE</replaceable> [--force]</screen>
-       <para>
-         For example:
-       </para>
+     <para>
+      For example:
+     </para>
 <screen>&prompt.smaster;ceph config set global ms_cluster_mode "secure crc"</screen>
-       <para>
-         If you want to check the current value, including default value, run
-         the following command:
-       </para>
+     <para>
+      If you want to check the current value, including default value, run the
+      following command:
+     </para>
 <screen>&prompt.smaster;ceph config get <replaceable>CEPH_COMPONENT</replaceable> <replaceable>CONNECTION_OPTION</replaceable></screen>
-       <para>
-         For example, to get the <literal>ms_cluster_mode</literal> for OSD's, run:
-       </para>
+     <para>
+      For example, to get the <literal>ms_cluster_mode</literal> for OSD's,
+      run:
+     </para>
 <screen>&prompt.smaster;ceph config get osd ms_cluster_mode</screen>
-     </tip>
+    </tip>
    </sect3>
-
    <sect3 xml:id="deploy-cephadm-enable-network">
     <title>Configure the Cluster Network</title>
     <para>
@@ -1086,9 +1086,10 @@ config: OK
    </para>
 <screen>&prompt.smaster;ceph-salt apply</screen>
    <note>
-     <para>
-       When bootstrapping is complete, the cluster will have one &mon; and one &mgr;.
-     </para>
+    <para>
+     When bootstrapping is complete, the cluster will have one &mon; and one
+     &mgr;.
+    </para>
    </note>
    <para>
     The above command will open an interactive user interface that shows the
@@ -1116,59 +1117,63 @@ config: OK
 <screen>&prompt.smaster;ceph-salt apply --non-interactive</screen>
    </tip>
   </sect2>
-  <sect2 xml:id="deploy-min-cluster-final-steps">
-    <title>Final Steps</title>
-    <para>
-      Once the <command>ceph-salt apply</command> command has completed,
-      you should have one &mon; and one &mgr;. You should be able to run
-      the <command>ceph status</command> command successfully on any of the
-      minions that were given the <literal>admin</literal> role, either as <literal>root</literal>
-      or the <literal>cephadm</literal> user.
-    </para>
-    <para>
-      The next steps involve using the &cephadm; to deploy additional &mon;,
-      &mgr;, OSDs, the Monitoring Stack, and Gateways.
-    </para>
-    <para>
-      Before you continue, review your new cluster's network settings. At this
-      point, the <literal>public_network</literal> setting has been populated
-      based on what was entered for <literal>/cephadm_bootstrap/mon_ip</literal>
-      in the <literal>ceph-salt</literal> configuration. However, this setting
-      was only applied to &mon;. You can review this setting with the following
-      command:
-    </para>
-<screen>&prompt.smaster;ceph config get mon public_network</screen>
-    <para>
-      This is the minimum that &ceph; requires to work, but we recommend
-      making this <literal>public_network</literal> setting <literal>global</literal>,
-      which means it will apply to all types of &ceph; daemons, and not just to MONs:
-    </para>
-<screen>&prompt.smaster;ceph config set global public_network "$(ceph config get mon public_network)"</screen>
-    <note>
-      <para>
-        This step is not required. However, if you do not use this setting, the
-        &ceph; OSDs and other daemons (except &mon;) will listen on <emphasis>all addresses</emphasis>.
-      </para>
-      <para>
-        If you want your OSDs to communicate amongst themselves using a
-        completely separate network, run the following command:
-      </para>
-<screen>&prompt.smaster;ceph config set global cluster_network "<replaceable>cluster_network_in_cidr_notation</replaceable>"</screen>
-      <para>
-        Executing this command will ensure that the OSDs created in your
-        deployment will use the intended cluster network from the start.
-      </para>
-    </note>
-  </sect2>
-</sect1>
 
+  <sect2 xml:id="deploy-min-cluster-final-steps">
+   <title>Final Steps</title>
+   <para>
+    Once the <command>ceph-salt apply</command> command has completed, you
+    should have one &mon; and one &mgr;. You should be able to run the
+    <command>ceph status</command> command successfully on any of the minions
+    that were given the <literal>admin</literal> role, either as
+    <literal>root</literal> or the <literal>cephadm</literal> user.
+   </para>
+   <para>
+    The next steps involve using the &cephadm; to deploy additional &mon;,
+    &mgr;, OSDs, the Monitoring Stack, and Gateways.
+   </para>
+   <para>
+    Before you continue, review your new cluster's network settings. At this
+    point, the <literal>public_network</literal> setting has been populated
+    based on what was entered for <literal>/cephadm_bootstrap/mon_ip</literal>
+    in the <literal>ceph-salt</literal> configuration. However, this setting
+    was only applied to &mon;. You can review this setting with the following
+    command:
+   </para>
+<screen>&prompt.smaster;ceph config get mon public_network</screen>
+   <para>
+    This is the minimum that &ceph; requires to work, but we recommend making
+    this <literal>public_network</literal> setting <literal>global</literal>,
+    which means it will apply to all types of &ceph; daemons, and not just to
+    MONs:
+   </para>
+<screen>&prompt.smaster;ceph config set global public_network "$(ceph config get mon public_network)"</screen>
+   <note>
+    <para>
+     This step is not required. However, if you do not use this setting, the
+     &ceph; OSDs and other daemons (except &mon;) will listen on <emphasis>all
+     addresses</emphasis>.
+    </para>
+    <para>
+     If you want your OSDs to communicate amongst themselves using a completely
+     separate network, run the following command:
+    </para>
+<screen>&prompt.smaster;ceph config set global cluster_network "<replaceable>cluster_network_in_cidr_notation</replaceable>"</screen>
+    <para>
+     Executing this command will ensure that the OSDs created in your
+     deployment will use the intended cluster network from the start.
+    </para>
+   </note>
+  </sect2>
+ </sect1>
  <sect1 xml:id="deploy-cephadm-day2">
   <title>Deploying Services and Gateways</title>
+
   <para>
-   After deploying the basic &ceph; cluster, deploy core
-   services to more cluster nodes. To make the cluster data accessible to
-   clients, deploy additional services as well.
+   After deploying the basic &ceph; cluster, deploy core services to more
+   cluster nodes. To make the cluster data accessible to clients, deploy
+   additional services as well.
   </para>
+
   <para>
    Currently, we support deployment of &ceph; services on the command line by
    using the &ceph; orchestrator (<command>ceph orch</command> subcommands).
@@ -1594,11 +1599,11 @@ placement:
      automatically deployed when you create the &cephfs;. To create a &cephfs;,
      first create MDS servers by applying the following specification:
     </para>
-     <note>
-      <para>
-        Ensure you have at least two pools, one for &cephfs; data and one for &cephfs;
-        metadata, created before applying the following specification.
-      </para>
+    <note>
+     <para>
+      Ensure you have at least two pools, one for &cephfs; data and one for
+      &cephfs; metadata, created before applying the following specification.
+     </para>
     </note>
 <screen>
 service_type: mds
@@ -1639,28 +1644,29 @@ spec:
   rgw_realm: <replaceable>RGW_REALM</replaceable>
   rgw_zone: <replaceable>RGW_ZONE</replaceable>
 </screen>
-  <sect4>
-   <title>Using Secure SSL Access</title>
-   <para>
-    To use a secure SSL connection to the &ogw;, you need a pair of valid SSL
-    certificate and key files (see <xref linkend="ceph-rgw-https"/> for more
-    details). You need to enable SSL, specify a port number for SSL
-    connections, and the SSL certificate and key files.
-   </para>
-   <para>
-     To enable SSL and specify the port number, include the following in your
-     specification:
-   </para>
+    <sect4>
+     <title>Using Secure SSL Access</title>
+     <para>
+      To use a secure SSL connection to the &ogw;, you need a pair of valid SSL
+      certificate and key files (see <xref linkend="ceph-rgw-https"/> for more
+      details). You need to enable SSL, specify a port number for SSL
+      connections, and the SSL certificate and key files.
+     </para>
+     <para>
+      To enable SSL and specify the port number, include the following in your
+      specification:
+     </para>
 <screen>
 spec:
   ssl: true
   rgw_frontend_port: 443
 </screen>
-   <para>
-    To specify the SSL certificate and key, you can paste their contents directly
-    into the YAML specification file. The pipe sign '|' at the end of line tells
-    the parser to expect a multi-line string as a value:
-   </para>
+     <para>
+      To specify the SSL certificate and key, you can paste their contents
+      directly into the YAML specification file. The pipe sign
+      (<literal>|</literal>) at the end of line tells the parser to expect a
+      multi-line string as a value. For example:
+     </para>
 <screen>
 spec:
   ssl: true
@@ -1678,28 +1684,28 @@ spec:
    [...]
    -----END PRIVATE KEY-----
 </screen>
-   <tip>
-    <para>
-     Instead of pasting the content of SSL certificate and key files, you can
-     omit the <literal>rgw_frontend_ssl_certificate:</literal> and
-     <literal>rgw_frontend_ssl_key:</literal> keywords and upload them to the
-     configuration database:
-    </para>
+     <tip>
+      <para>
+       Instead of pasting the content of SSL certificate and key files, you can
+       omit the <literal>rgw_frontend_ssl_certificate:</literal> and
+       <literal>rgw_frontend_ssl_key:</literal> keywords and upload them to the
+       configuration database:
+      </para>
 <screen>
 &prompt.cephuser;ceph config-key set rgw/cert/<replaceable>REALM_NAME</replaceable>/<replaceable>ZONE_NAME</replaceable>.crt \
  -i <replaceable>SSL_CERT_FILE</replaceable>
 &prompt.cephuser;ceph config-key set rgw/cert/<replaceable>REALM_NAME</replaceable>/<replaceable>ZONE_NAME</replaceable>.key \
  -i <replaceable>SSL_KEY_FILE</replaceable>
 </screen>
-   </tip>
-  </sect4>
-  <sect4>
-   <title>Deploying with a Subcluster</title>
-   <para>
-    <emphasis>Subclusters</emphasis> help you organize the nodes in your
-    clusters to isolate workloads and make elastic scaling easier. If you are
-    deploying with a subcluster, apply the following configuration:
-   </para>
+     </tip>
+    </sect4>
+    <sect4>
+     <title>Deploying with a Subcluster</title>
+     <para>
+      <emphasis>Subclusters</emphasis> help you organize the nodes in your
+      clusters to isolate workloads and make elastic scaling easier. If you are
+      deploying with a subcluster, apply the following configuration:
+     </para>
 <screen>
 service_type: rgw
 service_id: <replaceable>REALM_NAME</replaceable>.<replaceable>ZONE_NAME</replaceable>.<replaceable>SUBCLUSTER</replaceable>
@@ -1713,25 +1719,24 @@ spec:
   rgw_zone: <replaceable>RGW_ZONE</replaceable>
   subcluster: <replaceable>SUBCLUSTER</replaceable>
 </screen>
-  </sect4>
+    </sect4>
    </sect3>
    <sect3 xml:id="deploy-cephadm-day2-service-igw">
     <title>Deploy &igw;s</title>
     <para>
-      &cephadm; deploys an &igw; which is a storage area
-      network (SAN) protocol that allows clients (called
-      initiators) to send SCSI commands to SCSI storage devices
-      (targets) on remote servers.
+     &cephadm; deploys an &igw; which is a storage area network (SAN) protocol
+     that allows clients (called initiators) to send SCSI commands to SCSI
+     storage devices (targets) on remote servers.
     </para>
     <para>
-      Apply the following configuration to deploy. Ensure <literal>trusted_ip_list</literal>
-      contains the IP addresses of all &igw; and &mgr; nodes (see the
-      example output below).
+     Apply the following configuration to deploy. Ensure
+     <literal>trusted_ip_list</literal> contains the IP addresses of all &igw;
+     and &mgr; nodes (see the example output below).
     </para>
     <note>
-      <para>
-        Ensure the pool is created before applying the following specification.
-      </para>
+     <para>
+      Ensure the pool is created before applying the following specification.
+     </para>
     </note>
 <screen>
 service_type: iscsi

--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -1681,7 +1681,9 @@ spec:
    <tip>
     <para>
      Instead of pasting the content of SSL certificate and key files, you can
-     upload them to the configuration database:
+     omit the <literal>rgw_frontend_ssl_certificate:</literal> and
+     <literal>rgw_frontend_ssl_key:</literal> keywords and upload them to the
+     configuration database:
     </para>
 <screen>
 &prompt.cephuser;ceph config-key set rgw/cert/<replaceable>REALM_NAME</replaceable>/<replaceable>ZONE_NAME</replaceable>.crt \

--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -1659,7 +1659,7 @@ spec:
    <para>
     To specify the SSL certificate and key, you can paste their contents directly
     into the YAML specification file. The pipe sign '|' at the end of line tells
-    the parser to expect a multiline string as a value:
+    the parser to expect a multi-line string as a value:
    </para>
 <screen>
 spec:


### PR DESCRIPTION
* extends the original section on RGW deployment using YAML specs
* created 2 subsections to better organize the flow
* rendered version attached (scroll down to section 5.4.3.4)
[deploy-cephadm-day2_color_en.pdf](https://github.com/SUSE/doc-ses/files/5364630/deploy-cephadm-day2_color_en.pdf)
