### PR TITLE
Reflect #472 to JPN version

### DIFF
--- a/ja/xml/admin_saltcluster.xml
+++ b/ja/xml/admin_saltcluster.xml
@@ -611,7 +611,26 @@ Device Path Size rotates available Model name
    </step>
    <step>
     <para>
-     DeepSeaステージ1～5を実行します。
+     ceph.confをOSDノードにコピーし、OSDを有効化します。
+    </para>
+<screen>
+<prompt>root@master # </prompt>salt '<replaceable>osd_node</replaceable>' state.apply ceph.configuration
+<prompt>root@master # </prompt>salt '<replaceable>osd_node</replaceable>' cmd.run "ceph-volume lvm activate --all"
+</screen>
+   </step>
+   <step>
+    <para>
+     次のコマンドのうち1つを実行し、OSDが有効化されたことを確認します。
+    </para>
+<screen>
+<prompt>root@master # </prompt>ceph -s
+# OR
+<prompt>root@master # </prompt>ceph osd tree
+</screen>
+   </step>
+   <step>
+    <para>
+     クラスタ全体で整合性を保つため、DeepSeaステージを次の順序で実行します。
     </para>
 <screen>
 <prompt>root@master # </prompt>salt-run state.orch ceph.stage.1
@@ -619,6 +638,7 @@ Device Path Size rotates available Model name
 <prompt>root@master # </prompt>salt-run state.orch ceph.stage.3
 <prompt>root@master # </prompt>salt-run state.orch ceph.stage.4
 <prompt>root@master # </prompt>salt-run state.orch ceph.stage.5
+<prompt>root@master # </prompt>salt-run state.orch ceph.stage.0
 </screen>
    </step>
    <step>


### PR DESCRIPTION
[The procedure to recover a reinstalled OSD node](https://documentation.suse.com/ses/6/html/ses-all/storage-salt-cluster.html#ds-osd-recover) was updated with #472.
The present commit reflects this update to the Japanese document.