### PR TITLE
SES6: Remove literal in screen

### DIFF
--- a/xml/manager_modules.xml
+++ b/xml/manager_modules.xml
@@ -255,7 +255,7 @@
     <para>
      To add a contact and description to the report:
     </para>
-<screen>&prompt.cephuser;ceph config set mgr mgr/telemetry/contact ‘John Doe <literal>john.doe@example.com</literal>’
+<screen>&prompt.cephuser;ceph config set mgr mgr/telemetry/contact ‘John Doe john.doe@example.com’
 &prompt.cephuser;ceph config set mgr mgr/telemetry/description ‘My first Ceph cluster’</screen>
    </step>
    <step>


### PR DESCRIPTION
This PR just contains the following small fix for SES6:

* Remove the `<literal>` inside a `<screen>`.
   It's an unnecessary tag and isn't allowed in the upcoming GeekoDoc release. This makes it possible to stay compatible.
* No layout or further text changes.