### PR TITLE
iscsi: Update list of RBD features supported by kernel

### DIFF
--- a/xml/deployment_iscsi.xml
+++ b/xml/deployment_iscsi.xml
@@ -287,12 +287,20 @@
    </para>
    <note>
     <para>
-     Only the following RBD image features are supported:
-     <option>layering</option>, <option>striping (v2)</option>,
-     <option>exclusive-lock</option>, <option>fast-diff</option>, and
-     <option>data-pool</option>. RBD images with any other feature enabled
-     cannot be exported.
+     RBD images with the following properties cannot be exported via iSCSI:
     </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       images with the <option>journaling</option> feature enabled
+      </para>
+     </listitem>
+     <listitem>
+       <para>
+        images with a <option>stripe unit</option> less than 4096 bytes
+       </para>
+      </listitem>
+    </itemizedlist>
    </note>
    <para>
     As &rootuser;, enter the &igw; container:


### PR DESCRIPTION
In SLE15-SP2, the following features are now supported by kernel:

- 'RBD_FEATURE_OBJECT_MAP'
- 'RBD_FEATURE_FAST_DIFF'
- 'RBD_FEATURE_DEEP_FLATTEN',

This PR updates documentation accordingly.

Relates to: https://github.com/SUSE/ceph-iscsi/commit/a7b4d3884a6cc7b803ae6f086665da310359b011

Signed-off-by: Ricardo Marques <rimarques@suse.com>