### PR TITLE
troubleshooting_caasp_debugging_rook: Use set env for log level

### DIFF
--- a/xml/troubleshooting_caasp_debugging_rook.xml
+++ b/xml/troubleshooting_caasp_debugging_rook.xml
@@ -49,7 +49,7 @@
        chosen, the log level can always be set by editing the deployment
        directly with <command>kubectl</command>. For example:
      </para>
-<screen>&prompt.kubeuser;kubectl --namespace rook-ceph edit deployment rook-ceph-operator</screen>
+<screen>&prompt.kubeuser;kubectl --namespace rook-ceph set env deployment/rook-ceph-operator ROOK_LOG_LEVEL=DEBUG</screen>
      <para>
        After editing the deployment, the operator pod will restart automatically
        and will start outputting logs with the new log level.


### PR DESCRIPTION
That way, you don't have to edit the deployment manually but can just
execute the command and the deployment will be updated.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>