### PR TITLE
Add blank line to keyring sample

### DIFF
--- a/xml/windows-appendix.xml
+++ b/xml/windows-appendix.xml
@@ -43,13 +43,14 @@
    </para>
 <screen>
 ; This file should be copied directly from /etc/ceph/ceph.client.admin.keyring
-; The contents should be similar to the following example:
+; and must include a final blank line as in the following example:
 [client.admin]
     key = ADCyl77eBBAAABDDjX72tAljOwv04m121v/7yA==
     caps mds = "allow *"
     caps mon = "allow *"
     caps osd = "allow *"
     caps mgr = "allow *"
+
 </screen>
  </sect1>
  <sect1 xml:id="windows-appendix-b">


### PR DESCRIPTION
As reported by a user, the keyring file must contain a blank line
as the final line in the file. Update the comments and file contents
to reflect this.

Signed-off-by: Mike Latimer <mlatimer@suse.com>