### PR TITLE
Recommend 4GB as minimum MDS ram

### DIFF
--- a/xml/deployment_hwrecommend.xml
+++ b/xml/deployment_hwrecommend.xml
@@ -742,7 +742,7 @@
   <itemizedlist>
    <listitem>
     <para>
-     3&nbsp;GB of RAM for each &mds; daemon.
+     4&nbsp;GB of RAM for each &mds; daemon.
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
mds_cache_memory_limit defaults to 4GB