### PR TITLE
remove deactivate step

### DIFF
--- a/xml/admin_ceph_cephfs.xml
+++ b/xml/admin_ceph_cephfs.xml
@@ -300,51 +300,6 @@
     [...]
     mds: cephfs-1/1/1 up  {0=node2=up:active}, 1 up:standby
     [...]</screen>
-   <para>
-    Note that we still have two active MDSs. The ranks still exist even though
-    we have decreased <option>max_mds</option>, because
-    <option>max_mds</option> only restricts the creation of new ranks.
-   </para>
-   <para>
-    Next, use the <command>ceph mds deactivate
-    <replaceable>rank</replaceable></command> command to remove the unneeded
-    rank:
-   </para>
-<screen>&prompt.cephuser;<command>ceph</command> status
-  [...]
-  services:
-    [...]
-    mds: cephfs-2/2/1 up  {0=node2=up:active,1=node1=up:active}
-&prompt.cephuser;<command>ceph</command> mds deactivate 1
-telling mds.1:1 192.168.58.101:6805/2799214375 to deactivate
-
-&prompt.cephuser;<command>ceph</command> status
-  [...]
-  services:
-    [...]
-    mds: cephfs-2/2/1 up  {0=node2=up:active,1=node1=up:stopping}
-
-&prompt.cephuser;<command>ceph</command> status
-  [...]
-  services:
-    [...]
-    mds: cephfs-1/1/1 up  {0=node2=up:active}, 1 up:standby</screen>
-   <para>
-    The deactivated rank will first enter the stopping state, for a period of
-    time while it hands off its share of the metadata to the remaining active
-    daemons. This phase can take from seconds to minutes. If the MDS appears to
-    be stuck in the stopping state then that should be investigated as a
-    possible bug.
-   </para>
-   <para>
-    If an MDS daemon crashes or is terminated while in the 'stopping' state, a
-    standby will take over and the rank will go back to 'active'. You can try
-    to deactivate it again when it has come back up.
-   </para>
-   <para>
-    When a daemon finishes stopping, it will start again and go back to being a
-    standby.
-   </para>
   </sect2>
 
   <sect2 xml:id="cephfs-activeactive-pinning">


### PR DESCRIPTION
When decreasing the number of active MDS, deactivate is no longer needes. In fact to command no longer exists.