### PR TITLE
Add note regarding virtual .snap dir

### DIFF
--- a/xml/admin_ceph_cephfs.xml
+++ b/xml/admin_ceph_cephfs.xml
@@ -601,13 +601,20 @@ setfattr -n ceph.dir.pin -v 0 a/b # "a/b" is now pinned to rank 0
 </screen>
    <para>
     After you enable snapshots, all directories in the &cephfs; will have a
-    special <filename>.snap</filename> subdirectory. Note that this is a virtual subdirectory.
-    In other words this directory does not appear in the directory listing of the parent directory,
-    but the name <filename>.snap</filename> can not be used as a file or directory name.
-    To access the <filename>.snap</filename> directory one has to explicitly access it, for exmaple
+    special <filename>.snap</filename> subdirectory.
+  </para>
+    <note>
+      <para>
+        This is a <emphasis>virtual</emphasis> subdirectory. It does not appear in
+        the directory listing of the parent directory, but the name <filename>.snap</filename>
+        can not be used as a file or directory name. To access the <filename>.snap</filename>
+        directory one has to explicitly access it, for example:
+      </para>   
+    
 <screen>
 &prompt.user;ls -la /<replaceable>CEPHFS_MOUNT</replaceable>/.snap/
  </screen>
+    </note>
     in order to list all existing snapshots in a directory, call
    </para>
    <important>

--- a/xml/admin_ceph_cephfs.xml
+++ b/xml/admin_ceph_cephfs.xml
@@ -609,14 +609,11 @@ setfattr -n ceph.dir.pin -v 0 a/b # "a/b" is now pinned to rank 0
         the directory listing of the parent directory, but the name <filename>.snap</filename>
         can not be used as a file or directory name. To access the <filename>.snap</filename>
         directory one has to explicitly access it, for example:
-      </para>   
-    
+      </para>    
 <screen>
 &prompt.user;ls -la /<replaceable>CEPHFS_MOUNT</replaceable>/.snap/
  </screen>
     </note>
-    in order to list all existing snapshots in a directory, call
-   </para>
    <important>
     <title>Kernel clients limitation</title>
     <para>

--- a/xml/admin_ceph_cephfs.xml
+++ b/xml/admin_ceph_cephfs.xml
@@ -601,7 +601,14 @@ setfattr -n ceph.dir.pin -v 0 a/b # "a/b" is now pinned to rank 0
 </screen>
    <para>
     After you enable snapshots, all directories in the &cephfs; will have a
-    special <filename>.snap</filename> subdirectory.
+    special <filename>.snap</filename> subdirectory. Note that this is a virtual subdirectory.
+    In other words this directory does not appear in the directory listing of the parent directory,
+    but the name <filename>.snap</filename> can not be used as a file or directory name.
+    To access the <filename>.snap</filename> directory one has to explicitly access it, for exmaple
+<screen>
+&prompt.user;ls -la /<replaceable>CEPHFS_MOUNT</replaceable>/.snap/
+ </screen>
+    in order to list all existing snapshots in a directory, call
    </para>
    <important>
     <title>Kernel clients limitation</title>

--- a/xml/admin_ceph_cephfs.xml
+++ b/xml/admin_ceph_cephfs.xml
@@ -607,7 +607,7 @@ setfattr -n ceph.dir.pin -v 0 a/b # "a/b" is now pinned to rank 0
       <para>
         This is a <emphasis>virtual</emphasis> subdirectory. It does not appear in
         the directory listing of the parent directory, but the name <filename>.snap</filename>
-        can not be used as a file or directory name. To access the <filename>.snap</filename>
+        cannot be used as a file or directory name. To access the <filename>.snap</filename>
         directory one has to explicitly access it, for example:
       </para>    
 <screen>
@@ -615,7 +615,7 @@ setfattr -n ceph.dir.pin -v 0 a/b # "a/b" is now pinned to rank 0
  </screen>
     </note>
    <important>
-    <title>Kernel clients limitation</title>
+    <title>Kernel Clients Limitation</title>
     <para>
      &cephfs; kernel clients have a limitation: they cannot handle more than 400
      snapshots in a filesystem. The number of snapshots should always be


### PR DESCRIPTION
The name .snap being absent from a dir listing has confused users in the past.