### PR TITLE
Remove outdated rbd-mirror-daemon section

### DIFF
--- a/xml/admin_rbd.xml
+++ b/xml/admin_rbd.xml
@@ -1396,43 +1396,6 @@ SCHEDULE TIME       IMAGE
     </para>
    </tip>
   </sect2>
-
-  <sect2 xml:id="rbd-mirror-daemon">
-   <title>&rbdmirror; Daemon</title>
-   <para>
-    The two &rbdmirror; daemons are responsible for watching image journals on
-    the <literal>remote</literal> peer cluster and replaying the journal events
-    against the <literal>local</literal> cluster. The RBD image journaling
-    feature records all modifications to the image in the order they occur.
-    This ensures that a crash-consistent mirror of the remote image is
-    available locally.
-   </para>
-   <important>
-    <para>
-     Each &rbdmirror; daemon requires the ability to connect to both clusters
-     simultaneously.
-    </para>
-   </important>
-   <para>
-    Each &rbdmirror; daemon should use a unique &ceph; user ID. To create a
-    &ceph; user, use the <command>ceph auth get-or-create</command> command,
-    followed by a user name, monitor caps, and OSD caps:
-   </para>
-<screen>&prompt.cephuser;ceph auth get-or-create client.rbd-mirror.<replaceable>UNIQUE-ID</replaceable> mon 'profile rbd-mirror' osd 'profile rbd'</screen>
-   <para>
-    The &rbdmirror; daemon can be managed by &systemd; by specifying the user
-    ID as the daemon instance. To identify the unique FSID of the cluster, run
-    <command>ceph fsid</command>. To identify the &rbdmirror; daemon name, run
-    <command>ceph orch ps ---hostname
-    <replaceable>HOSTNAME</replaceable></command>.
-   </para>
-<screen>&prompt.sminion;systemctl enable ceph-<replaceable>FSID</replaceable>@<replaceable>DAEMON_NAME</replaceable></screen>
-   <para>
-    The <command>rbd-mirror</command> can also be run in foreground by
-    <command>rbd-mirror</command> command:
-   </para>
-<screen>&prompt.cephuser;rbd-mirror -f --log-file=<replaceable>LOG-PATH</replaceable></screen>
-  </sect2>
  </sect1>
  <sect1 xml:id="rbd-cache-settings">
   <title>Cache Settings</title>


### PR DESCRIPTION
Closes #779

This is because this section has been superceded by: https://documentation.suse.com/ses/7/single-html/ses-deployment/#deploy-cephadm-day2-service-rbdmirror