### PR TITLE
Add section on querying the default container images

### DIFF
--- a/xml/bp_troubleshooting_cephadm.xml
+++ b/xml/bp_troubleshooting_cephadm.xml
@@ -118,8 +118,59 @@ systemctl status "ceph-$(cephadm shell ceph fsid)@<replaceable>service name</rep
   done
 </screen>
  </sect1>
- <sect1 xml:id="bp-troubleshooting-cephadm-container-images">
-   <title>List all Downloaded Container Images</title>
+ <sect1 xml:id="bp-troubleshooting-cephadm-configured-container-images">
+   <title>List Configured Container Images</title>
+   <para>
+     &cephadm; has a set of container images configured by default.
+   </para>
+   <para>
+     To get the value of the configured default container:
+   </para>
+<screen>&prompt.cephuser;ceph config get mgr mgr/cephadm/<replaceable>OPTION_NAME</replaceable></screen>
+   <para>
+     Where <replaceable>OPTION_NAME</replaceable> is any of the following names:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+       container_image_base
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+       container_image_prometheus
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+       container_image_node_exporter
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+       container_image_alertmanager
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+       container_image_grafana
+     </para>
+    </listitem>
+   </itemizedlist>
+   <para>
+     For example:
+   </para>
+<screen>
+  &prompt.cephuser;ceph config get mgr mgr/cephadm/container_image_base
+  registry.suse.com/ses/7/ceph/ceph
+</screen>
+   <note>
+     <para>
+       <literal>mgr/cephadm/container_image_base</literal> is the default &ceph; conatiner image used by all services except the monitoring stack
+     </para>
+   </note>
+ </sect1>
+ <sect1 xml:id="bp-troubleshooting-cephadm-downloaded-container-images">
    <title>List All Downloaded Container Images</title>
    <para>
      To list all container images that are downloaded on a host:

--- a/xml/bp_troubleshooting_cephadm.xml
+++ b/xml/bp_troubleshooting_cephadm.xml
@@ -120,6 +120,7 @@ systemctl status "ceph-$(cephadm shell ceph fsid)@<replaceable>service name</rep
  </sect1>
  <sect1 xml:id="bp-troubleshooting-cephadm-container-images">
    <title>List all Downloaded Container Images</title>
+   <title>List All Downloaded Container Images</title>
    <para>
      To list all container images that are downloaded on a host:
    </para>


### PR DESCRIPTION
Add section to the cephadm troubleshooting guide on how to query the
list of default container images (BNC#1177102)

Signed-off-by: Michael Fritch <mfritch@suse.com>