### PR TITLE
windows: Fix capitalization of Dokany

### DIFF
--- a/xml/windows-ses.xml
+++ b/xml/windows-ses.xml
@@ -65,7 +65,7 @@
    </para>
    <para>
      &cephfs; functionality requires a third party FUSE wrapper provided
-     through the <link xlink:href="https://github.com/dokan-dev/dokany">dokany project</link>.
+     through the <link xlink:href="https://github.com/dokan-dev/dokany">Dokany project</link>.
      This functionality should be considered experimental, and is not
      recommended for production use.
    </para>


### PR DESCRIPTION
The upstream Dokany project is capitalized, so we should
use that in our docs as well.

Signed-off-by: Mike Latimer <mlatimer@suse.com>