### PR TITLE
Get proper balancer status output

### DIFF
--- a/xml/manager_modules.xml
+++ b/xml/manager_modules.xml
@@ -64,7 +64,7 @@
    <para>
     To view the current balancer configuration, run:
    </para>
-<screen>&prompt.cephuser;ceph config-key dump</screen>
+<screen>&prompt.cephuser;ceph balancer status</screen>
   </tip>
 
   <sect2 xml:id="mgr-balancer-crush-compat">


### PR DESCRIPTION
To get the balancer configuration the correct command should be `ceph balancer status` since what is returned with `ceph config-key dump` is much more than just the balancer configuration and is confusing if one is only looking for the balancer specific information.