### PR TITLE
Fixing typo: "zypper migrate" -> "zypper migration"

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -313,7 +313,7 @@
      <listitem>
       <para>
        For cluster whose all nodes are registered with SCC, run <command>zypper
-       migrate</command>.
+       migration</command>.
       </para>
      </listitem>
      <listitem>
@@ -439,7 +439,7 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
      <listitem>
       <para>
        If the cluster's nodes are all registered with SCC, run <command>zypper
-       migrate</command>.
+       migration</command>.
       </para>
      </listitem>
      <listitem>


### PR DESCRIPTION
The command `zypper migrate` does not exist, `zypper migration` is correct.