### PR TITLE
cephadm user needs sudo

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -1129,8 +1129,8 @@ config: OK
     Once the <command>ceph-salt apply</command> command has completed, you
     should have one &mon; and one &mgr;. You should be able to run the
     <command>ceph status</command> command successfully on any of the minions
-    that were given the <literal>admin</literal> role, either as
-    <literal>root</literal> or the <literal>cephadm</literal> user.
+    that were given the <literal>admin</literal> role as
+    <literal>root</literal> or the <literal>cephadm</literal> user using <literal>sudo</literal>.
    </para>
    <para>
     The next steps involve using the &cephadm; to deploy additional &mon;,


### PR DESCRIPTION
By default, the cephadm user can not execute ceph commands, it is configured to execute the commands using sudo via the "/etc/sudoers.d/ceph-salt" file.