### PR TITLE
deployment_smb: recommend kernel backed shares

### DIFF
--- a/xml/deployment_cifs.xml
+++ b/xml/deployment_cifs.xml
@@ -113,6 +113,25 @@
   smbd: backgroundqueue = no
 
 [<replaceable>SHARE_NAME</replaceable>]
+  path = <replaceable>CEPHFS_MOUNT</replaceable>
+  read only = no
+  oplocks = no
+  kernel share modes = no
+ </screen>
+     <para>
+      The <replaceable>CEPHFS_MOUNT</replaceable> path above must be mounted
+      prior to starting &samba; with a kernel &cephfs; share configuration. See
+      <xref linkend="ceph-cephfs-cephfs-fstab"/>.
+     </para>
+     <para>
+     The above share configuration uses the Linux kernel &cephfs; client, which
+     is recommended for performance reasons. As an alternative, the &samba;
+     <systemitem>vfs_ceph</systemitem> module can also be used to communicate
+     with the &ceph; cluster. The instructions are shown below for legacy
+     purposes and are not recommended for new &samba; deployments:
+     </para>
+<screen>
+[<replaceable>SHARE_NAME</replaceable>]
   path = /
   vfs objects = ceph
   ceph: config_file = /etc/ceph/ceph.conf
@@ -120,26 +139,7 @@
   read only = no
   oplocks = no
   kernel share modes = no
- </screen>
-     <para>
-      The above share configuration uses the <systemitem>vfs_ceph</systemitem>
-      module for &samba; to communicate with the &ceph; cluster. As a
-      higher-performing but less-flexible alternative, &samba; can instead be
-      configured to use the Linux kernel &cephfs; client, as shown below:
-     </para>
-<screen>
-[<replaceable>SHARE_NAME</replaceable>]
-  path = <replaceable>CEPHFS_MOUNT</replaceable>
-  # "vfs objects = ceph" and "ceph: config_file / user_id" are dropped
-  read only = no
-  oplocks = no
-  kernel share modes = no
 </screen>
-     <para>
-      The <replaceable>CEPHFS_MOUNT</replaceable> path above must be mounted
-      prior to starting &samba; with a kernel &cephfs; share configuration. See
-      <xref linkend="ceph-cephfs-cephfs-fstab"/>.
-     </para>
      <tip>
       <title>Oplocks and share modes</title>
       <para>


### PR DESCRIPTION
Performance and resource consumption benefits make CephFS kernel backed
shares desirable. Retain vfs_ceph instructions for legacy purposes.
(jsc#SES-2215).