### PR TITLE
SES7: Add docs about newly introduced GRAFANA_FRONTEND_API_URL setting

### DIFF
--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -70,9 +70,9 @@
  </para>
  <para>
   By default, traffic to &grafana; is encrypted with TLS. You can either supply
-  your own TLS certificate or use a self-signed one. A self-signed certificate
-  is automatically created and configured for &grafana; if no custom certificate
-  has been configured before &grafana; has been deployed.
+  your own TLS certificate or use a self-signed one. If no custom certificate
+  has been configured before &grafana; has been deployed, then a self-signed
+  certificate is automatically created and configured for &grafana;.
  </para>
  <para>
   Custom certificates for &grafana; can be configured using the following

--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -44,7 +44,7 @@
   <listitem>
    <para>
     <emphasis role="bold">&grafana;</emphasis> is the visualization and
-    alerting software. The alerting functionality of Grafana is not utilized by
+    alerting software. The alerting functionality of &grafana; is not utilized by
     this monitoring stack. For alerting, the Alertmanager is used.
    </para>
   </listitem>
@@ -71,8 +71,8 @@
  <para>
   By default, traffic to &grafana; is encrypted with TLS. You can either supply
   your own TLS certificate or use a self-signed one. A self-signed certificate
-  is automatically created and configured for Grafana if no custom certificate
-  has been configured before Grafana has been deployed.
+  is automatically created and configured for &grafana; if no custom certificate
+  has been configured before &grafana; has been deployed.
  </para>
  <para>
   Custom certificates for &grafana; can be configured using the following
@@ -86,7 +86,7 @@
   The &alertmanager; handles alerts sent by the &prometheus; server. It takes
   care of deduplicating, grouping, and routing them to the correct receiver.
   Alerts can be silenced using the &alertmanager;, but silences can also be
-  managed using the Ceph Dashboard.
+  managed using the &dashboard;.
  </para>
  <para>
   We recommend that the <systemitem class="daemon">Node exporter</systemitem>

--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -212,6 +212,55 @@
 &prompt.cephuser;ceph mgr module disable prometheus
       </screen>
  </sect1>
+ <sect1 xml:id="monitoring-grafana-config">
+  <title>Configuring &grafana;</title>
+
+  <para>
+    The &dashboard; backend requires the &grafana; URL to be able to verify the
+    existence of &grafana; Dashboards before the frontend even loads them. Due to
+    the nature of how &grafana; is implemented in &dashboard;, this means that
+    two working connections are required in order to be able to see &grafana;
+    graphs in &dashboard;:
+  </para>
+
+  <itemizedlist>
+    <listitem>
+      <para>
+        The backend (&ceph; MGR module) needs to verify the existence of the
+        requested graph. If this request succeeds, it lets the frontend know
+        that it can safely access &grafana;.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        The frontend then requests the &grafana; graphs directly from the user's
+        browser using an <literal>iframe</literal>. The &grafana; instance is
+        accessed directly without any detour through &dashboard;.
+      </para>
+    </listitem>
+  </itemizedlist>
+
+  <para>
+    Now, it might be the case that your environment makes it difficult for the
+    user's browser to directly access the URL configured in &dashboard;. To
+    solve this issue, a separate URL can be configured which will solely be used
+    to tell the frontend (the user's browser) which URL it should use to access
+    &grafana;.
+  </para>
+
+  <para>
+    To change the URL that is returned to the frontend issue the following command:
+  </para>
+
+<screen>&prompt.cephuser;ceph dashboard set-grafana-frontend-api-url <replaceable>GRAFANA-SERVER-URL</replaceable></screen>
+
+  <para>
+    If no value is set for that option, it will simply fall back to the value of
+    the <replaceable>GRAFANA_API_URL</replaceable> option, which is set
+    automatically and periodically updated by &cephadm;. If set, it will instruct the
+    browser to use this URL to access &grafana;.
+  </para>
+ </sect1>
  <sect1 xml:id="monitoring-cephadm-config">
   <title>Configuring the &prometheusmgr;</title>
 


### PR DESCRIPTION
Add section about newly added GRAFANA_FRONTEND_API_URL to be able to
configure Grafana so that it can be reached when the Grafana users are
in a different DNS zone than the Ceph Dashboard back-end.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1176390

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>