### PR TITLE
Add ability to build docs from non-SUSE distros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,8 @@
 *.orig
 *.swp
 
+# when working with docker
+.viminfo
+.bash_history
+
 build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM opensuse/leap
+RUN zypper -n in sudo tar daps
+RUN useradd -m user && \
+    echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+USER user
+WORKDIR /home/user

--- a/README.adoc
+++ b/README.adoc
@@ -74,3 +74,10 @@ sudo /sbin/OneClickInstallUI https://gitlab.nue.suse.com/susedoc/doc-ymp/raw/mas
 ** `$ daps -d DC-<YOUR_BOOK> html`: Build multi-page HTML document
 ** `$ daps -d DC-<YOUR_BOOK> optipng`: Always optimize new PNG images
 ** Learn more at https://opensuse.github.io/daps
+* To contribute from a non-SUSE distribution, you can use the provided
+  Dockerfile/docker-compose.yml files.
+* Using DAPS from Docker is similarly easy:
+** `$ docker-compose run daps -d DC-<YOUR_BOOK> validate`: Make sure what you have written is
+    well-formed XML and valid DocBook 5
+** `$ docker-compose run daps -d DC-<YOUR_BOOK> pdf`: Build a PDF document
+** `$ docker-compose run daps -d DC-<YOUR_BOOK> html`: Build multi-page HTML document

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.4'
+
+services:
+  daps:
+    build:
+      context: .
+      network: host
+    container_name: daps
+    hostname: daps
+    network_mode: host
+    tty: true
+    stdin_open: true
+    volumes:
+      - type: bind
+        source: .
+        target: /home/user
+    entrypoint: daps


### PR DESCRIPTION
I know that there was a Dockerfile once, but it has been removed (not sure why, I used it [rarely]). Since then I've had to rely on these files. Furthermore, I always have to cherry pick those changes into my working branch to be able to create the documentation. As I don't use a SUSE distribution, this is the only way for me to check my work locally. Surely, `daps` is available on various distros (like Ubuntu) but it does not contain the also required styling package `suse-xsl-stylesheets`, which, by the way, also cannot be simply copied to Ubuntu to make daps work on these docs. So, in the hope that things get easier for me but will also enable every interesting party, independent of the distribution used, to check code locally before submitting a pull request, I created this pull request.

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>