### PR TITLE
SES6: Add docs about newly introduced GRAFANA_FRONTEND_API_URL setting

### DIFF
--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -130,10 +130,11 @@
     </itemizedlist>
     <para>
       The &dashboard; embeds the &grafana; dashboards via HTML <literal>iframe</literal>
-      elements. If &grafana; is configured without SSL/TLS support or if SSL
-      uses self-signed certificates, most browsers will block the embedding of
-      insecure content into a secured web page if the SSL support in the
-      dashboard has been enabled (which is the default configuration). If you
+      elements. If &grafana; is configured without SSL/TLS support, or if SSL
+      is using self-signed certificates, and if the SSL support in the dashboard
+      has been enabled (which is the default configuration), then most
+      browsers will block the embedding of insecure content into a secured web page.
+      If you
       can not see the embedded &grafana; dashboards in &dashboard;,
       check your browser's documentation on how to unblock mixed content
       or how to accept self-signed certificates. Alternatively, consider

--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -161,7 +161,7 @@
   <itemizedlist>
     <listitem>
       <para>
-        The backend (Ceph Mgr module) needs to verify the existence of the
+        The backend (&mgr; module) needs to verify the existence of the
         requested graph. If this request succeeds, it lets the frontend know
         that it can safely access &grafana;.
       </para>

--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -168,7 +168,7 @@
     <listitem>
       <para>
         The frontend then requests the &grafana; graphs directly from the user's
-        browser using an iframe. The &grafana; instance is accessed directly
+        browser using an <literal>iframe</literal>. The &grafana; instance is accessed directly
         without any detour through &dashboard;.
       </para>
     </listitem>

--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -142,10 +142,10 @@
       issued by a certificate authority (CA) known to the browser.
     </para>
     <para>For more information on supplying your own SSL certificates,
-      see <xref linkend="cert-sign-CA"/>, for generating a self-signed or trusted
-      third-party certificate using OpenSSL, see <xref linkend="self-sign-certificates-openssl"/>,
-      for creating your own CA signed certificate, see <xref linkend="self-sign-certificates"/>,
-      and for creating your own custom CA signed certificate, see
+      see <xref linkend="cert-sign-CA"/>. For generating a self-signed or trusted
+      third-party certificate using OpenSSL, see <xref linkend="self-sign-certificates-openssl"/>.
+      For creating your own CA-signed certificate, see <xref linkend="self-sign-certificates"/>.
+      For creating your own custom CA signed certificate, see
       <xref linkend="cert-sign-custom-CA"/>.
     </para>
   </sect2>

--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -110,41 +110,87 @@
 
 <sect1 xml:id="grafana">
   <title>&grafana;</title>
+  <sect2 xml:id="grafana-certs">
+    <title>&grafana; SSL/TLS certificates</title>
+    <para>
+      All traffic is encrypted through &grafana;. You can either supply your
+      own SSL certs or create self-signed one.</para>
+    <para>&grafana; uses the following variables:</para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          <emphasis role="bold"><literal>ssl_cert</literal></emphasis>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis role="bold"><literal>ssl_key</literal></emphasis>
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      The &dashboard; embeds the &grafana; dashboards via HTML <literal>iframe</literal>
+      elements. If &grafana; is configured without SSL/TLS support or if SSL
+      uses self-signed certificates, most browsers will block the embedding of
+      insecure content into a secured web page if the SSL support in the
+      dashboard has been enabled (which is the default configuration). If you
+      can not see the embedded &grafana; dashboards in &dashboard;,
+      check your browser's documentation on how to unblock mixed content
+      or how to accept self-signed certificates. Alternatively, consider
+      enabling SSL/TLS support in &grafana;, using a certificate that is
+      issued by a certificate authority (CA) known to the browser.
+    </para>
+    <para>For more information on supplying your own SSL certificates,
+      see <xref linkend="cert-sign-CA"/>, for generating a self-signed or trusted
+      third-party certificate using OpenSSL, see <xref linkend="self-sign-certificates-openssl"/>,
+      for creating your own CA signed certificate, see <xref linkend="self-sign-certificates"/>,
+      and for creating your own custom CA signed certificate, see
+      <xref linkend="cert-sign-custom-CA"/>.
+    </para>
+  </sect2>
+  <sect2 xml:id="grafana-url">
+  <title>Configuring &grafana; frontend URL</title>
   <para>
-    All traffic is encrypted through &grafana;. You can either supply your
-    own SSL certs or create self-signed one.</para>
-  <para>&grafana; uses the following variables:</para>
+    The &dashboard; backend requires the &grafana; URL to be able to verify the
+    existence of &grafana; dashboards before the frontend even loads them. Due to
+    the nature of how &grafana; is implemented in &dashboard;, this means that
+    two working connections are required in order to be able to see &grafana;
+    graphs in &dashboard;:
+  </para>
   <itemizedlist>
     <listitem>
       <para>
-        <emphasis role="bold"><literal>ssl_cert</literal></emphasis>
+        The backend (Ceph Mgr module) needs to verify the existence of the
+        requested graph. If this request succeeds, it lets the frontend know
+        that it can safely access &grafana;.
       </para>
     </listitem>
     <listitem>
       <para>
-        <emphasis role="bold"><literal>ssl_key</literal></emphasis>
+        The frontend then requests the &grafana; graphs directly from the user's
+        browser using an iframe. The &grafana; instance is accessed directly
+        without any detour through &dashboard;.
       </para>
     </listitem>
   </itemizedlist>
   <para>
-    The &dashboard; embeds the &grafana; dashboards via HTML <literal>iframe</literal>
-    elements. If &grafana; is configured without SSL/TLS support or if SSL
-    uses self-signed certificates, most browsers will block the embedding of
-    insecure content into a secured web page if the SSL support in the
-    dashboard has been enabled (which is the default configuration). If you
-    can not see the embedded &grafana; dashboards in &dashboard;,
-    check your browser's documentation on how to unblock mixed content
-    or how to accept self-signed certificates. Alternatively, consider
-    enabling SSL/TLS support in &grafana;, using a certificate that is
-    issued by a certificate authority (CA) known to the browser.
+    Now, it might be the case that your environment makes it difficult for the
+    user's browser to directly access the URL configured in &dashboard;. To
+    solve this issue, a separate URL can be configured which will solely be used
+    to tell the frontend (the user's browser) which URL it should use to access
+    &grafana;.
   </para>
-  <para>For more information on supplying your own SSL certificates,
-    see <xref linkend="cert-sign-CA"/>, for generating a self-signed or trusted
-    third-party certificate using OpenSSL, see <xref linkend="self-sign-certificates-openssl"/>,
-    for creating your own CA signed certificate, see <xref linkend="self-sign-certificates"/>,
-    and for creating your own custom CA signed certificate, see
-    <xref linkend="cert-sign-custom-CA"/>.
+  <para>
+    To change the URL that is returned to the frontend issue the following command:
   </para>
+<screen>&prompt.cephuser;ceph dashboard set-grafana-frontend-api-url <replaceable>GRAFANA-SERVER-URL</replaceable></screen>
+  <para>
+    If no value is set for that option, it will simply fall back to the value of
+    the <replaceable>GRAFANA_API_URL</replaceable> option, which is set
+    automatically by &deepsea;. If set, it will instruct the browser to use this
+    URL to access &grafana;.
+  </para>
+  </sect2>
 </sect1>
 
  <sect1 xml:id="prometheus">


### PR DESCRIPTION
Add section about newly added GRAFANA_FRONTEND_API_URL to be able to
configure Grafana so that it can be reached when the Grafana users are
in a different DNS zone than the Ceph Dashboard back-end.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1176390

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>