### PR TITLE
Updates to troubleshooting guide from upstream docs (#885)

### DIFF
--- a/xml/bp_troubleshooting_cephadm.xml
+++ b/xml/bp_troubleshooting_cephadm.xml
@@ -484,4 +484,59 @@ Failed to connect to node5 (node5.example.com).
    <xref linkend="deploy-os"/> for more details.
   </para>
  </sect1>
+ <sect1 xml:id="bp-troubleshooting-unmanaged-daemons">
+  <title>Disabling automatic deployment of daemons</title>
+
+  <para>
+   By default, &ceph; daemons are automatically deployed to new hosts after you
+   add these host to the placement specification and apply it (refer to
+   <xref linkend="deploy-cephadm-day2"/> for more details).
+  </para>
+
+  <para>
+   If you need to disable the automated deployment of &ceph; daemons, add
+   <literal>unmanaged: true</literal> to its specification and apply it, for
+   example:
+  </para>
+
+<screen>
+cat mgr.yaml
+service_type: mgr
+unmanaged: true
+placement:
+  label: mgr
+[...]
+
+&prompt.cephuser;ceph orch apply -i mgr.yaml
+</screen>
+
+  <para>
+   After applying this specification, &cephadm; will no longer deploy any new
+   daemons on hosts that match the placement specification.
+  </para>
+
+  <para>
+   To manually deploy a daemon on a new host, run:
+  </para>
+
+<screen>ceph orch daemon add <replaceable>DAEMON_TYPE</replaceable> --placement=<replaceable>PLACEMENT_SPEC</replaceable></screen>
+
+  <para>
+   For example:
+  </para>
+
+<screen>&prompt.cephuser;ceph orch daemon add mgr --placement=ses-min3</screen>
+
+  <para>
+   To manually remove a daemon, run:
+  </para>
+
+<screen>ceph orch daemon rm <replaceable>DAEMON_NAME</replaceable> [--force]</screen>
+
+  <para>
+   For example:
+  </para>
+
+<screen>&prompt.cephuser;ceph orch daemon rm mgr.ses-min3.xietsy</screen>
+ </sect1>
 </chapter>

--- a/xml/bp_troubleshooting_cephadm.xml
+++ b/xml/bp_troubleshooting_cephadm.xml
@@ -495,7 +495,7 @@ Failed to connect to node5 (node5.example.com).
 
   <para>
    If you need to disable the automated deployment of &ceph; daemons, add
-   <literal>unmanaged: true</literal> to its specification and apply it, for
+   <literal>unmanaged: true</literal> to its specification file and apply it, for
    example:
   </para>
 

--- a/xml/bp_troubleshooting_cephadm.xml
+++ b/xml/bp_troubleshooting_cephadm.xml
@@ -489,7 +489,7 @@ Failed to connect to node5 (node5.example.com).
 
   <para>
    By default, &ceph; daemons are automatically deployed to new hosts after you
-   add these host to the placement specification and apply it (refer to
+   add these hosts to the placement specification and apply it (refer to
    <xref linkend="deploy-cephadm-day2"/> for more details).
   </para>
 

--- a/xml/bp_troubleshooting_logging.xml
+++ b/xml/bp_troubleshooting_logging.xml
@@ -1491,7 +1491,7 @@ debug mds balancer = 1/20
   <title>Per-service and per-daemon events</title>
 
   <para>
-   In order to simplify debugging deployments of failed daemons, &cephadm;
+   In order to simplify debugging failed daemon deployments, &cephadm;
    stores events on a per-service and per-daemon basis. To view the list of
    events for a specific <emphasis>service</emphasis>, run the following
    example command:

--- a/xml/bp_troubleshooting_logging.xml
+++ b/xml/bp_troubleshooting_logging.xml
@@ -1327,8 +1327,8 @@ debug mds balancer = 1/20
      <term><literal>rgw log object name</literal></term>
      <listitem>
       <para>
-       Description: Should an object’s name be logged. // man date to see
-       codes (a subset are supported)
+       Description: Should an object’s name be logged. // man date to see codes
+       (a subset are supported)
       </para>
       <para>
        Type: String
@@ -1486,5 +1486,47 @@ debug mds balancer = 1/20
   </para>
 
 <screen>&prompt.root;echo "file fs/ceph/snap.c -p" > /sys/kernel/debug/dynamic_debug/control</screen>
+ </sect1>
+ <sect1 xml:id="logging-service-daemons-events">
+  <title>Per-service and per-daemon events</title>
+
+  <para>
+   In order to simplify debugging deployments of failed daemons, &cephadm;
+   stores events on a per service and per daemon basis. To view the list of
+   events for a specific <emphasis>service</emphasis>, run the following
+   example command:
+  </para>
+
+<screen>
+&prompt.cephuser;ceph orch ls --service_name=<replaceable>alertmanager</replaceable> --format yaml
+  service_type: alertmanager
+  service_name: alertmanager
+  placement:
+    hosts:
+    - unknown_host
+[...]
+  events:
+  - 2021-02-01T08:58:02.741162 service:alertmanager [INFO] "service was created"
+  - 2021-02-01T12:09:25.264584 service:alertmanager [ERROR] "Failed to apply: \
+   Cannot place &lt;AlertManagerSpec for service_name=alertmanager> on \
+   unknown_host: Unknown hosts"'
+</screen>
+
+  <para>
+   To view the list of events for a specific <emphasis>daemon</emphasis>, run
+   the following example command:
+  </para>
+
+<screen>
+&prompt.cephuser;ceph orch ceph --service-type <replaceable>mds</replaceable> \
+ --daemon-id=<replaceable>hostname.ppdhsz</replaceable> --format yaml
+  daemon_type: mds
+  daemon_id: cephfs.hostname.ppdhsz
+  hostname: hostname
+[...]
+  events:
+  - 2021-02-01T08:59:43.845866 daemon:mds.cephfs.hostname.ppdhsz [INFO] \
+   "Reconfigured mds.cephfs.hostname.ppdhsz on host 'hostname'"
+</screen>
  </sect1>
 </chapter>

--- a/xml/bp_troubleshooting_logging.xml
+++ b/xml/bp_troubleshooting_logging.xml
@@ -1492,7 +1492,7 @@ debug mds balancer = 1/20
 
   <para>
    In order to simplify debugging deployments of failed daemons, &cephadm;
-   stores events on a per service and per daemon basis. To view the list of
+   stores events on a per-service and per-daemon basis. To view the list of
    events for a specific <emphasis>service</emphasis>, run the following
    example command:
   </para>
@@ -1513,8 +1513,8 @@ debug mds balancer = 1/20
 </screen>
 
   <para>
-   To view the list of events for a specific <emphasis>daemon</emphasis>, run
-   the following example command:
+   As opposed to a specific service, to view the list of events for a specific
+   <emphasis>daemon</emphasis>, for example,  run the following command:
   </para>
 
 <screen>

--- a/xml/bp_troubleshooting_monitors.xml
+++ b/xml/bp_troubleshooting_monitors.xml
@@ -37,11 +37,12 @@
     </question>
     <answer>
      <para>
-      Occasionally, you can be running <literal>iptable</iptable> rules that block access to
-      monitor servers or monitor ports. This can often be the case from monitor
-      stress-testing that was forgotten. We recommend trying to <literal>ssh</literal> into the
-      server and, if that succeeds, try connecting to the monitor's port using
-      your tool of choice (such as <command>telnet</command> or <command>netcat</command>).
+      Occasionally, you can be running <literal>iptable</literal> rules that
+      block access to monitor servers or monitor ports. This can often be the
+      case from monitor stress-testing that was forgotten. We recommend trying
+      to <literal>ssh</literal> into the server and, if that succeeds, try
+      connecting to the monitor's port using your tool of choice (such as
+      <command>telnet</command> or <command>netcat</command>).
      </para>
     </answer>
    </qandaentry>
@@ -278,10 +279,10 @@ mon.a (rank 0) addr 127.0.0.1:6789/0 is down (out of quorum)</screen>
     should be one of <literal>probing</literal>, <literal>electing</literal> or
     <literal>synchronizing</literal>. If it happens to be either
     <literal>leader</literal> or <literal>peon</literal>, then the monitor
-    believes itself to be in the quorum, while the remaining cluster is sure it is not; or
-    maybe it got into the quorum while we were troubleshooting the monitor.
-    Check using <command>ceph -s</command> again, just to make sure. Continue if the
-    monitor is not yet in quorum.
+    believes itself to be in the quorum, while the remaining cluster is sure it
+    is not; or maybe it got into the quorum while we were troubleshooting the
+    monitor. Check using <command>ceph -s</command> again, just to make sure.
+    Continue if the monitor is not yet in quorum.
    </para>
    <qandaset>
     <qandaentry>

--- a/xml/bp_troubleshooting_monitors.xml
+++ b/xml/bp_troubleshooting_monitors.xml
@@ -5,7 +5,7 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="bp-troubleshooting-monitors">
- <title>Troubleshooting monitors</title>
+ <title>Troubleshooting &mon;s and &mgr;s</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:editurl>https://github.com/SUSE/doc-ses/edit/master/xml/</dm:editurl>
@@ -717,5 +717,67 @@ debug ms = 1
    </para>
 <screen>&prompt.cephuser;ceph daemon mon.FOO config get 'OPTION_NAME'</screen>
   </sect2>
+ </sect1>
+ <sect1 xml:id="deploy-mgr-manually">
+  <title>Manually deploying a MGR daemon</title>
+
+  <para>
+   &cephadm; requires a MGR daemon in order to manage the cluster. If the last
+   MGR of a cluster was removed, follow these steps to deploy an example MGR
+   daemon named <literal>mgr.hostname.smfvfd</literal> on a random host of your
+   cluster manually:
+  </para>
+
+  <procedure>
+   <step>
+    <para>
+     Disable the &cephadm; scheduler to prevent &cephadm; from removing the new
+     MGR daemon:
+    </para>
+<screen>&prompt.cephuser;ceph config-key set mgr/cephadm/pause true</screen>
+   </step>
+   <step>
+    <para>
+     Get or create the auth entry for the new MGR daemon:
+    </para>
+<screen>
+&prompt.cephuser;ceph auth get-or-create <replaceable>mgr.hostname.smfvfd</replaceable> \
+mon "profile mgr" osd "allow *" mds "allow *"
+</screen>
+   </step>
+   <step>
+    <para>
+     Generate a minimal <filename>ceph.conf</filename>:
+    </para>
+<screen>&prompt.cephuser;ceph config generate-minimal-conf</screen>
+   </step>
+   <step>
+    <para>
+     Find the name of the container image:
+    </para>
+<screen>&prompt.cephuser;ceph config get "mgr.hostname.smfvfd" container_image</screen>
+   </step>
+   <step>
+    <para>
+     Create a file <filename>config-json.json</filename> which contains the
+     information necessary to deploy the daemon, for example:
+    </para>
+<screen>
+{
+  "config": "# minimal ceph.conf for 8255263a-a97e-4934-822c-00bfe029b28f\n[global]\n\tfsid = 8255263a-a97e-4934-822c-00bfe029b28f\n\tmon_host = [v2:192.168.0.1:40483/0,v1:192.168.0.1:40484/0]\n",
+  "keyring": "[mgr.hostname.smfvfd]\n\tkey = V2VyIGRhcyBsaWVzdCBpc3QgZG9vZi4=\n"
+}
+</screen>
+   </step>
+   <step>
+    <para>
+     Deploy the daemon:
+    </para>
+<screen>&prompt.cephuser;cephadm --image <replaceable>IMAGE_NAME</replaceable> \
+ deploy --fsid <replaceable>CLUSTER_FSID</replaceable> \
+ --name mgr.hostname.smfvfd --config-json config-json.json
+</screen>
+   </step>
+  </procedure>
  </sect1>
 </chapter>

--- a/xml/bp_troubleshooting_monitors.xml
+++ b/xml/bp_troubleshooting_monitors.xml
@@ -198,7 +198,7 @@
   <procedure>
    <step>
     <para>
-     Stop all MONs. Log in to each MON host via SSH and run the following
+     Stop all &mon;s. Log in to each &mon; host via SSH and run the following
      command there:
     </para>
 <screen>&prompt.cephuser;cephadm unit --name mon.`hostname` stop</screen>

--- a/xml/bp_troubleshooting_monitors.xml
+++ b/xml/bp_troubleshooting_monitors.xml
@@ -40,9 +40,9 @@
      <para>
       Occasionally, you can be running iptable rules that block access to
       monitor servers or monitor ports. This can often be the case from monitor
-      stress-testing that were forgotten. We recommend to try ssh’ing into
-      the server and, if that succeeds, try connecting to the monitor’s port
-      using your tool of choice (telnet, nc).
+      stress-testing that were forgotten. We recommend to try ssh’ing into the
+      server and, if that succeeds, try connecting to the monitor’s port using
+      your tool of choice (telnet, nc).
      </para>
     </answer>
    </qandaentry>
@@ -74,8 +74,8 @@
      <para>
       Contact each monitor individually for the status, regardless of a quorum
       being formed. This can be achieved using <command>ceph tell mon.ID
-      mon_status</command> with the ID being the monitor’s identifier.
-      Perform this for each monitor in the cluster. The section
+      mon_status</command> with the ID being the monitor’s identifier. Perform
+      this for each monitor in the cluster. The section
       <xref linkend="mons-understanding-mons-status"/> explains how to
       interpret the output of this command.
      </para>
@@ -88,8 +88,8 @@
 
   <para>
    The admin socket allows you to interact with a given daemon directly using a
-   Unix socket file. This file can be found in your monitor’s run directory.
-   By default, the admin socket will be kept in
+   Unix socket file. This file can be found in your monitor’s run directory. By
+   default, the admin socket will be kept in
    <filename>/var/run/ceph/ceph-mon.ID.asok</filename> but this can vary if you
    defined it otherwise. If you are unable to find it there, check your
    <filename>ceph.conf</filename> for an alternative path or run:
@@ -186,6 +186,76 @@
    <literal>mon.a</literal> has rank 0.
   </para>
  </sect1>
+ <sect1 xml:id="mons-restoring-quorum">
+  <title>Restoring the MONs quorum</title>
+
+  <para>
+   In case the &mon;s cannot form a quorum, &cephadm; is not able to manage the
+   cluster until the quorum is restored. In order to restore the MON quorum,
+   remove unhealthy MONs form the monmap by following these steps:
+  </para>
+
+  <procedure>
+   <step>
+    <para>
+     Stop all MONs. Log in to each MON host via SSH and run the following
+     command there:
+    </para>
+<screen>&prompt.cephuser;cephadm unit --name mon.`hostname` stop</screen>
+   </step>
+   <step>
+    <para>
+     Identify a surviving monitor by logging in to that host via SSH and
+     running:
+    </para>
+<screen>&prompt.cephuser;cephadm enter --name mon.`hostname`</screen>
+   </step>
+   <step>
+    <para>
+     Extract a copy of the monmap to a file, for example
+     <filename>/tmp/monmap</filename>. Note that
+     <replaceable>MON_ID</replaceable> is usually identical to the string that
+     the <command>hostname</command> command returns:
+    </para>
+<screen>ceph-mon -i <replaceable>MON_ID</replaceable> --extract-monmap <replaceable>/tmp/monmap</replaceable></screen>
+   </step>
+   <step>
+    <para>
+     Remove the non-surviving or problematic monitors. For example, if you have
+     three monitors, <literal>mon.a</literal>, <literal>mon.b</literal>, and
+     <literal>mon.c</literal> where only <literal>mon.a</literal> will survive,
+     follow this example:
+    </para>
+<screen>
+&prompt.cephuser;monmaptool /tmp/monmap --rm b
+&prompt.cephuser;monmaptool /tmp/monmap --rm c
+</screen>
+   </step>
+   <step>
+    <para>
+     Inject the surviving map with the removed monitors into the surviving
+     monitor(s). For example, to inject the map into the monitor
+     <literal>mon.a</literal>, follow this example:
+    </para>
+<screen>&prompt.cephuser;ceph-mon -i a --inject-monmap /tmp/monmap</screen>
+   </step>
+   <step>
+    <para>
+     Start only the surviving monitors, and verify that the monitors form a
+     quorum with the <command>ceph -s</command> command.
+    </para>
+   </step>
+  </procedure>
+
+  <note>
+   <para>
+    You may wish to archive the removed monitors' data directory in
+    <filename>/var/lib/ceph/mon</filename> in a safe location, or delete it if
+    you are confident the remaining monitors are healthy and are sufficiently
+    redundant.
+   </para>
+  </note>
+ </sect1>
  <sect1 xml:id="mons-common-issues">
   <title>Most common monitor issues</title>
 
@@ -204,15 +274,15 @@ mon.a (rank 0) addr 127.0.0.1:6789/0 is down (out of quorum)</screen>
     server from the other monitors' servers. Check the ports as well. Check
     iptables on all your monitor nodes and make sure you are not dropping or
     rejecting connections. If this initial troubleshooting does not solve your
-    problems, check the problematic monitor’s <literal>mon_status</literal>
-    via the admin socket. Considering the monitor is out of the quorum, its
-    state should be one of <literal>probing</literal>,
-    <literal>electing</literal> or <literal>synchronizing</literal>. If it
-    happens to be either <literal>leader</literal> or <literal>peon</literal>,
-    then the monitor believes to be in quorum, while the remaining cluster is
-    sure it is not; or maybe it got into the quorum while we were
-    troubleshooting the monitor, check <command>ceph -s</command> again just to
-    make sure. Continue if the monitor is not yet in quorum.
+    problems, check the problematic monitor’s <literal>mon_status</literal> via
+    the admin socket. Considering the monitor is out of the quorum, its state
+    should be one of <literal>probing</literal>, <literal>electing</literal> or
+    <literal>synchronizing</literal>. If it happens to be either
+    <literal>leader</literal> or <literal>peon</literal>, then the monitor
+    believes to be in quorum, while the remaining cluster is sure it is not; or
+    maybe it got into the quorum while we were troubleshooting the monitor,
+    check <command>ceph -s</command> again just to make sure. Continue if the
+    monitor is not yet in quorum.
    </para>
    <qandaset>
     <qandaentry>
@@ -630,8 +700,8 @@ debug ms = 1
     </listitem>
     <listitem>
      <para>
-      If you have no quorum, use the monitor’s admin socket and directly
-      adjust the configuration options:
+      If you have no quorum, use the monitor’s admin socket and directly adjust
+      the configuration options:
      </para>
 <screen>&prompt.cephuser;ceph daemon mon.FOO config set debug_mon 10/10</screen>
     </listitem>

--- a/xml/bp_troubleshooting_monitors.xml
+++ b/xml/bp_troubleshooting_monitors.xml
@@ -192,7 +192,7 @@
   <para>
    If the &mon;s cannot form a quorum, &cephadm; will not be able to manage the
    cluster until the quorum is restored. In order to restore the &mon; quorum,
-   remove unhealthy MONs form the monmap by following these steps:
+   remove unhealthy &mon;s form the monmap by following these steps:
   </para>
 
   <procedure>

--- a/xml/bp_troubleshooting_monitors.xml
+++ b/xml/bp_troubleshooting_monitors.xml
@@ -223,7 +223,7 @@
     <para>
      Remove the non-surviving or problematic monitors. For example, if you have
      three monitors, <literal>mon.a</literal>, <literal>mon.b</literal>, and
-     <literal>mon.c</literal> where only <literal>mon.a</literal> will survive,
+     <literal>mon.c</literal> where only <literal>mon.a</literal> is surviving,
      follow this example:
     </para>
 <screen>

--- a/xml/bp_troubleshooting_monitors.xml
+++ b/xml/bp_troubleshooting_monitors.xml
@@ -38,11 +38,11 @@
     </question>
     <answer>
      <para>
-      Occasionally, you can be running iptable rules that block access to
+      Occasionally, you can be running <literal>iptable</iptable> rules that block access to
       monitor servers or monitor ports. This can often be the case from monitor
-      stress-testing that were forgotten. We recommend to try ssh’ing into the
-      server and, if that succeeds, try connecting to the monitor’s port using
-      your tool of choice (telnet, nc).
+      stress-testing that was forgotten. We recommend trying to <literal>ssh</literal> into the
+      server and, if that succeeds, try connecting to the monitor's port using
+      your tool of choice (such as <command>telnet</command> or <command>netcat</command>).
      </para>
     </answer>
    </qandaentry>
@@ -74,7 +74,7 @@
      <para>
       Contact each monitor individually for the status, regardless of a quorum
       being formed. This can be achieved using <command>ceph tell mon.ID
-      mon_status</command> with the ID being the monitor’s identifier. Perform
+      mon_status</command> with the ID being the monitor's identifier. Perform
       this for each monitor in the cluster. The section
       <xref linkend="mons-understanding-mons-status"/> explains how to
       interpret the output of this command.
@@ -88,7 +88,7 @@
 
   <para>
    The admin socket allows you to interact with a given daemon directly using a
-   Unix socket file. This file can be found in your monitor’s run directory. By
+   Unix socket file. This file can be found in your monitor's run directory. By
    default, the admin socket will be kept in
    <filename>/var/run/ceph/ceph-mon.ID.asok</filename> but this can vary if you
    defined it otherwise. If you are unable to find it there, check your
@@ -190,8 +190,8 @@
   <title>Restoring the MONs quorum</title>
 
   <para>
-   In case the &mon;s cannot form a quorum, &cephadm; is not able to manage the
-   cluster until the quorum is restored. In order to restore the MON quorum,
+   If the &mon;s cannot form a quorum, &cephadm; will not be able to manage the
+   cluster until the quorum is restored. In order to restore the &mon; quorum,
    remove unhealthy MONs form the monmap by following these steps:
   </para>
 
@@ -249,7 +249,7 @@
 
   <note>
    <para>
-    You may wish to archive the removed monitors' data directory in
+    You may wish to archive the removed monitors' data directories from
     <filename>/var/lib/ceph/mon</filename> in a safe location, or delete it if
     you are confident the remaining monitors are healthy and are sufficiently
     redundant.
@@ -274,14 +274,14 @@ mon.a (rank 0) addr 127.0.0.1:6789/0 is down (out of quorum)</screen>
     server from the other monitors' servers. Check the ports as well. Check
     iptables on all your monitor nodes and make sure you are not dropping or
     rejecting connections. If this initial troubleshooting does not solve your
-    problems, check the problematic monitor’s <literal>mon_status</literal> via
+    problems, check the problematic monitor's <literal>mon_status</literal> via
     the admin socket. Considering the monitor is out of the quorum, its state
     should be one of <literal>probing</literal>, <literal>electing</literal> or
     <literal>synchronizing</literal>. If it happens to be either
     <literal>leader</literal> or <literal>peon</literal>, then the monitor
-    believes to be in quorum, while the remaining cluster is sure it is not; or
-    maybe it got into the quorum while we were troubleshooting the monitor,
-    check <command>ceph -s</command> again just to make sure. Continue if the
+    believes itself to be in the quorum, while the remaining cluster is sure it is not; or
+    maybe it got into the quorum while we were troubleshooting the monitor.
+    Check using <command>ceph -s</command> again, just to make sure. Continue if the
     monitor is not yet in quorum.
    </para>
    <qandaset>
@@ -700,7 +700,7 @@ debug ms = 1
     </listitem>
     <listitem>
      <para>
-      If you have no quorum, use the monitor’s admin socket and directly adjust
+      If you have no quorum, use the monitor's admin socket and directly adjust
       the configuration options:
      </para>
 <screen>&prompt.cephuser;ceph daemon mon.FOO config set debug_mon 10/10</screen>


### PR DESCRIPTION
closes #885 

rendered PDF is attached 
[book-storage-troubleshooting_color_en.pdf](https://github.com/SUSE/doc-ses/files/6034703/book-storage-troubleshooting_color_en.pdf)

See the new sections:
2.7 Per-service and per-daemon events
3.13 Disabling automatic deployment of daemons
6.4 Restoring the MONs quorum
6.8 Manually deploying a MGR daemon

