### PR TITLE
Use 'ganesha' as example NFS namespace

### DIFF
--- a/xml/deploy_cephadm.xml
+++ b/xml/deploy_cephadm.xml
@@ -1860,7 +1860,7 @@ spec:
      <listitem>
       <para>
        <replaceable>EXAMPLE_NAMESPACE</replaceable> (optional) with the desired
-       &ogw; NFS namespace (for example, <literal>nfs</literal>).
+       &ogw; NFS namespace (for example, <literal>ganesha</literal>).
       </para>
      </listitem>
     </itemizedlist>


### PR DESCRIPTION
Previously the example was "nfs". I've changed it to "ganesha" for consistency with what DeepSea created in previous SES releases.

Signed-off-by: Tim Serong <tserong@suse.com>