### PR TITLE
Replaced 'redeploy' with 'reconfig' for moitoring services (#903)

### DIFF
--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -80,7 +80,12 @@
 <screen>
 &prompt.cephuser; ceph config-key set mgr/cephadm/grafana_key -i $PWD/key.pem
 &prompt.cephuser; ceph config-key set mgr/cephadm/grafana_crt -i $PWD/certificate.pem
-  </screen>
+</screen>
+ <para>
+  If you already deployed &grafana;, you need to re-configure the service to
+  reflect the new certificate paths and set the right URL for the &dashboard;:
+ </para>
+<screen>&prompt.cephuser;ceph orch reconfig grafana</screen>
  <para>
   The &alertmanager; handles alerts sent by the &prometheus; server. It takes
   care of deduplicating, grouping, and routing them to the correct receiver.
@@ -224,14 +229,14 @@
   </para>
 
   <para>
-   To do so, use <command>ceph orch redeploy</command> like so:
+   To do so, use <command>ceph orch reconfig</command> like so:
   </para>
 
 <screen>
-&prompt.cephuser;ceph orch redeploy node-exporter
-&prompt.cephuser;ceph orch redeploy prometheus
-&prompt.cephuser;ceph orch redeploy alertmanager
-&prompt.cephuser;ceph orch redeploy grafana
+&prompt.cephuser;ceph orch reconfig node-exporter
+&prompt.cephuser;ceph orch reconfig prometheus
+&prompt.cephuser;ceph orch reconfig alertmanager
+&prompt.cephuser;ceph orch reconfig grafana
 </screen>
 
   <para>


### PR DESCRIPTION
This update applies to https://github.com/ceph/ceph/pull/39932/files but I could not find mentionings of jinja templates in our downstream docs. @mgfritch can you please double-check and possibly update?

closes #903 