### PR TITLE
Syncing salt modules during upgrade (bsc#1181092)

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -258,7 +258,7 @@
    </para>
 <screen>
 &prompt.smaster;systemctl restart salt-master.service
-&prompt.smaster;salt "*" saltutil.sync_all
+&prompt.smaster;salt '*' saltutil.sync_all
 &prompt.cephuser;ceph -s
 </screen>
   </sect2>

--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -245,10 +245,22 @@
     &prevproductnumber; are applied to all cluster nodes:
    </para>
 <screen>&prompt.root;zypper refresh &amp;&amp; zypper patch</screen>
+   <tip>
+    <para>
+     Refer to <link
+     xlink:href="https://documentation.suse.com/ses/6/html/ses-all/storage-salt-cluster.html#deepsea-rolling-updates"/>
+     for detailed information about updating the cluster nodes.
+    </para>
+   </tip>
    <para>
-    After updates are applied, check the cluster health:
+    After updates are applied, restart the &smaster;, synchronize new &salt;
+    modules, and check the cluster health:
    </para>
-<screen>&prompt.cephuser;ceph -s</screen>
+<screen>
+&prompt.smaster;systemctl restart salt-master
+&prompt.smaster;salt "*" saltutil.sync_all
+&prompt.cephuser;ceph -s
+</screen>
   </sect2>
 
   <sect2 xml:id="verify-previous-upgrade-patch-repos">

--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -257,7 +257,7 @@
     modules, and check the cluster health:
    </para>
 <screen>
-&prompt.smaster;systemctl restart salt-master
+&prompt.smaster;systemctl restart salt-master.service
 &prompt.smaster;salt "*" saltutil.sync_all
 &prompt.cephuser;ceph -s
 </screen>


### PR DESCRIPTION
Recommends to restart salt-master and synchronize salt modules during upgrade

Closes bsc#1181092