### PR TITLE
Update Grafana container tag version

### DIFF
--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -173,7 +173,7 @@
    </listitem>
    <listitem>
     <para>
-     registry.suse.com/ses/7/ceph/grafana:7.0.3
+     registry.suse.com/ses/7/ceph/grafana:7.3.1
     </para>
    </listitem>
   </itemizedlist>


### PR DESCRIPTION
Signed-off-by: Patrick Seidensal <pseidensal@suse.com>

Related to updating the container version for Grafana shipped by default: https://github.com/SUSE/ceph/pull/429