### PR TITLE
Revise adoption of monitoring services

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -41,14 +41,14 @@
   <para>
    The upgrade information in this chapter <emphasis>only</emphasis> applies to
    upgrades from &deepsea; to &cephadm;. Do not attempt to follow these
-   instructions if you want to deploy &productname; on the &caasp;.
+   instructions if you want to deploy &productname; on &caasp;.
   </para>
  </warning>
  <important>
   <para>
    Upgrading from &productname; versions older than &prevproductnumber; is not
-   supported. You first need to upgrade to the latest version of &productname;
-   &prevproductnumber; and then follow the steps in this chapter.
+   supported. First, you must upgrade to the latest version of &productname;
+   &prevproductnumber;, and then follow the steps in this chapter.
   </para>
  </important>
  <sect1 xml:id="before-upgrade">
@@ -89,7 +89,7 @@
    <itemizedlist>
     <listitem>
      <para>
-      <emphasis>Read the release notes</emphasis> - there you can find
+      <emphasis>Read the release notes</emphasis>. In them, you can find
       additional information on changes since the previous release of
       &productname;. Check the release notes to see whether:
      </para>
@@ -141,17 +141,17 @@
     </listitem>
     <listitem>
      <para>
-      You need to upgrade the &smaster; first, and replace &deepsea; with
-      &cephsalt; and &cephadm; after. You will <emphasis>not</emphasis> be able
-      to start using the &cephadm; orchestrator module until at least all
-      &mgr;'s are upgraded.
+      You need to upgrade the &smaster; first, then replace &deepsea; with
+      &cephsalt; and &cephadm;. You will <emphasis>not</emphasis> be able to
+      start using the &cephadm; orchestrator module until at least all &mgr;
+      nodes are upgraded.
      </para>
     </listitem>
     <listitem>
      <para>
       The upgrade from using &prevcephname; RPMs to &cephname; containers needs
-      to happen all in one step. This means upgrade an entire node at a time,
-      not one daemon at a time.
+      to happen in a single step. This means upgrading an entire node at a
+      time, not one daemon at a time.
      </para>
     </listitem>
     <listitem>
@@ -173,17 +173,17 @@
          in this case they may be down for the entire duration of the cluster
          upgrade. If this is going to be a problem, consider deploying these
          services separately on additional nodes before upgrading, so that they
-         are down for the least amount of time possible. This is the duration
-         of the upgrade of the gateway nodes, not the duration of the upgrade
-         of the entire cluster.
+         are down for the shortest possible time. This is the duration of the
+         upgrade of the gateway nodes, not the duration of the upgrade of the
+         entire cluster.
         </para>
        </important>
       </listitem>
       <listitem>
        <para>
         &ganesha; and &igw;s are down only while nodes are rebooting during
-        upgrade from &prevcephos; to &cephos; and again briefly when each
-        service is redeployed in containerized mode.
+        upgrade from &prevcephos; to &cephos;, and again briefly when each
+        service is redeployed on the containerized mode.
        </para>
       </listitem>
      </itemizedlist>
@@ -195,7 +195,7 @@
    <title>Backing Up cluster configuration and data</title>
    <para>
     We strongly recommend backing up all cluster configuration and data before
-    starting your upgrade to &productname; &productnumber;. For instruction on
+    starting your upgrade to &productname; &productnumber;. For instructions on
     how to back up all your data, see
     <link xlink:href="https://documentation.suse.com/ses/6/single-html/ses-admin/#cha-deployment-backup"/>.
    </para>
@@ -222,7 +222,7 @@
     If <option>configuration_init</option> is still set to
     <option>default-import</option>, the cluster is using
     <filename>ceph.conf.import</filename> as its configuration file and not
-    &deepsea;'s default <filename>ceph.conf</filename> which is compiled from
+    &deepsea;'s default <filename>ceph.conf</filename>, which is compiled from
     files in
     <filename>/srv/salt/ceph/configuration/files/ceph.conf.d/</filename>.
    </para>
@@ -268,8 +268,8 @@
   <sect2 xml:id="verify-previous-upgrade-patch-repos">
    <title>Verifying access to software repositories and container images</title>
    <para>
-    Verify that each cluster node has access to &cephos; and &productname;
-    &productnumber; software repositories as well as registry of container
+    Verify that each cluster node has access to the &cephos; and &productname;
+    &productnumber; software repositories, as well as the registry of container
     images.
    </para>
    <sect3 xml:id="verify-previous-upgrade-patch-repos-repos">
@@ -685,8 +685,9 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
    <step>
     <para>
      If you are <emphasis role="bold">not</emphasis> using container images
-     from <literal>registry.suse.com</literal> but rather the locally
-     configured registry, inform &ceph; which container image to use by running
+     from <literal>registry.suse.com</literal> but rather the
+     locally-configured registry, inform &ceph; which container image to use by
+     running
     </para>
 <screen>&prompt.smaster;ceph config set global container_image <replaceable>IMAGE_NAME</replaceable></screen>
     <para>
@@ -880,8 +881,8 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
     <literal>ganesha_config</literal>
    </para>
    <para>
-    Before attempting any migration, we strongly recommend to make a copy of
-    the export and daemon configuration objects located in the RADOS pool To
+    Before attempting any migration, we strongly recommend making a copy of the
+    export and daemon configuration objects located in the RADOS pool. To
     locate the configured RADOS pool, run the following command:
    </para>
 <screen>&prompt.cephuser;grep -A5 RADOS_URLS /etc/ganesha/ganesha.conf</screen>
@@ -911,7 +912,7 @@ drwx------ 9 root root 4.0K Sep 8 03:23 ..
 -rw-r--r-- 1 root root 350 Sep 8 03:30 export-3
 -rw-r--r-- 1 root root 358 Sep 8 03:30 export-4</screen>
    <para>
-    On a per node basis, an existing &ganesha; service needs to be stopped and
+    On a per-node basis, any existing &ganesha; service needs to be stopped and
     then replaced with a container managed by &cephadm;.
    </para>
    <procedure>
@@ -942,7 +943,7 @@ placement:
   namespace: ganesha
 </screen>
      <para>
-      For more information on creating a placement specification see
+      For more information on creating a placement specification, see
       <xref linkend="cephadm-service-and-placement-specs"/>.
      </para>
     </step>
@@ -1037,7 +1038,7 @@ drwxr-xr-x 3 root root 4.0K Sep 8 16:47 ..
     </step>
    </procedure>
    <para>
-    After the service has been successfully migrated, the Nautilus based
+    After the service has been successfully migrated, the Nautilus-based
     &ganesha; service can be removed.
    </para>
    <procedure>
@@ -1252,9 +1253,9 @@ spec:
       Pools in &productname; 6 had the <option>pg_autoscale_mode</option> set
       to <option>warn</option> by default. This resulted in a warning message
       in case of suboptimal number of PGs, but autoscaling did not actually
-      happen. The default in &productname; &productnumber; is the
+      happen. The default in &productname; &productnumber; is that the
       <option>pg_autoscale_mode</option> option is set to <option>on</option>
-      for new pools and PGs will actually autoscale. The upgrade process does
+      for new pools, and PGs will actually autoscale. The upgrade process does
       not automatically change the <option>pg_autoscale_mode</option> of
       existing pools. If you want to change it to <option>on</option> to get
       the full benefit of the autoscaler, see the instructions in

--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -738,7 +738,7 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
      <para>
       If you are <emphasis role="bold">not</emphasis> running the default
       container image registry <literal>registry.suse.com</literal>, you need
-      to specify the image to use, for example:
+      to specify the image to use on each command, for example:
      </para>
 <screen>
 &prompt.cephuser;cephadm --image 192.168.121.1:5000/caasp/v4.5/prometheus-server:2.18.0 \
@@ -749,18 +749,23 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
  adopt --style=legacy --name grafana.$(hostname)
 </screen>
      <para>
-      For more details on using custom or local container images, refer to
+      The container images required and their respective versions are listed in
       <xref linkend="monitoring-custom-images"/>.
      </para>
     </tip>
    </step>
    <step>
     <para>
-     Remove the Node-Exporter. It does not need to be migrated and will be
-     re-installed as a container when the <filename>specs.yaml</filename> file
-     is applied.
+     Remove Node-Exporter from <emphasis role="bold">all</emphasis> nodes. The
+     Node-Exporter does not need to be migrated and will be re-installed as a
+     container when the <filename>specs.yaml</filename> file is applied.
     </para>
 <screen>&prompt.sudo;zypper rm golang-github-prometheus-node_exporter</screen>
+    <para>
+     Alternatively, you can remove Node-Exporter from all nodes simultaneously
+     using &salt; on the admin node:
+    </para>
+<screen>&prompt.smaster;salt '*' pkg.remove golang-github-prometheus-node_exporter</screen>
    </step>
    <step>
     <para>
@@ -768,6 +773,35 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
      &deepsea;:
     </para>
 <screen>&prompt.cephuser;ceph orch apply -i specs.yaml</screen>
+    <tip>
+     <para>
+      If you are <emphasis role="bold">not</emphasis> running the default
+      container image registry <literal>registry.suse.com</literal>, but a
+      local container registry, configure &cephadm; to use the container image
+      from the local registry for the deployment of Node-Exporter before
+      deploying the Node-Exporter. Otherwise you can safely skip this step and
+      ignore the following warning.
+     </para>
+<screen>&prompt.cephuser;ceph config set mgr mgr/cephadm/container_image_node_exporter <replaceable>QUALIFIED_IMAGE_PATH</replaceable></screen>
+     <para>
+      Make sure that all container images for monitoring services point to the
+      local registry, not only the one for Node-Exporter. This step requires
+      you to do so for the Node-Exporter only, but it is advised than you set
+      all the monitoring container images in &cephadm; to point to the local
+      registry at this point.
+     </para>
+     <para>
+      If you do not do so, new deployments of monitoring services as well as
+      re-deployments will use the default &cephadm; configuration and you may
+      end up being unable to deploy services (in the case of air-gapped
+      deployments), or with services deployed with mixed versions.
+     </para>
+     <para>
+      How &cephadm; needs to be configured to use container images from the
+      local registry is described in
+      <xref linkend="monitoring-custom-images"/>.
+     </para>
+    </tip>
    </step>
    <step>
     <para>

--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -13,7 +13,8 @@
   </dm:docmanager>
  </info>
  <para>
-  This chapter introduces steps to upgrade &productname; &prevproductnumber; to version &productnumber;.
+  This chapter introduces steps to upgrade &productname; &prevproductnumber; to
+  version &productnumber;.
  </para>
  <para>
   The upgrade includes the following tasks:
@@ -26,7 +27,8 @@
   </listitem>
   <listitem>
    <para>
-    Switching from installing and running &ceph; via RPM packages to running in containers.
+    Switching from installing and running &ceph; via RPM packages to running in
+    containers.
    </para>
   </listitem>
   <listitem>
@@ -37,35 +39,43 @@
  </itemizedlist>
  <warning>
   <para>
-   The upgrade information in this chapter <emphasis>only</emphasis> applies to upgrades from &deepsea; to &cephadm;.
-   Do not attempt to follow these instructions if you want to deploy &productname; on the &caasp;.
+   The upgrade information in this chapter <emphasis>only</emphasis> applies to
+   upgrades from &deepsea; to &cephadm;. Do not attempt to follow these
+   instructions if you want to deploy &productname; on the &caasp;.
   </para>
  </warning>
  <important>
   <para>
-   Upgrading from &productname; versions older than &prevproductnumber; is not supported.
-   You first need to upgrade to the latest version of &productname; &prevproductnumber; and then follow the steps in this chapter.
+   Upgrading from &productname; versions older than &prevproductnumber; is not
+   supported. You first need to upgrade to the latest version of &productname;
+   &prevproductnumber; and then follow the steps in this chapter.
   </para>
  </important>
  <sect1 xml:id="before-upgrade">
   <title>Before upgrading</title>
 
   <para>
-   The following tasks <emphasis>must</emphasis> be completed before you start the upgrade.
-   This can be done at any time during the &productname; &prevproductnumber; life time.
+   The following tasks <emphasis>must</emphasis> be completed before you start
+   the upgrade. This can be done at any time during the &productname;
+   &prevproductnumber; life time.
   </para>
 
   <itemizedlist>
    <listitem>
     <para>
-     The OSD migration from &filestore; to &bluestore; <emphasis>must</emphasis> happen before the upgrade as &filestore; unsupported in &productname; &productnumber;.
-     Find more details about &bluestore; and how to migrate from &filestore; at <link xlink:href="https://documentation.suse.com/ses/6/single-html/ses-deployment/#filestore2bluestore"/>.
+     The OSD migration from &filestore; to &bluestore;
+     <emphasis>must</emphasis> happen before the upgrade as &filestore;
+     unsupported in &productname; &productnumber;. Find more details about
+     &bluestore; and how to migrate from &filestore; at
+     <link xlink:href="https://documentation.suse.com/ses/6/single-html/ses-deployment/#filestore2bluestore"/>.
     </para>
    </listitem>
    <listitem>
     <para>
-     If you are running an older cluster that still uses <literal>ceph-disk</literal> OSDs, you <emphasis>need</emphasis> to switch to <literal>ceph-volume</literal> before the upgrade.
-     Find more details in <link xlink:href="https://documentation.suse.com/ses/6/single-html/ses-deployment/#upgrade-osd-deployment"/>.
+     If you are running an older cluster that still uses
+     <literal>ceph-disk</literal> OSDs, you <emphasis>need</emphasis> to switch
+     to <literal>ceph-volume</literal> before the upgrade. Find more details in
+     <link xlink:href="https://documentation.suse.com/ses/6/single-html/ses-deployment/#upgrade-osd-deployment"/>.
     </para>
    </listitem>
   </itemizedlist>
@@ -73,13 +83,15 @@
   <sect2 xml:id="upgrade-consider-points">
    <title>Points to consider</title>
    <para>
-    Before upgrading, ensure you read through the following sections to ensure you understand all tasks that need to be executed.
+    Before upgrading, ensure you read through the following sections to ensure
+    you understand all tasks that need to be executed.
    </para>
    <itemizedlist>
     <listitem>
      <para>
-      <emphasis>Read the release notes</emphasis> - there you can find additional information on changes since the previous release of &productname;.
-      Check the release notes to see whether:
+      <emphasis>Read the release notes</emphasis> - there you can find
+      additional information on changes since the previous release of
+      &productname;. Check the release notes to see whether:
      </para>
      <itemizedlist>
       <listitem>
@@ -99,59 +111,79 @@
       </listitem>
      </itemizedlist>
      <para>
-      The release notes also provide information that could not make it into the manual on time.
-      They also contain notes about known issues.
+      The release notes also provide information that could not make it into
+      the manual on time. They also contain notes about known issues.
      </para>
      <para>
-      You can find SES &productnumber; release notes online at <link xlink:href="https://www.suse.com/releasenotes/"/>.
+      You can find SES &productnumber; release notes online at
+      <link xlink:href="https://www.suse.com/releasenotes/"/>.
      </para>
      <para>
-      Additionally, after having installed the package <package>release-notes-ses</package> from the SES &productnumber; repository, find the release notes locally in the directory <filename>/usr/share/doc/release-notes</filename> or online at <link xlink:href="https://www.suse.com/releasenotes/"/>.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      Read <xref linkend="deploy-cephadm"/> to familiarise yourself with &cephsalt; and the &ceph; orchestrator, and in particular the information on service specifications.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      The cluster upgrade may take a long time&mdash;approximately the time it takes to upgrade one machine multiplied by the number of cluster nodes.
+      Additionally, after having installed the package
+      <package>release-notes-ses</package> from the SES &productnumber;
+      repository, find the release notes locally in the directory
+      <filename>/usr/share/doc/release-notes</filename> or online at
+      <link xlink:href="https://www.suse.com/releasenotes/"/>.
      </para>
     </listitem>
     <listitem>
      <para>
-      You need to upgrade the &smaster; first, and replace &deepsea; with &cephsalt; and &cephadm; after.
-      You will <emphasis>not</emphasis> be able to start using the &cephadm; orchestrator module until at least all &mgr;'s are upgraded.
+      Read <xref linkend="deploy-cephadm"/> to familiarise yourself with
+      &cephsalt; and the &ceph; orchestrator, and in particular the information
+      on service specifications.
      </para>
     </listitem>
     <listitem>
      <para>
-      The upgrade from using &prevcephname; RPMs to &cephname; containers needs to happen all in one step.
-      This means upgrade an entire node at a time, not one daemon at a time.
+      The cluster upgrade may take a long time&mdash;approximately the time it
+      takes to upgrade one machine multiplied by the number of cluster nodes.
      </para>
     </listitem>
     <listitem>
      <para>
-      The upgrade of core services (MON, MGR, OSD) happens in an orderly fashion.
-      Each service is available during the upgrade.
-      The gateway services (&mds;, &ogw;, &ganesha;, &igw;) need to be redeployed after the core services are upgraded.
-      There is a certain amount of downtime for each of the following services:
+      You need to upgrade the &smaster; first, and replace &deepsea; with
+      &cephsalt; and &cephadm; after. You will <emphasis>not</emphasis> be able
+      to start using the &cephadm; orchestrator module until at least all
+      &mgr;'s are upgraded.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      The upgrade from using &prevcephname; RPMs to &cephname; containers needs
+      to happen all in one step. This means upgrade an entire node at a time,
+      not one daemon at a time.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      The upgrade of core services (MON, MGR, OSD) happens in an orderly
+      fashion. Each service is available during the upgrade. The gateway
+      services (&mds;, &ogw;, &ganesha;, &igw;) need to be redeployed after the
+      core services are upgraded. There is a certain amount of downtime for
+      each of the following services:
      </para>
      <itemizedlist>
       <listitem>
        <important>
         <para>
-         &mds;s and &ogw;s are down from the time the nodes are upgraded from &prevcephos; to &cephos; until the services are redeployed at the end of the upgrade procedure.
-         This is particularly important to bear in mind if these services are colocated with MONs, MGRs or OSDs, because in this case they may be down for the entire duration of the cluster upgrade.
-         If this is going to be a problem, consider deploying these services separately on additional nodes before upgrading, so that they are down for the least amount of time possible.
-         This is the duration of the upgrade of the gateway nodes, not the duration of the upgrade of the entire cluster.
+         &mds;s and &ogw;s are down from the time the nodes are upgraded from
+         &prevcephos; to &cephos; until the services are redeployed at the end
+         of the upgrade procedure. This is particularly important to bear in
+         mind if these services are colocated with MONs, MGRs or OSDs, because
+         in this case they may be down for the entire duration of the cluster
+         upgrade. If this is going to be a problem, consider deploying these
+         services separately on additional nodes before upgrading, so that they
+         are down for the least amount of time possible. This is the duration
+         of the upgrade of the gateway nodes, not the duration of the upgrade
+         of the entire cluster.
         </para>
        </important>
       </listitem>
       <listitem>
        <para>
-        &ganesha; and &igw;s are down only while nodes are rebooting during upgrade from &prevcephos; to &cephos; and again briefly when each service is redeployed in containerized mode.
+        &ganesha; and &igw;s are down only while nodes are rebooting during
+        upgrade from &prevcephos; to &cephos; and again briefly when each
+        service is redeployed in containerized mode.
        </para>
       </listitem>
      </itemizedlist>
@@ -162,48 +194,69 @@
   <sect2 xml:id="upgrade-backup-config-data">
    <title>Backing Up cluster configuration and data</title>
    <para>
-    We strongly recommend backing up all cluster configuration and data before starting your upgrade to &productname; &productnumber;.
-    For instruction on how to back up all your data, see <link xlink:href="https://documentation.suse.com/ses/6/single-html/ses-admin/#cha-deployment-backup"/>.
+    We strongly recommend backing up all cluster configuration and data before
+    starting your upgrade to &productname; &productnumber;. For instruction on
+    how to back up all your data, see
+    <link xlink:href="https://documentation.suse.com/ses/6/single-html/ses-admin/#cha-deployment-backup"/>.
    </para>
   </sect2>
 
   <sect2 xml:id="verify-previous-upgrade">
    <title>Verifying steps from the previous upgrade</title>
    <para>
-    In case you previously upgraded from version 5, verify that the upgrade to version 6 was completed successfully:
+    In case you previously upgraded from version 5, verify that the upgrade to
+    version 6 was completed successfully:
    </para>
    <para>
-    Check for the existence of the <filename>/srv/salt/ceph/configuration/files/ceph.conf.import</filename> file.
+    Check for the existence of the
+    <filename>/srv/salt/ceph/configuration/files/ceph.conf.import</filename>
+    file.
    </para>
    <para>
-    This file is created by the engulf process during the upgrade from &productname; 5 to 6.
-    The <option>configuration_init: default-import</option> option is set in <filename>/srv/pillar/ceph/proposals/config/stack/default/ceph/cluster.yml</filename>.
+    This file is created by the engulf process during the upgrade from
+    &productname; 5 to 6. The <option>configuration_init:
+    default-import</option> option is set in
+    <filename>/srv/pillar/ceph/proposals/config/stack/default/ceph/cluster.yml</filename>.
    </para>
    <para>
-    If <option>configuration_init</option> is still set to <option>default-import</option>, the cluster is using <filename>ceph.conf.import</filename> as its configuration file and not &deepsea;'s default <filename>ceph.conf</filename> which is compiled from files in <filename>/srv/salt/ceph/configuration/files/ceph.conf.d/</filename>.
+    If <option>configuration_init</option> is still set to
+    <option>default-import</option>, the cluster is using
+    <filename>ceph.conf.import</filename> as its configuration file and not
+    &deepsea;'s default <filename>ceph.conf</filename> which is compiled from
+    files in
+    <filename>/srv/salt/ceph/configuration/files/ceph.conf.d/</filename>.
    </para>
    <para>
-    Therefore, you need to inspect <filename>ceph.conf.import</filename> for any custom configuration, and possibly move the configuration to one of the files in <filename>/srv/salt/ceph/configuration/files/ceph.conf.d/</filename>.
+    Therefore, you need to inspect <filename>ceph.conf.import</filename> for
+    any custom configuration, and possibly move the configuration to one of the
+    files in
+    <filename>/srv/salt/ceph/configuration/files/ceph.conf.d/</filename>.
    </para>
    <para>
-    Then remove the <option>configuration_init: default-import</option> line from <filename>/srv/pillar/ceph/proposals/config/stack/default/ceph/cluster.yml</filename>.
+    Then remove the <option>configuration_init: default-import</option> line
+    from
+    <filename>/srv/pillar/ceph/proposals/config/stack/default/ceph/cluster.yml</filename>.
    </para>
   </sect2>
 
   <sect2 xml:id="verify-previous-upgrade-patch">
    <title>Updating cluster nodes and verifying cluster health</title>
    <para>
-    Verify that all latest updates of &prevcephos; and &productname; &prevproductnumber; are applied to all cluster nodes:
+    Verify that all latest updates of &prevcephos; and &productname;
+    &prevproductnumber; are applied to all cluster nodes:
    </para>
 <screen>&prompt.root;zypper refresh &amp;&amp; zypper patch</screen>
    <tip>
     <para>
-     Refer to <link
-     xlink:href="https://documentation.suse.com/ses/6/html/ses-all/storage-salt-cluster.html#deepsea-rolling-updates"/> for detailed information about updating the cluster nodes.
+     Refer to
+     <link
+     xlink:href="https://documentation.suse.com/ses/6/html/ses-all/storage-salt-cluster.html#deepsea-rolling-updates"/>
+     for detailed information about updating the cluster nodes.
     </para>
    </tip>
    <para>
-    After updates are applied, restart the &smaster;, synchronize new &salt; modules, and check the cluster health:
+    After updates are applied, restart the &smaster;, synchronize new &salt;
+    modules, and check the cluster health:
    </para>
 <screen>
 &prompt.smaster;systemctl restart salt-master.service
@@ -215,17 +268,24 @@
   <sect2 xml:id="verify-previous-upgrade-patch-repos">
    <title>Verifying access to software repositories and container images</title>
    <para>
-    Verify that each cluster node has access to &cephos; and &productname; &productnumber; software repositories as well as registry of container images.
+    Verify that each cluster node has access to &cephos; and &productname;
+    &productnumber; software repositories as well as registry of container
+    images.
    </para>
    <sect3 xml:id="verify-previous-upgrade-patch-repos-repos">
     <title>Software repositories</title>
     <para>
-     If all nodes are registered with SCC, you will be able to use the <command>zypper migration</command> command to upgrade.
-     Refer to <link
-      xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-upgrade-online.html#sec-upgrade-online-zypper"/> for more details.
+     If all nodes are registered with SCC, you will be able to use the
+     <command>zypper migration</command> command to upgrade. Refer to
+     <link
+      xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-upgrade-online.html#sec-upgrade-online-zypper"/>
+     for more details.
     </para>
     <para>
-     If nodes are <emphasis role="bold">not</emphasis> registered with SCC, disable all existing software repositories and add both the <literal>Pool</literal> and <literal>Updates</literal> repositories for each of the following extensions:
+     If nodes are <emphasis role="bold">not</emphasis> registered with SCC,
+     disable all existing software repositories and add both the
+     <literal>Pool</literal> and <literal>Updates</literal> repositories for
+     each of the following extensions:
     </para>
     <itemizedlist>
      <listitem>
@@ -253,9 +313,9 @@
    <sect3 xml:id="verify-previous-upgrade-patch-repos-images">
     <title>Container images</title>
     <para>
-     All cluster nodes need access to the container image registry.
-     In most cases, you will use the public SUSE registry at <literal>registry.suse.com</literal>.
-     You need the following images:
+     All cluster nodes need access to the container image registry. In most
+     cases, you will use the public SUSE registry at
+     <literal>registry.suse.com</literal>. You need the following images:
     </para>
     <itemizedlist>
      <listitem>
@@ -285,9 +345,12 @@
      </listitem>
     </itemizedlist>
     <para>
-     Alternatively&mdash;for example, for air-gapped deployments&mdash;configure a local registry and verify that you have the correct set of container images available.
-     Refer to <xref
-     linkend="deploy-cephadm-configure-registry"/> for more details about configuring a local container image registry.
+     Alternatively&mdash;for example, for air-gapped
+     deployments&mdash;configure a local registry and verify that you have the
+     correct set of container images available. Refer to
+     <xref
+     linkend="deploy-cephadm-configure-registry"/> for more details
+     about configuring a local container image registry.
     </para>
    </sect3>
   </sect2>
@@ -307,20 +370,22 @@
     <itemizedlist>
      <listitem>
       <para>
-       For cluster whose all nodes are registered with SCC, run <command>zypper migration</command>.
+       For cluster whose all nodes are registered with SCC, run <command>zypper
+       migration</command>.
       </para>
      </listitem>
      <listitem>
       <para>
-       For cluster whose nodes have software repositories assigned manually, run <command>zypper dup</command> followed by <command>reboot</command>.
+       For cluster whose nodes have software repositories assigned manually,
+       run <command>zypper dup</command> followed by <command>reboot</command>.
       </para>
      </listitem>
     </itemizedlist>
    </step>
    <step>
     <para>
-     Disable the &deepsea; stages to avoid accidental use.
-     Add the following content to <filename>/srv/pillar/ceph/stack/global.yml</filename>:
+     Disable the &deepsea; stages to avoid accidental use. Add the following
+     content to <filename>/srv/pillar/ceph/stack/global.yml</filename>:
     </para>
 <screen>
 stage_prep: disabled
@@ -337,8 +402,13 @@ stage_remove: disabled
    </step>
    <step>
     <para>
-     If you are <emphasis role="bold">not</emphasis> using container images from <literal>registry.suse.com</literal> but rather the locally configured registry, edit <filename>/srv/pillar/ceph/stack/global.yml</filename> to inform &deepsea; which &ceph; container image and registry to use.
-     For example, to use <literal>192.168.121.1:5000/my/ceph/image</literal> add the following lines:
+     If you are <emphasis role="bold">not</emphasis> using container images
+     from <literal>registry.suse.com</literal> but rather the locally
+     configured registry, edit
+     <filename>/srv/pillar/ceph/stack/global.yml</filename> to inform &deepsea;
+     which &ceph; container image and registry to use. For example, to use
+     <literal>192.168.121.1:5000/my/ceph/image</literal> add the following
+     lines:
     </para>
 <screen>
 ses7_container_image: 192.168.121.1:5000/my/ceph/image
@@ -358,8 +428,8 @@ ses7_container_registries:
    </step>
    <step>
     <para>
-     Verify the upgrade status.
-     Your output may differ depending on your cluster configuration:
+     Verify the upgrade status. Your output may differ depending on your
+     cluster configuration:
     </para>
 <screen>
 &prompt.smaster;salt-run upgrade.status
@@ -385,19 +455,23 @@ Nodes running older software versions must be upgraded in the following order:
   <title>Upgrading the MON, MGR, and OSD nodes</title>
 
   <para>
-   Upgrade the &mon;, &mgr;, and OSD nodes one at a time.
-   For each service, follow these steps:
+   Upgrade the &mon;, &mgr;, and OSD nodes one at a time. For each service,
+   follow these steps:
   </para>
 
   <procedure>
    <step>
     <para>
-     If the node you are upgrading is an OSD node, avoid having the OSD marked <literal>out</literal> during the upgrade by running the following command:
+     If the node you are upgrading is an OSD node, avoid having the OSD marked
+     <literal>out</literal> during the upgrade by running the following
+     command:
     </para>
 <screen>&prompt.cephuser;ceph osd add-noout <replaceable>SHORT_NODE_NAME</replaceable></screen>
     <para>
-     Replace <replaceable>SHORT_NODE_NAME</replaceable> with the short name of the node as it appears in the output of the <command>ceph osd tree</command> command.
-     In the following input, the short host names are <literal>ses-min1</literal> and <literal>ses-min2</literal>
+     Replace <replaceable>SHORT_NODE_NAME</replaceable> with the short name of
+     the node as it appears in the output of the <command>ceph osd
+     tree</command> command. In the following input, the short host names are
+     <literal>ses-min1</literal> and <literal>ses-min2</literal>
     </para>
 <screen>
 &prompt.smaster;ceph osd tree
@@ -421,28 +495,34 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
     <itemizedlist>
      <listitem>
       <para>
-       If the cluster's nodes are all registered with SCC, run <command>zypper migration</command>.
+       If the cluster's nodes are all registered with SCC, run <command>zypper
+       migration</command>.
       </para>
      </listitem>
      <listitem>
       <para>
-       If the cluster's nodes have software repositories assigned manually, run <command>zypper dup</command> followed by <command>reboot</command>.
+       If the cluster's nodes have software repositories assigned manually, run
+       <command>zypper dup</command> followed by <command>reboot</command>.
       </para>
      </listitem>
     </itemizedlist>
    </step>
    <step>
     <para>
-     After the node is rebooted, containerize all existing MON, MGR, and OSD daemons on that node by running the following command on the &smaster;:
+     After the node is rebooted, containerize all existing MON, MGR, and OSD
+     daemons on that node by running the following command on the &smaster;:
     </para>
 <screen>&prompt.smaster;salt <replaceable>MINION_ID</replaceable> state.apply ceph.upgrade.ses7.adopt</screen>
     <para>
-     Replace <replaceable>MINION_ID</replaceable> with the ID of the minion that you are upgrading.
-     You can get the list of minion IDs by running the <command>salt-key -L</command> command on the &smaster;.
+     Replace <replaceable>MINION_ID</replaceable> with the ID of the minion
+     that you are upgrading. You can get the list of minion IDs by running the
+     <command>salt-key -L</command> command on the &smaster;.
     </para>
     <tip>
      <para>
-      To see the status and progress of the <emphasis>adoption</emphasis>, check the &dashboard; or run one of the following commands on the &smaster;:
+      To see the status and progress of the <emphasis>adoption</emphasis>,
+      check the &dashboard; or run one of the following commands on the
+      &smaster;:
      </para>
 <screen>
 &prompt.smaster;ceph status
@@ -453,7 +533,9 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
    </step>
    <step>
     <para>
-     After the adoption has successfully finished, unset the <literal>noout</literal> flag if the node you are upgrading is an OSD node:
+     After the adoption has successfully finished, unset the
+     <literal>noout</literal> flag if the node you are upgrading is an OSD
+     node:
     </para>
 <screen>&prompt.cephuser;ceph osd rm-noout <replaceable>SHORT_NODE_NAME</replaceable></screen>
    </step>
@@ -463,35 +545,44 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
   <title>Upgrading gateway nodes</title>
 
   <para>
-   Upgrade your separate gateway nodes (&mds;, &ogw;, &ganesha;, or &igw;) next.
-   Upgrade the underlying OS to &cephos; for each node:
+   Upgrade your separate gateway nodes (&mds;, &ogw;, &ganesha;, or &igw;)
+   next. Upgrade the underlying OS to &cephos; for each node:
   </para>
 
   <itemizedlist>
    <listitem>
     <para>
-     If the cluster's nodes are all registered with &scc;, run the <command>zypper migration</command> command.
+     If the cluster's nodes are all registered with &scc;, run the
+     <command>zypper migration</command> command.
     </para>
    </listitem>
    <listitem>
     <para>
-     If the cluster's nodes have software repositories assigned manually, run the <command>zypper dup</command> followed by the <command>reboot</command> commands.
+     If the cluster's nodes have software repositories assigned manually, run
+     the <command>zypper dup</command> followed by the
+     <command>reboot</command> commands.
     </para>
    </listitem>
   </itemizedlist>
 
   <para>
-   This step also applies for any nodes that are part of the cluster, but do not yet have any roles assigned (if in doubt, check the list of hosts on the &smaster; provided by the <command>salt-key -L</command> command and compare it to the output of the <command>salt-run upgrade.status</command> command).
+   This step also applies for any nodes that are part of the cluster, but do
+   not yet have any roles assigned (if in doubt, check the list of hosts on the
+   &smaster; provided by the <command>salt-key -L</command> command and compare
+   it to the output of the <command>salt-run upgrade.status</command> command).
   </para>
 
   <para>
-   Once the OS is upgraded on all nodes in the cluster, the next step is to install the <package>ceph-salt</package> package and apply the cluster configuration.
-   The actual gateway services are redeployed in a containerized mode at the end of the upgrade procedure.
+   Once the OS is upgraded on all nodes in the cluster, the next step is to
+   install the <package>ceph-salt</package> package and apply the cluster
+   configuration. The actual gateway services are redeployed in a containerized
+   mode at the end of the upgrade procedure.
   </para>
 
   <note>
    <para>
-    &mds; and &ogw; services are unavailable from the time of upgrading to &cephos; until they are redeployed at the end of the upgrade procedure.
+    &mds; and &ogw; services are unavailable from the time of upgrading to
+    &cephos; until they are redeployed at the end of the upgrade procedure.
    </para>
   </note>
  </sect1>
@@ -499,7 +590,9 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
   <title>Installing &cephsalt; and applying the cluster configuration</title>
 
   <para>
-   Before you start the procedure of installing &cephsalt; and applying the cluster configuration, check the cluster and upgrade status by running the following commands:
+   Before you start the procedure of installing &cephsalt; and applying the
+   cluster configuration, check the cluster and upgrade status by running the
+   following commands:
   </para>
 
 <screen>
@@ -511,9 +604,10 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
   <procedure>
    <step>
     <para>
-     Remove the &deepsea;-created <literal>rbd_exporter</literal> and <literal>rgw_exporter</literal> cron jobs.
-     On the &smaster; as the &rootuser; run the <command>crontab -e</command> command to edit the crontab.
-     Delete the following items if present:
+     Remove the &deepsea;-created <literal>rbd_exporter</literal> and
+     <literal>rgw_exporter</literal> cron jobs. On the &smaster; as the
+     &rootuser; run the <command>crontab -e</command> command to edit the
+     crontab. Delete the following items if present:
     </para>
 <screen>
 # SALT_CRON_IDENTIFIER:deepsea rbd_exporter cron job
@@ -526,7 +620,8 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
    </step>
    <step>
     <para>
-     Export cluster configuration from &deepsea;, by running the following commands:
+     Export cluster configuration from &deepsea;, by running the following
+     commands:
     </para>
 <screen>
 &prompt.smaster;salt-run upgrade.ceph_salt_config > ceph-salt-config.json
@@ -564,11 +659,13 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
 <screen>&prompt.smaster;ceph-salt config /ssh generate</screen>
     <tip>
      <para>
-      Verify that the cluster configuration was imported from &deepsea; and specify potentially missed options:
+      Verify that the cluster configuration was imported from &deepsea; and
+      specify potentially missed options:
      </para>
 <screen>&prompt.smaster;ceph-salt config ls</screen>
      <para>
-      For a complete description of cluster configuration, refer to <xref linkend="deploy-cephadm-configure"/>.
+      For a complete description of cluster configuration, refer to
+      <xref linkend="deploy-cephadm-configure"/>.
      </para>
     </tip>
    </step>
@@ -580,12 +677,16 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
    </step>
    <step>
     <para>
-     If you need to supply local container registry URL and access credentials, follow the steps described in <xref linkend="deploy-cephadm-configure-registry"/>.
+     If you need to supply local container registry URL and access credentials,
+     follow the steps described in
+     <xref linkend="deploy-cephadm-configure-registry"/>.
     </para>
    </step>
    <step>
     <para>
-     If you are <emphasis role="bold">not</emphasis> using container images from <literal>registry.suse.com</literal> but rather the locally configured registry, inform &ceph; which container image to use by running
+     If you are <emphasis role="bold">not</emphasis> using container images
+     from <literal>registry.suse.com</literal> but rather the locally
+     configured registry, inform &ceph; which container image to use by running
     </para>
 <screen>&prompt.smaster;ceph config set global container_image <replaceable>IMAGE_NAME</replaceable></screen>
     <para>
@@ -595,9 +696,10 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
    </step>
    <step>
     <para>
-     Stop and disable the &productname; 6 <systemitem
-     class="daemon">ceph-crash</systemitem> daemons.
-     New containerized forms of these daemons are started later automatically.
+     Stop and disable the &productname; 6
+     <systemitem
+     class="daemon">ceph-crash</systemitem> daemons. New
+     containerized forms of these daemons are started later automatically.
     </para>
 <screen>
 &prompt.smaster;salt '*' service.stop ceph-crash
@@ -610,7 +712,8 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
   <title>Upgrading and adopting the monitoring stack</title>
 
   <para>
-   This following procedure adopts all components of the monitoring stack (see <xref linkend="monitoring-alerting"/> for more details).
+   This following procedure adopts all components of the monitoring stack (see
+   <xref linkend="monitoring-alerting"/> for more details).
   </para>
 
   <procedure>
@@ -622,7 +725,8 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
    </step>
    <step>
     <para>
-     On whichever node is running &prometheus;, &grafana; and &alertmanager; (the &smaster; by default), run the following commands:
+     On whichever node is running &prometheus;, &grafana; and &alertmanager;
+     (the &smaster; by default), run the following commands:
     </para>
 <screen>
 &prompt.cephuser;cephadm adopt --style=legacy --name prometheus.$(hostname)
@@ -631,7 +735,9 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
 </screen>
     <tip>
      <para>
-      If you are <emphasis role="bold">not</emphasis> running the default container image registry <literal>registry.suse.com</literal>, you need to specify the image to use, for example:
+      If you are <emphasis role="bold">not</emphasis> running the default
+      container image registry <literal>registry.suse.com</literal>, you need
+      to specify the image to use, for example:
      </para>
 <screen>
 &prompt.cephuser;cephadm --image 192.168.121.1:5000/caasp/v4.5/prometheus-server:2.18.0 \
@@ -642,20 +748,23 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
  adopt --style=legacy --name grafana.$(hostname)
 </screen>
      <para>
-      For more details on using custom or local container images, refer to <xref linkend="monitoring-custom-images"/>.
+      For more details on using custom or local container images, refer to
+      <xref linkend="monitoring-custom-images"/>.
      </para>
     </tip>
    </step>
    <step>
     <para>
-     Remove the Node-Exporter.
-     It does not need to be migrated and will be re-installed as a container when the <filename>specs.yaml</filename> file is applied.
+     Remove the Node-Exporter. It does not need to be migrated and will be
+     re-installed as a container when the <filename>specs.yaml</filename> file
+     is applied.
     </para>
 <screen>&prompt.sudo;zypper rm golang-github-prometheus-node_exporter</screen>
    </step>
    <step>
     <para>
-     Apply the service specifications that you previously exported from &deepsea;:
+     Apply the service specifications that you previously exported from
+     &deepsea;:
     </para>
 <screen>&prompt.cephuser;ceph orch apply -i specs.yaml</screen>
    </step>
@@ -673,9 +782,12 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
   <sect2 xml:id="upgrade-ogw">
    <title>Upgrading the &ogw;</title>
    <para>
-    In &productname; &productnumber;, the &ogw;s are always configured with a realm, which allows for multi-site (see <xref linkend="ceph-rgw-fed"/> for more details) in the future.
-    If you used a single-site &ogw; configuration in &productname; &prevproductnumber;, follow these steps to add a realm.
-    If you do not plan to actually use the multi-site functionality, it is fine to use <literal>default</literal> for the realm, &zgroup; and zone names.
+    In &productname; &productnumber;, the &ogw;s are always configured with a
+    realm, which allows for multi-site (see <xref linkend="ceph-rgw-fed"/> for
+    more details) in the future. If you used a single-site &ogw; configuration
+    in &productname; &prevproductnumber;, follow these steps to add a realm. If
+    you do not plan to actually use the multi-site functionality, it is fine to
+    use <literal>default</literal> for the realm, &zgroup; and zone names.
    </para>
    <procedure>
     <step>
@@ -712,10 +824,11 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
     </step>
     <step>
      <para>
-      Configure the master zone.
-      For this, you will need the ACCESS_KEY and SECRET_KEY of an &ogw; user with the <option>system</option> flag enabled.
-      This is usually the <literal>admin</literal> user.
-      To get the ACCESS_KEY and SECRET_KEY, run <command>radosgw-admin user info --uid admin</command>.
+      Configure the master zone. For this, you will need the ACCESS_KEY and
+      SECRET_KEY of an &ogw; user with the <option>system</option> flag
+      enabled. This is usually the <literal>admin</literal> user. To get the
+      ACCESS_KEY and SECRET_KEY, run <command>radosgw-admin user info --uid
+      admin</command>.
      </para>
 <screen>
 &prompt.cephuser;radosgw-admin zone modify \
@@ -736,7 +849,9 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
     </step>
    </procedure>
    <para>
-    To have the &ogw; service containerized, create its specification file as described in <xref linkend="deploy-cephadm-day2-service-ogw"/>, and apply it.
+    To have the &ogw; service containerized, create its specification file as
+    described in <xref linkend="deploy-cephadm-day2-service-ogw"/>, and apply
+    it.
    </para>
 <screen>
 &prompt.cephuser;ceph orch apply -i <replaceable>RGW</replaceable>.yml
@@ -747,20 +862,27 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
    <title>Upgrading &ganesha;</title>
    &ganesha_support;
    <para>
-    The following demonstrates how to migrate an existing &ganesha; service running &ceph; Nautilus to an &ganesha; container running &ceph; Octopus.
+    The following demonstrates how to migrate an existing &ganesha; service
+    running &ceph; Nautilus to an &ganesha; container running &ceph; Octopus.
    </para>
    <warning>
     <para>
-     The following documentation requires you to have already successfully upgraded the core &ceph; services.
+     The following documentation requires you to have already successfully
+     upgraded the core &ceph; services.
     </para>
    </warning>
    <para>
-    &ganesha; stores additional per-daemon configuration and exports configuration in a &rados; pool.
-    The configured &rados; pool can be found on the <literal>watch_url</literal> line of the <literal>RADOS_URLS</literal> block in the <filename>ganesha.conf</filename> file.
-    By default, this pool will be named <literal>ganesha_config</literal>
+    &ganesha; stores additional per-daemon configuration and exports
+    configuration in a &rados; pool. The configured &rados; pool can be found
+    on the <literal>watch_url</literal> line of the
+    <literal>RADOS_URLS</literal> block in the
+    <filename>ganesha.conf</filename> file. By default, this pool will be named
+    <literal>ganesha_config</literal>
    </para>
    <para>
-    Before attempting any migration, we strongly recommend to make a copy of the export and daemon configuration objects located in the RADOS pool To locate the configured RADOS pool, run the following command:
+    Before attempting any migration, we strongly recommend to make a copy of
+    the export and daemon configuration objects located in the RADOS pool To
+    locate the configured RADOS pool, run the following command:
    </para>
 <screen>&prompt.cephuser;grep -A5 RADOS_URLS /etc/ganesha/ganesha.conf</screen>
    <para>
@@ -789,7 +911,8 @@ drwx------ 9 root root 4.0K Sep 8 03:23 ..
 -rw-r--r-- 1 root root 350 Sep 8 03:30 export-3
 -rw-r--r-- 1 root root 358 Sep 8 03:30 export-4</screen>
    <para>
-    On a per node basis, an existing &ganesha; service needs to be stopped and then replaced with a container managed by &cephadm;.
+    On a per node basis, an existing &ganesha; service needs to be stopped and
+    then replaced with a container managed by &cephadm;.
    </para>
    <procedure>
     <step>
@@ -802,8 +925,12 @@ drwx------ 9 root root 4.0K Sep 8 03:23 ..
     </step>
     <step>
      <para>
-      After the existing &ganesha; service has been stopped, a new one can be deployed in a container using &cephadm;.
-      To do so, you need to create a service specification that contains a <literal>service_id</literal> that will be used to identify this new NFS cluster, the host name of the node we are migrating listed as a host in the placement specification, and the RADOS pool and namespace that contains the configured NFS export objects.
+      After the existing &ganesha; service has been stopped, a new one can be
+      deployed in a container using &cephadm;. To do so, you need to create a
+      service specification that contains a <literal>service_id</literal> that
+      will be used to identify this new NFS cluster, the host name of the node
+      we are migrating listed as a host in the placement specification, and the
+      RADOS pool and namespace that contains the configured NFS export objects.
       For example:
      </para>
 <screen>service_type: nfs
@@ -815,7 +942,8 @@ placement:
   namespace: ganesha
 </screen>
      <para>
-      For more information on creating a placement specification see <xref linkend="cephadm-service-and-placement-specs"/>.
+      For more information on creating a placement specification see
+      <xref linkend="cephadm-service-and-placement-specs"/>.
      </para>
     </step>
     <step>
@@ -834,9 +962,10 @@ nfs.foo.node2  node2  running (26m)  8m ago     27m  3.3      registry.suse.com/
     </step>
     <step>
      <para>
-      Repeat these steps for each &ganesha; node.
-      You do not need to create a separate service specification for each node.
-      It is sufficient to add each node's host name to the existing NFS service specification and re-apply it.
+      Repeat these steps for each &ganesha; node. You do not need to create a
+      separate service specification for each node. It is sufficient to add
+      each node's host name to the existing NFS service specification and
+      re-apply it.
      </para>
     </step>
    </procedure>
@@ -851,7 +980,8 @@ nfs.foo.node2  node2  running (26m)  8m ago     27m  3.3      registry.suse.com/
     </listitem>
     <listitem>
      <para>
-      Manually copy the contents of each per-daemon &rados; object into the newly created &ganesha; common configuration.
+      Manually copy the contents of each per-daemon &rados; object into the
+      newly created &ganesha; common configuration.
      </para>
     </listitem>
    </itemizedlist>
@@ -907,7 +1037,8 @@ drwxr-xr-x 3 root root 4.0K Sep 8 16:47 ..
     </step>
    </procedure>
    <para>
-    After the service has been successfully migrated, the Nautilus based &ganesha; service can be removed.
+    After the service has been successfully migrated, the Nautilus based
+    &ganesha; service can be removed.
    </para>
    <procedure>
     <step>
@@ -943,13 +1074,14 @@ warning: /etc/ganesha/ganesha.conf saved as /etc/ganesha/ganesha.conf.rpmsave</s
   <sect2 xml:id="upgrade-mds">
    <title>Upgrading the &mds;</title>
    <para>
-    Unlike MONs, MGRs and OSDs, &mds; cannot be adopted in-place.
-    Instead, you need to redeploy them in containers using the &ceph; orchestrator.
+    Unlike MONs, MGRs and OSDs, &mds; cannot be adopted in-place. Instead, you
+    need to redeploy them in containers using the &ceph; orchestrator.
    </para>
    <procedure>
     <step>
      <para>
-      Run the <command>ceph fs ls</command> command to obtain the name of your file system, for example:
+      Run the <command>ceph fs ls</command> command to obtain the name of your
+      file system, for example:
      </para>
 <screen>
 &prompt.cephuser;ceph fs ls
@@ -958,8 +1090,10 @@ name: cephfs, metadata pool: cephfs_metadata, data pools: [cephfs_data ]
     </step>
     <step>
      <para>
-      Create a new service specification file <filename>mds.yml</filename> as described in <xref linkend="deploy-cephadm-day2-service-mds"/> by using the file system name as the <option>service_id</option> and specifying the hosts that will run the MDS daemons.
-      For example:
+      Create a new service specification file <filename>mds.yml</filename> as
+      described in <xref linkend="deploy-cephadm-day2-service-mds"/> by using
+      the file system name as the <option>service_id</option> and specifying
+      the hosts that will run the MDS daemons. For example:
      </para>
 <screen>
 service_type: mds
@@ -973,7 +1107,8 @@ placement:
     </step>
     <step>
      <para>
-      Run the <command>ceph orch apply -i mds.yml</command> command to apply the service specification and start the MDS daemons.
+      Run the <command>ceph orch apply -i mds.yml</command> command to apply
+      the service specification and start the MDS daemons.
      </para>
     </step>
    </procedure>
@@ -982,8 +1117,9 @@ placement:
   <sect2 xml:id="upgrade-igw">
    <title>Upgrading the &igw;</title>
    <para>
-    To upgrade the &igw;, you need to redeploy it in containers using the &ceph; orchestrator.
-    If you have multiple &igw;s, you need to redeploy them one-by-one to reduce the service downtime.
+    To upgrade the &igw;, you need to redeploy it in containers using the
+    &ceph; orchestrator. If you have multiple &igw;s, you need to redeploy them
+    one-by-one to reduce the service downtime.
    </para>
    <procedure>
     <step>
@@ -999,13 +1135,19 @@ placement:
     </step>
     <step>
      <para>
-      Create a service specification for the &igw; as described in <xref
-      linkend="deploy-cephadm-day2-service-igw"/>.
-      For this, you need the <option>pool</option>, <option>trusted_ip_list</option>, and <option>api_*</option> settings from the existing <filename>/etc/ceph/iscsi-gateway.cfg</filename> file.
-      If you have SSL support enabled (<literal>api_secure = true</literal>), you also need the SSL certificate (<filename>/etc/ceph/iscsi-gateway.crt</filename>) and key (<filename>/etc/ceph/iscsi-gateway.key</filename>).
+      Create a service specification for the &igw; as described in
+      <xref
+      linkend="deploy-cephadm-day2-service-igw"/>. For this, you
+      need the <option>pool</option>, <option>trusted_ip_list</option>, and
+      <option>api_*</option> settings from the existing
+      <filename>/etc/ceph/iscsi-gateway.cfg</filename> file. If you have SSL
+      support enabled (<literal>api_secure = true</literal>), you also need the
+      SSL certificate (<filename>/etc/ceph/iscsi-gateway.crt</filename>) and
+      key (<filename>/etc/ceph/iscsi-gateway.key</filename>).
      </para>
      <para>
-      For example, if <filename>/etc/ceph/iscsi-gateway.cfg</filename> contains the following:
+      For example, if <filename>/etc/ceph/iscsi-gateway.cfg</filename> contains
+      the following:
      </para>
 <screen>
 [config]
@@ -1018,7 +1160,8 @@ api_password = admin
 api_secure = true
 </screen>
      <para>
-      Then you need to create the following service specification file <filename>iscsi.yml</filename>:
+      Then you need to create the following service specification file
+      <filename>iscsi.yml</filename>:
      </para>
 <screen>
 service_type: iscsi
@@ -1048,20 +1191,30 @@ spec:
 </screen>
      <note>
       <para>
-       The <option>pool</option>, <option>trusted_ip_list</option>, <option>api_port</option>, <option>api_user</option>, <option>api_password</option>, <option>api_secure</option> settings are identical to the ones from the <filename>/etc/ceph/iscsi-gateway.cfg</filename> file.
-       The <option>ssl_cert</option> and <option>ssl_key</option> values can be copied in from the existing SSL certificate and key files.
-       Verify that they are indented correctly and the <emphasis>pipe</emphasis> character <literal>|</literal> appears at the end of the <literal>ssl_cert:</literal> and <literal>ssl_key:</literal> lines (see the content of the <filename>iscsi.yml</filename> file above).
+       The <option>pool</option>, <option>trusted_ip_list</option>,
+       <option>api_port</option>, <option>api_user</option>,
+       <option>api_password</option>, <option>api_secure</option> settings are
+       identical to the ones from the
+       <filename>/etc/ceph/iscsi-gateway.cfg</filename> file. The
+       <option>ssl_cert</option> and <option>ssl_key</option> values can be
+       copied in from the existing SSL certificate and key files. Verify that
+       they are indented correctly and the <emphasis>pipe</emphasis> character
+       <literal>|</literal> appears at the end of the
+       <literal>ssl_cert:</literal> and <literal>ssl_key:</literal> lines (see
+       the content of the <filename>iscsi.yml</filename> file above).
       </para>
      </note>
     </step>
     <step>
      <para>
-      Run the <command>ceph orch apply -i iscsi.yml</command> command to apply the service specification and start the &igw; daemons.
+      Run the <command>ceph orch apply -i iscsi.yml</command> command to apply
+      the service specification and start the &igw; daemons.
      </para>
     </step>
     <step>
      <para>
-      Remove the old <package>ceph-iscsi</package> package from each of the existing iSCSI gateway nodes:
+      Remove the old <package>ceph-iscsi</package> package from each of the
+      existing iSCSI gateway nodes:
      </para>
 <screen>&prompt.cephuser;zypper rm -u ceph-iscsi</screen>
     </step>
@@ -1078,7 +1231,8 @@ spec:
   <procedure>
    <step>
     <para>
-     Verify that the cluster was successfully upgraded by checking the current &ceph; version:
+     Verify that the cluster was successfully upgraded by checking the current
+     &ceph; version:
     </para>
 <screen>&prompt.cephuser;ceph versions</screen>
    </step>
@@ -1095,11 +1249,16 @@ spec:
 <screen>&prompt.cephuser;ceph mgr module enable pg_autoscaler</screen>
     <important>
      <para>
-      Pools in &productname; 6 had the <option>pg_autoscale_mode</option> set to <option>warn</option> by default.
-      This resulted in a warning message in case of suboptimal number of PGs, but autoscaling did not actually happen.
-      The default in &productname; &productnumber; is the <option>pg_autoscale_mode</option> option is set to <option>on</option> for new pools and PGs will actually autoscale.
-      The upgrade process does not automatically change the <option>pg_autoscale_mode</option> of existing pools.
-      If you want to change it to <option>on</option> to get the full benefit of the autoscaler, see the instructions in <xref
+      Pools in &productname; 6 had the <option>pg_autoscale_mode</option> set
+      to <option>warn</option> by default. This resulted in a warning message
+      in case of suboptimal number of PGs, but autoscaling did not actually
+      happen. The default in &productname; &productnumber; is the
+      <option>pg_autoscale_mode</option> option is set to <option>on</option>
+      for new pools and PGs will actually autoscale. The upgrade process does
+      not automatically change the <option>pg_autoscale_mode</option> of
+      existing pools. If you want to change it to <option>on</option> to get
+      the full benefit of the autoscaler, see the instructions in
+      <xref
       linkend="op-pgs-autoscaler"/>.
      </para>
     </important>


### PR DESCRIPTION
Revise monitoring adoption section

- Add docs about how to set Node-Exporter image in cephadm for local registry.
- Be more clear about having to remove the Node-Exporter service from all nodes.
- Add a command to remove Node-Exporter from all nodes at once with Salt.
- Other text revisions.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1181301

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>
