### PR TITLE
highlight existence of formatting tool for contributors

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -51,7 +51,7 @@ Thank you for contributing to this repo. When creating a pull request, please fo
 
 . For help on style and structure, refer to the https://documentation.suse.com/style/current[Documentation Style Guide].
 
-. Modified docbook files are re-formatted automatically on each pull request. if you still want to reformat the documentation manually, use `daps xmlformat`.
+. Modified DocBook files are re-formatted automatically on each pull request. If you still want to reformat the documentation manually, use `daps xmlformat`.
 
 == Editing DocBook
 

--- a/README.adoc
+++ b/README.adoc
@@ -51,6 +51,7 @@ Thank you for contributing to this repo. When creating a pull request, please fo
 
 . For help on style and structure, refer to the https://documentation.suse.com/style/current[Documentation Style Guide].
 
+. To reformat the documentation automatically, use `daps xmlformat`.
 
 == Editing DocBook
 

--- a/README.adoc
+++ b/README.adoc
@@ -51,7 +51,7 @@ Thank you for contributing to this repo. When creating a pull request, please fo
 
 . For help on style and structure, refer to the https://documentation.suse.com/style/current[Documentation Style Guide].
 
-. To reformat the documentation automatically, use `daps xmlformat`.
+. Modified docbook files are re-formatted automatically on each pull request. if you still want to reformat the documentation manually, use `daps xmlformat`.
 
 == Editing DocBook
 


### PR DESCRIPTION
Although I eventually found a reference to `daps-xmlformat` documented in the [Documentation Style Guide (at the end of chapter 8)](https:/documentation.suse.comstylecurrent), where the `README.adoc` is also pointing to, I can't help but wondering if it wouldn't be a little bit better to explicitly and briefly mention its existence directly in the `README.adoc`.

What do you think?

Fixes #901 

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>