### PR TITLE
Update ceph-dokan uid/gid instructions

### DIFF
--- a/xml/app_win_sample_conffile.xml
+++ b/xml/app_win_sample_conffile.xml
@@ -20,12 +20,22 @@
 <screen>
 [global]
      log to stderr = true
+     ; Uncomment the following in order to use the Windows Event Log
+     ; log to syslog = true
+
      run dir = C:/ProgramData/ceph
      crash dir = C:/ProgramData/ceph
+
+     ; Use the following to change the cephfs client log level
+     ; debug client = 2
 [client]
      keyring = C:/ProgramData/ceph/keyring
-     log file = C:/ProgramData/ceph/$name.$pid.log
+     ; log file = C:/ProgramData/ceph/$name.$pid.log
      admin socket = C:/ProgramData/ceph/$name.$pid.asok
+
+     ; client_permissions = true
+     ; client_mount_uid = 1000
+     ; client_mount_gid = 1000
 [global]
      ; Specify IP addresses for monitor nodes as in the following example: ;
      mon host = [v2:10.1.1.1:3300,v1:10.1.1.1:6789] [v2:10.1.1.2:3300,v1:10.1.1.2:6789] [v2:10.1.1.3:3300,v1:1.1.1.3:6789]

--- a/xml/windows-ses.xml
+++ b/xml/windows-ses.xml
@@ -329,7 +329,7 @@ SYSTEM\CurrentControlSet\Services\rbd-wnbd
 
   <para>
    &ceph; for &mswin; provides &cephfs; support through the Dokany FUSE
-   wrapper. In order to use &cephfs;, install Dokany v1.3.1 or newer using the
+   wrapper. In order to use &cephfs;, install Dokany v1.4.1 or newer using the
    installers available here: https://github.com/dokan-dev/dokany/releases
   </para>
 
@@ -359,13 +359,25 @@ ceph-dokan.exe -l x
 
   <para>
    The UID and GID used for mounting the file system defaults to
-   <literal>0</literal> and may be changed using the <option>-u</option> and
-   <option>-g</option> arguments. <option>-n</option> can be used in order to
-   skip enforcing permissions on client side. Be aware that &mswin; Access
-   Control Lists (ACLs) are ignored. Portable Operating System Interface
-   (POSIX) ACLs are supported but cannot be modified using the current CLI. In
-   the future, we may add some command actions to change file ownership or
-   permissions.
+   <literal>0</literal> and may be changed using the following
+   <filename>ceph.conf</filename> options:
+  </para>
+<screen>
+[client]
+# client_permissions = true
+client_mount_uid = 1000
+client_mount_gid = 1000
+</screen>
+  <para>
+   Be aware that &mswin; Access Control Lists (ACLs) are ignored. Portable
+   Operating System Interface (POSIX) ACLs are supported but cannot be
+   modified using the current CLI.
+  </para>
+
+  <para>
+   Another thing to note is that &cephfs; doesn’t support mandatory file
+   locks, which &mswin; heavily relies upon. At the moment, we’re letting
+   Dokan handle file locks, which are only enforced locally.
   </para>
 
   <para>
@@ -377,7 +389,9 @@ ceph-dokan.exe -l x
 
   <para>
    You may use <option>--help</option> to get the full list of available
-   options.
+   options. Additional information on this <emphasis>experimental</emphasis>
+   feature may be found in the upstream &ceph; documentation:
+   <link xlink:href="https://docs.ceph.com/en/latest/cephfs/ceph-dokan"/>
   </para>
  </sect1>
 </chapter>

--- a/xml/windows-ses.xml
+++ b/xml/windows-ses.xml
@@ -376,9 +376,10 @@ client_mount_gid = 1000
   </para>
   </important>
 
+  <important>
   <para>
-   Another thing to note is that &cephfs; doesn’t support mandatory file
-   locks, which &mswin; heavily relies upon. At the moment, we’re letting
+   &cephfs; does not support mandatory file
+   locks, which &mswin; heavily relies upon. At the moment, we are letting
    Dokan handle file locks, which are only enforced locally.
   </para>
 

--- a/xml/windows-ses.xml
+++ b/xml/windows-ses.xml
@@ -382,7 +382,7 @@ client_mount_gid = 1000
    locks, which &mswin; heavily relies upon. At the moment, we are letting
    Dokan handle file locks, which are only enforced locally.
   </para>
-
+</important>
   <para>
    For debugging purposes, <option>-d</option> and <option>-s</option> may be
    used. The former enables debug output and the latter enables

--- a/xml/windows-ses.xml
+++ b/xml/windows-ses.xml
@@ -368,11 +368,13 @@ ceph-dokan.exe -l x
 client_mount_uid = 1000
 client_mount_gid = 1000
 </screen>
+  <important>
   <para>
-   Be aware that &mswin; Access Control Lists (ACLs) are ignored. Portable
+   &mswin; Access Control Lists (ACLs) are ignored. Portable
    Operating System Interface (POSIX) ACLs are supported but cannot be
    modified using the current CLI.
   </para>
+  </important>
 
   <para>
    Another thing to note is that &cephfs; doesn’t support mandatory file


### PR DESCRIPTION
Command line parameters have been transitioned to ceph.conf settings.
Update documentation and examples to reflect this.

Addresses #879 

Signed-off-by: Mike Latimer <mlatimer@suse.com>