### PR TITLE
doc: rook operator needs to get stoped on OSD removal

### DIFF
--- a/xml/admin_caasp_cephosd.xml
+++ b/xml/admin_caasp_cephosd.xml
@@ -106,7 +106,7 @@
     <step>
      <para>
       On host-based clusters, you may need to stop the &rook; Operator 
-      while performing OSD removal steps in order to prevent Rook from 
+      while performing OSD removal steps in order to prevent &rook; from 
       detecting the old OSD and trying to re-create it before the disk is wiped 
       or removed.
      </para>

--- a/xml/admin_caasp_cephosd.xml
+++ b/xml/admin_caasp_cephosd.xml
@@ -105,7 +105,7 @@
     </step>
     <step>
      <para>
-      On host-based clusters, you may need to stop the Rook Operator 
+      On host-based clusters, you may need to stop the &rook; Operator 
       while performing OSD removal steps in order to prevent Rook from 
       detecting the old OSD and trying to re-create it before the disk is wiped 
       or removed.

--- a/xml/admin_caasp_cephosd.xml
+++ b/xml/admin_caasp_cephosd.xml
@@ -103,6 +103,14 @@
       removing multiple OSDs
      </para>
     </step>
+    <step>
+     <para>
+      On host-based clusters, you may need to stop the Rook Operator 
+      while performing OSD removal steps in order to prevent Rook from 
+      detecting the old OSD and trying to re-create it before the disk is wiped 
+      or removed.
+     </para>
+    </step>
    </procedure>
    <para>
     If all the PGs are <literal>active+clean</literal> and there are no


### PR DESCRIPTION
This important part was missing when removing/replacing OSDs on a rook-based Ceph-cluster

On host-based clusters, you may need to stop the Rook Operator while performing OSD removal steps in order to prevent Rook from detecting the old OSD and trying to re-create it before the disk is wiped or removed.

Signed-off-by: Stefan Haas <shaas@suse.com>