### PR TITLE
Replaced with radosgw-admin zone 'delete' instead of 'rm' (bsc#1186263)

### DIFF
--- a/xml/admin_ceph_gateway.xml
+++ b/xml/admin_ceph_gateway.xml
@@ -6,7 +6,7 @@
 ]>
 <!-- Converted by suse-upgrade version 1.1 -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-ceph-gw">
-<!-- ============================================================== -->
+ <!-- ============================================================== -->
  <title>&cogw;</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -2247,9 +2247,9 @@ number_of_objects_expected_in_a_bucket / 100000
    <title>Displaying placement targets</title>
    <para>
     Placement targets control which pools are associated with a particular
-    bucket. A bucket’s placement target is selected on creation, and cannot
-    be modified. You can display its <literal>placement_rule</literal> by
-    running the following command:
+    bucket. A bucket’s placement target is selected on creation, and cannot be
+    modified. You can display its <literal>placement_rule</literal> by running
+    the following command:
    </para>
 <screen>
 &prompt.cephuser;radosgw-admin bucket stats

--- a/xml/admin_ceph_gateway.xml
+++ b/xml/admin_ceph_gateway.xml
@@ -2906,11 +2906,13 @@ number_of_objects_expected_in_a_bucket / 100000
      <option>secret_key</option> of the generated system user stored in the
      master zone of the master &zgroup;. Execute the following:
     </para>
-<screen>&prompt.cephuser;radosgw-admin zone create --rgw-zonegroup=<replaceable>ZONE-GROUP-NAME</replaceable>\
-                            --rgw-zone=<replaceable>ZONE-NAME</replaceable> --endpoints=<replaceable>URL</replaceable> \
-                            --access-key=<replaceable>SYSTEM-KEY</replaceable> --secret=<replaceable>SECRET</replaceable>\
-                            --endpoints=http://<replaceable>FQDN</replaceable>:80 \
-                            [--read-only]</screen>
+<screen>
+&prompt.cephuser;radosgw-admin zone create --rgw-zonegroup=<replaceable>ZONE-GROUP-NAME</replaceable>\
+ --rgw-zone=<replaceable>ZONE-NAME</replaceable> --endpoints=<replaceable>URL</replaceable> \
+ --access-key=<replaceable>SYSTEM-KEY</replaceable> --secret=<replaceable>SECRET</replaceable>\
+ --endpoints=http://<replaceable>FQDN</replaceable>:80 \
+ [--read-only]
+</screen>
     <para>
      For example:
     </para>
@@ -2960,7 +2962,7 @@ number_of_objects_expected_in_a_bucket / 100000
     <para>
      Delete the default zone if needed:
     </para>
-<screen>&prompt.cephuser;radosgw-admin zone rm --rgw-zone=default</screen>
+<screen>&prompt.cephuser;radosgw-admin zone delete --rgw-zone=default</screen>
     <para>
      Delete the default pools in your &ceph; storage cluster if needed:
     </para>


### PR DESCRIPTION
closes bsc#1186263