### PR TITLE
Fix only migrate data to an EC Pool command

### DIFF
--- a/xml/admin_operating_pools.xml
+++ b/xml/admin_operating_pools.xml
@@ -1105,7 +1105,7 @@ pool4                     1.1 MiB      13      0     39                  0      
        instead:
       </para>
 <screen>
-&prompt.cephuser;rbd migration prepare <replaceable>SRC_POOL</replaceable>/<replaceable>IMAGE</replaceable> \
+&prompt.cephuser;rbd migration prepare <replaceable>SRC_POOL</replaceable>/<replaceable>IMAGE</replaceable> <replaceable>SRC_POOL</replaceable>/<replaceable>IMAGE</replaceable> \
  --data-pool <replaceable>TARGET_POOL</replaceable>/<replaceable>IMAGE</replaceable>
 </screen>
      </tip>

--- a/xml/admin_operating_pools.xml
+++ b/xml/admin_operating_pools.xml
@@ -1105,8 +1105,8 @@ pool4                     1.1 MiB      13      0     39                  0      
        instead:
       </para>
 <screen>
-&prompt.cephuser;rbd migration prepare <replaceable>SRC_POOL</replaceable>/<replaceable>IMAGE</replaceable> <replaceable>SRC_POOL</replaceable>/<replaceable>IMAGE</replaceable> \
- --data-pool <replaceable>TARGET_POOL</replaceable>/<replaceable>IMAGE</replaceable>
+&prompt.cephuser;rbd migration prepare <replaceable>SRC_METADATA_POOL</replaceable>/<replaceable>IMAGE</replaceable> <replaceable>TARGET_METADATA_POOL</replaceable>/<replaceable>IMAGE</replaceable> \
+ --data-pool <replaceable>TARGET_DATA_POOL</replaceable>/<replaceable>IMAGE</replaceable>
 </screen>
      </tip>
     </step>


### PR DESCRIPTION
The command currently is incorrect, in as such as it by default will attempt to migrate to the pool `rbd`, and since that pool in general does not exist anymore on clusters, using the command as it currently is documented will result in the following failure:

```
rbd: error opening default pool 'rbd'
Ensure that the default pool has been created or specify an alternate pool name.
```

It is thus required to in this case again specify the existing metadata pool and image as the target metadata pool/image and only specify the new data pool using the `--data-pool` option.