### PR TITLE
Add missing -i option

### DIFF
--- a/xml/dashboard_user_cmdline.xml
+++ b/xml/dashboard_user_cmdline.xml
@@ -100,8 +100,8 @@
   </para>
 
   <para>
-   User accounts are stored in &mon;’s configuration database and are globally
-   shared across all &mgr; instances.
+   User accounts are stored in &mon;'s configuration database and are shared
+   globally across all &mgr; instances.
   </para>
 
   <para>

--- a/xml/dashboard_user_cmdline.xml
+++ b/xml/dashboard_user_cmdline.xml
@@ -121,7 +121,7 @@
     <term>Create a new user:</term>
     <listitem>
 <screen>
-&prompt.cephuser;ceph dashboard ac-user-create <replaceable>USERNAME</replaceable> [<replaceable>PASSWORD</replaceable>] [<replaceable>ROLENAME</replaceable>] [<replaceable>NAME</replaceable>] [<replaceable>EMAIL</replaceable>]
+&prompt.cephuser;ceph dashboard ac-user-create <replaceable>USERNAME</replaceable> -i [<replaceable>PASSWORD_FILE</replaceable>] [<replaceable>ROLENAME</replaceable>] [<replaceable>NAME</replaceable>] [<replaceable>EMAIL</replaceable>]
 </screen>
     </listitem>
    </varlistentry>
@@ -137,7 +137,7 @@
     <term>Change a user's password:</term>
     <listitem>
 <screen>
-&prompt.cephuser;ceph dashboard ac-user-set-password <replaceable>USERNAME</replaceable> <replaceable>PASSWORD</replaceable>
+&prompt.cephuser;ceph dashboard ac-user-set-password <replaceable>USERNAME</replaceable> -i <replaceable>PASSWORD_FILE</replaceable>
 </screen>
     </listitem>
    </varlistentry>

--- a/xml/dashboard_user_cmdline.xml
+++ b/xml/dashboard_user_cmdline.xml
@@ -100,8 +100,8 @@
   </para>
 
   <para>
-   User accounts are stored in &mon;’s configuration database and are
-   globally shared across all &mgr; instances.
+   User accounts are stored in &mon;’s configuration database and are globally
+   shared across all &mgr; instances.
   </para>
 
   <para>


### PR DESCRIPTION
The current management user commands mentions to simply specify the [PASSWORD] for the user, this will error out with for example:

`Error EINVAL: Please specify the file containing the password/secret with "-i" option.`

It is required to specify a password file containing the password using the -i option.