### PR TITLE
Pool name should be specified first

### DIFF
--- a/xml/admin_ceph_erasure.xml
+++ b/xml/admin_ceph_erasure.xml
@@ -387,7 +387,7 @@ ABCDEFGHI</screen>
   </para>
 
 <screen>
-&prompt.cephuser;ceph osd pool application enable rbd <replaceable>ec_pool_name</replaceable>
+&prompt.cephuser;ceph osd pool application enable <replaceable>ec_pool_name</replaceable> rbd
 </screen>
 
   <para>


### PR DESCRIPTION
Command syntax is incorrect for marking an EC pool as an RBD pool, the pool name needs to be specified before the application (we do seem to have this properly set elsewhere in the documentation), else (with the command as it is now in this part of the documentation) the following error will be returned since we then look for a pool name called `rbd` (which does by default not exist):

`Error ENOENT: unrecognized pool 'rbd'`