### PR TITLE
Update user info command syntax

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -890,7 +890,7 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
       SECRET_KEY of an &ogw; user with the <option>system</option> flag
       enabled. This is usually the <literal>admin</literal> user. To get the
       ACCESS_KEY and SECRET_KEY, run <command>radosgw-admin user info --uid
-      admin</command>.
+      admin --rgw-zone=<replaceable>ZONE_NAME</replaceable></command>.
      </para>
 <screen>
 &prompt.cephuser;radosgw-admin zone modify \


### PR DESCRIPTION
The command needs to include the zone else it will fail as follows:

'''
2021-09-24T21:10:40.291+0200 7f8ec8e14a40  1 Cannot find zone id= (name=), switching to local zonegroup configuration
2021-09-24T21:10:40.291+0200 7f8ec8e14a40 -1 Cannot find zone id= (name=)
2021-09-24T21:10:40.291+0200 7f8ec8e14a40  0 ERROR: failed to start notify service ((22) Invalid argument
2021-09-24T21:10:40.291+0200 7f8ec8e14a40  0 ERROR: failed to init services (ret=(22) Invalid argument)
'''