### PR TITLE
Update Dashboard SSO information

### DIFF
--- a/xml/dashboard_manual_config.xml
+++ b/xml/dashboard_manual_config.xml
@@ -418,7 +418,8 @@
     <listitem>
      <para>
       Optional. File path or content of the certificate that will be used by
-      &dashboard; (Service Provider) for signing and encryption (these file paths should be accessible from the active ceph-mgr instance).
+      &dashboard; (Service Provider) for signing and encryption (these file
+      paths should be accessible from the active ceph-mgr instance).
      </para>
     </listitem>
    </varlistentry>

--- a/xml/dashboard_manual_config.xml
+++ b/xml/dashboard_manual_config.xml
@@ -418,8 +418,8 @@
     <listitem>
      <para>
       Optional. File path or content of the certificate that will be used by
-      &dashboard; (Service Provider) for signing and encryption (these file
-      paths should be accessible from the active ceph-mgr instance).
+      &dashboard; (Service Provider) for signing and encryption. These file
+      paths need to be accessible from the active &mgr; instance.
      </para>
     </listitem>
    </varlistentry>

--- a/xml/dashboard_manual_config.xml
+++ b/xml/dashboard_manual_config.xml
@@ -418,7 +418,7 @@
     <listitem>
      <para>
       Optional. File path or content of the certificate that will be used by
-      &dashboard; (Service Provider) for signing and encryption.
+      &dashboard; (Service Provider) for signing and encryption (these file paths should be accessible from the active ceph-mgr instance).
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
The cert files should be present on the active MGR host, this information is specified since August in the online Ceph documentation (see https://docs.ceph.com/en/latest/mgr/dashboard/#enabling-single-sign-on-sso) but are not reflected currently in our documentation.