### PR TITLE
Revert update of Node-Exporter from 1.0.1 to 0.18.1

### DIFF
--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -163,7 +163,7 @@
    </listitem>
    <listitem>
     <para>
-     registry.suse.com/caasp/v4.5/prometheus-node-exporter:1.0.1
+     registry.suse.com/caasp/v4.5/prometheus-node-exporter:0.18.1
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
Revert update to Node-Exporter container. The issue that was tried to be solved by an update turned out to have been a mistake in merging. That way the correct version was replaced by an older one that was no longer available on registry.suse.com. This has been restored in https://github.com/SUSE/ceph/pull/445 to refer to Node-Exporter version 0.18.1. Naturally, the docs need to point to that version as well. Sorry for the fuss!