### PR TITLE
clean dm_tags ses6

### DIFF
--- a/de/xml/MAIN.susestorage.xml
+++ b/de/xml/MAIN.susestorage.xml
@@ -12,15 +12,15 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:editurl>https://github.com/SUSE/doc-ses/edit/maintenance/ses6/xml/</dm:editurl>
         <dm:maintainer>tbazant@suse.com</dm:maintainer>
-        <dm:status>Bearbeiten</dm:status>
+        <dm:status>editing</dm:status>
         <dm:deadline/>
         <dm:priority/>
-        <dm:translation>Ja</dm:translation>
+        <dm:translation>yes</dm:translation>
         <dm:languages/>
         <dm:release>SES 6</dm:release>
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Dokumentation</dm:component>
+          <dm:component>Documentation</dm:component>
           <dm:product>SUSE Enterprise Storage 6</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/es/xml/MAIN.susestorage.xml
+++ b/es/xml/MAIN.susestorage.xml
@@ -20,7 +20,7 @@
         <dm:release>SES 6</dm:release>
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Documentacion</dm:component>
+          <dm:component>Documentation</dm:component>
           <dm:product>SUSE Enterprise Storage 6</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/es/xml/MAIN.susestorage.xml
+++ b/es/xml/MAIN.susestorage.xml
@@ -12,15 +12,15 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:editurl>https://github.com/SUSE/doc-ses/edit/maintenance/ses6/xml/</dm:editurl>
         <dm:maintainer>tbazant@suse.com</dm:maintainer>
-        <dm:status>editar</dm:status>
+        <dm:status>editing</dm:status>
         <dm:deadline/>
         <dm:priority/>
-        <dm:translation>sí</dm:translation>
+        <dm:translation>yes</dm:translation>
         <dm:languages/>
         <dm:release>SES 6</dm:release>
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Documentación</dm:component>
+          <dm:component>Documentacion</dm:component>
           <dm:product>SUSE Enterprise Storage 6</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/fr/xml/MAIN.susestorage.xml
+++ b/fr/xml/MAIN.susestorage.xml
@@ -12,10 +12,10 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:editurl>https://github.com/SUSE/doc-ses/edit/maintenance/ses6/xml/</dm:editurl>
         <dm:maintainer>tbazant@suse.com</dm:maintainer>
-        <dm:status>modification</dm:status>
+        <dm:status>editing</dm:status>
         <dm:deadline/>
         <dm:priority/>
-        <dm:translation>oui</dm:translation>
+        <dm:translation>yes</dm:translation>
         <dm:languages/>
         <dm:release>SES 6</dm:release>
         <dm:bugtracker>

--- a/it/xml/MAIN.susestorage.xml
+++ b/it/xml/MAIN.susestorage.xml
@@ -15,7 +15,7 @@
         <dm:status>editing</dm:status>
         <dm:deadline/>
         <dm:priority/>
-        <dm:translation>sì</dm:translation>
+        <dm:translation>yes</dm:translation>
         <dm:languages/>
         <dm:release>SES 6</dm:release>
         <dm:bugtracker>

--- a/it/xml/MAIN.susestorage.xml
+++ b/it/xml/MAIN.susestorage.xml
@@ -20,7 +20,7 @@
         <dm:release>SES 6</dm:release>
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Documentacion</dm:component>
+          <dm:component>Documentation</dm:component>
           <dm:product>SUSE Enterprise Storage 6</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/it/xml/MAIN.susestorage.xml
+++ b/it/xml/MAIN.susestorage.xml
@@ -12,7 +12,7 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:editurl>https://github.com/SUSE/doc-ses/edit/maintenance/ses6/xml/</dm:editurl>
         <dm:maintainer>tbazant@suse.com</dm:maintainer>
-        <dm:status>modifica</dm:status>
+        <dm:status>editing</dm:status>
         <dm:deadline/>
         <dm:priority/>
         <dm:translation>sì</dm:translation>
@@ -20,7 +20,7 @@
         <dm:release>SES 6</dm:release>
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Documentazione</dm:component>
+          <dm:component>Documentacion</dm:component>
           <dm:product>SUSE Enterprise Storage 6</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/ja/xml/MAIN.susestorage.xml
+++ b/ja/xml/MAIN.susestorage.xml
@@ -12,7 +12,7 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:editurl>https://github.com/SUSE/doc-ses/edit/maintenance/ses6/xml/</dm:editurl>
         <dm:maintainer>tbazant@suse.com</dm:maintainer>
-        <dm:status>編集</dm:status>
+        <dm:status>editing</dm:status>
         <dm:deadline/>
         <dm:priority/>
         <dm:translation>yes</dm:translation>
@@ -21,7 +21,7 @@
         <dm:bugtracker>
           <dm:url>https://github.com/SUSE/doc-ses/issues/new/choose</dm:url>
           <dm:assignee>asettle</dm:assignee>
-          <dm:labels>バグ、質問、機能要求</dm:labels>
+          <dm:labels>Documentation</dm:labels>
         </dm:bugtracker>
       </dm:docmanager>
     </info>

--- a/pt_br/xml/MAIN.susestorage.xml
+++ b/pt_br/xml/MAIN.susestorage.xml
@@ -20,7 +20,7 @@
         <dm:release>SES 6</dm:release>
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Documentacion</dm:component>
+          <dm:component>Documentation</dm:component>
           <dm:product>SUSE Enterprise Storage 6</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/pt_br/xml/MAIN.susestorage.xml
+++ b/pt_br/xml/MAIN.susestorage.xml
@@ -15,7 +15,7 @@
         <dm:status>editing</dm:status>
         <dm:deadline/>
         <dm:priority/>
-        <dm:translation>yes (sim)</dm:translation>
+        <dm:translation>yes</dm:translation>
         <dm:languages/>
         <dm:release>SES 6</dm:release>
         <dm:bugtracker>

--- a/pt_br/xml/MAIN.susestorage.xml
+++ b/pt_br/xml/MAIN.susestorage.xml
@@ -12,7 +12,7 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:editurl>https://github.com/SUSE/doc-ses/edit/maintenance/ses6/xml/</dm:editurl>
         <dm:maintainer>tbazant@suse.com</dm:maintainer>
-        <dm:status>editando</dm:status>
+        <dm:status>editing</dm:status>
         <dm:deadline/>
         <dm:priority/>
         <dm:translation>yes (sim)</dm:translation>
@@ -20,7 +20,7 @@
         <dm:release>SES 6</dm:release>
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>Documentação</dm:component>
+          <dm:component>Documentacion</dm:component>
           <dm:product>SUSE Enterprise Storage 6</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/zh_cn/xml/MAIN.susestorage.xml
+++ b/zh_cn/xml/MAIN.susestorage.xml
@@ -12,7 +12,7 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:editurl>https://github.com/SUSE/doc-ses/edit/maintenance/ses6/xml/</dm:editurl>
         <dm:maintainer>tbazant@suse.com</dm:maintainer>
-        <dm:status>编辑</dm:status>
+        <dm:status>editing</dm:status>
         <dm:deadline/>
         <dm:priority/>
         <dm:translation>yes</dm:translation>
@@ -20,7 +20,7 @@
         <dm:release>SES 6</dm:release>
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>文档</dm:component>
+          <dm:component>Documentation</dm:component>
           <dm:product>SUSE Enterprise Storage 6</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>

--- a/zh_tw/xml/MAIN.susestorage.xml
+++ b/zh_tw/xml/MAIN.susestorage.xml
@@ -12,7 +12,7 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:editurl>https://github.com/SUSE/doc-ses/edit/maintenance/ses6/xml/</dm:editurl>
         <dm:maintainer>tbazant@suse.com</dm:maintainer>
-        <dm:status>編輯</dm:status>
+        <dm:status>editing</dm:status>
         <dm:deadline/>
         <dm:priority/>
         <dm:translation>yes</dm:translation>
@@ -20,7 +20,7 @@
         <dm:release>SES 6</dm:release>
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>文件</dm:component>
+          <dm:component>Documentation</dm:component>
           <dm:product>SUSE Enterprise Storage 6</dm:product>
           <dm:assignee>tbazant@suse.com</dm:assignee>
         </dm:bugtracker>


### PR DESCRIPTION
dm: tag cleaned-up  for all languages of SES 6.

Will be done for each branch version separately therefore no backports needed