### PR TITLE
Update monitoring container images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.swp
 
 build/
+
+.idea/

--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -357,17 +357,17 @@
      </listitem>
      <listitem>
       <para>
-       registry.suse.com/caasp/v4.5/prometheus-server
+       registry.suse.com/ses/7/prometheus/prometheus-server
       </para>
      </listitem>
      <listitem>
       <para>
-       registry.suse.com/caasp/v4.5/prometheus-node-exporter
+       registry.suse.com/ses/7/prometheus/prometheus-node-exporter
       </para>
      </listitem>
      <listitem>
       <para>
-       registry.suse.com/caasp/v4.5/prometheus-alertmanager
+       registry.suse.com/ses/7/prometheus/prometheus-alertmanager
       </para>
      </listitem>
     </itemizedlist>
@@ -781,9 +781,9 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
       to specify the image to use on each command, for example:
      </para>
 <screen>
-&prompt.cephuser;cephadm --image 192.168.121.1:5000/caasp/v4.5/prometheus-server:2.18.0 \
+&prompt.cephuser;cephadm --image 192.168.121.1:5000/ses/7/prometheus/prometheus-server:2.27.1 \
   adopt --style=legacy --name prometheus.$(hostname)
-&prompt.cephuser;cephadm --image 192.168.121.1:5000/caasp/v4.5/prometheus-alertmanager:0.16.2 \
+&prompt.cephuser;cephadm --image 192.168.121.1:5000/ses/7/prometheus/prometheus-alertmanager:0.21.0 \
   adopt --style=legacy --name alertmanager.$(hostname)
 &prompt.cephuser;cephadm --image 192.168.121.1:5000/ses/7/ceph/grafana:7.3.1 \
  adopt --style=legacy --name grafana.$(hostname)

--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -158,17 +158,17 @@
   <itemizedlist>
    <listitem>
     <para>
-     registry.suse.com/caasp/v4.5/prometheus-server:2.18.0
+     registry.suse.com/ses/7/prometheus/prometheus-server:2.27.1
     </para>
    </listitem>
    <listitem>
     <para>
-     registry.suse.com/caasp/v4.5/prometheus-node-exporter:0.18.1
+     registry.suse.com/ses/7/prometheus/prometheus-node-exporter:1.1.2
     </para>
    </listitem>
    <listitem>
     <para>
-     registry.suse.com/caasp/v4.5/prometheus-alertmanager:0.16.2
+     registry.suse.com/ses/7/prometheus/prometheus-alertmanager:0.21.0
     </para>
    </listitem>
    <listitem>

--- a/xml/bp_troubleshooting_cephadm.xml
+++ b/xml/bp_troubleshooting_cephadm.xml
@@ -89,8 +89,8 @@
     </para>
 <screen>
 &prompt.cephuser;ceph orch ps --daemon-type prometheus
-NAME               HOST    STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                                             IMAGE ID      CONTAINER ID
-prometheus.master  master  running (65m)  7m ago     2h   2.18.0   registry.suse.com/caasp/v4.5/prometheus-server:2.18.0  e77db6e75e78  7b11062150ab
+NAME               HOST    STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                                                   IMAGE ID      CONTAINER ID
+prometheus.master  master  running (65m)  7m ago     2h   2.27.1   registry.suse.com/ses/7/prometheus/prometheus-server:2.27.1  e77db6e75e78  7b11062150ab
 </screen>
     <para>
      In this example, <literal>prometheus.master</literal> is the name and the

--- a/xml/deploy_bootstrap.xml
+++ b/xml/deploy_bootstrap.xml
@@ -661,9 +661,9 @@ podman run --name myregistry -p <option>REG_HOST_PORT</option>:5000 \
 <screen>
 skopeo inspect docker://registry.suse.com/ses/7/ceph/ceph | jq .RepoTags
 skopeo inspect docker://registry.suse.com/ses/7/ceph/grafana | jq .RepoTags
-skopeo inspect docker://registry.suse.com/caasp/v4.5/prometheus-server:2.18.0 | jq .RepoTags
-skopeo inspect docker://registry.suse.com/caasp/v4.5/prometheus-node-exporter:0.18.1 | jq .RepoTags
-skopeo inspect docker://registry.suse.com/caasp/v4.5/prometheus-alertmanager:0.16.2 | jq .RepoTags
+skopeo inspect docker://registry.suse.com/ses/7/prometheus/prometheus-server:2.27.1 | jq .RepoTags
+skopeo inspect docker://registry.suse.com/ses/7/prometheus/prometheus-node-exporter:1.1.2 | jq .RepoTags
+skopeo inspect docker://registry.suse.com/ses/7/prometheus/prometheus-alertmanager:0.21.0 | jq .RepoTags
 </screen>
       </example>
       <example>
@@ -688,9 +688,9 @@ skopeo inspect docker://registry.suse.com/caasp/v4.5/prometheus-alertmanager:0.1
       <example>
        <title>Synchronize latest &prometheus; images</title>
 <screen>
-skopeo sync --src docker --dest dir registry.suse.com/caasp/v4.5/prometheus-server:2.18.0 /root/images/
-skopeo sync --src docker --dest dir registry.suse.com/caasp/v4.5/prometheus-node-exporter:0.18.1 /root/images/
-skopeo sync --src docker --dest dir registry.suse.com/caasp/v4.5/prometheus-alertmanager:0.16.2 /root/images/
+skopeo sync --src docker --dest dir registry.suse.com/ses/7/prometheus/prometheus-server:2.27.1 /root/images/
+skopeo sync --src docker --dest dir registry.suse.com/ses/7/prometheus/prometheus-node-exporter:1.1.2 /root/images/
+skopeo sync --src docker --dest dir registry.suse.com/ses/7/prometheus/prometheus-alertmanager:0.21.0 /root/images/
 </screen>
       </example>
      </step>


### PR DESCRIPTION
In order to reflect changes in https://github.com/SUSE/ceph/pull/449

Prometheus server: ses/7/prometheus/prometheus-server:2.27.1
Node exporter: ses/7/prometheus/prometheus-node-exporter:1.1.2
Alertmanager: ses/7/prometheus/prometheus-alertmanager:0.21.0

Signed-off-by: Tatjana Dehler <tdehler@suse.com>