### PR TITLE
Adapt Prometheus Alertmanager SNMP documentation to new upstream solution

### DIFF
--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -477,12 +477,12 @@
   </para>
  </sect1>
  <sect1 xml:id="prometheus-webhook-snmp">
-  <title>&prometheus; &alertmanager; SNMP Gateway</title>
+  <title>&prometheus; &alertmanager; SNMP gateway</title>
 
   <para>
    If you want to get notified about &prometheus; alerts via SNMP traps, then
-   you can install the &prometheus; &alertmanager; SNMP Gateway via &cephadm;
-   or the Ceph Dashboard. To do so for SNMPv2c for example, you need to create
+   you can install the &prometheus; &alertmanager; SNMP gateway via &cephadm;
+   or the &dashboard;. To do so for SNMPv2c, for example, you need to create
    a service and placement specification file with the following content:
   </para>
 
@@ -506,7 +506,7 @@ spec:
 </screen>
 
   <para>
-   Alternatively you can use the Ceph Dashboard to deploy the SNMP Gateway
+   Alternatively, you can use the &dashboard; to deploy the SNMP gateway
    service for SNMPv2c and SNMPv3.
   </para>
  </sect1>

--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -507,7 +507,8 @@ spec:
 
   <para>
    Alternatively, you can use the &dashboard; to deploy the SNMP gateway
-   service for SNMPv2c and SNMPv3. For more details, refer to <xref linkend="dashboard-cluster-services"/>.
+   service for SNMPv2c and SNMPv3. For more details, refer to
+   <xref linkend="dashboard-cluster-services"/>.
   </para>
  </sect1>
 </chapter>

--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -482,8 +482,8 @@
   <para>
    If you want to get notified about &prometheus; alerts via SNMP traps, then
    you can install the &prometheus; &alertmanager; SNMP gateway via &cephadm;
-   or the &dashboard;. To do so for SNMPv2c, for example, you need to create
-   a service and placement specification file with the following content:
+   or the &dashboard;. To do so for SNMPv2c, for example, you need to create a
+   service and placement specification file with the following content:
   </para>
 
   <note>

--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -482,8 +482,8 @@
   <para>
    If you want to get notified about &prometheus; alerts via SNMP traps, then
    you can install the &prometheus; &alertmanager; SNMP Gateway via &cephadm;
-   or the Ceph Dashboard. To do so for SNMPv2c for example, you need to create a service and
-   placement specification file with the following content:
+   or the Ceph Dashboard. To do so for SNMPv2c for example, you need to create
+   a service and placement specification file with the following content:
   </para>
 
   <note>

--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -507,7 +507,7 @@ spec:
 
   <para>
    Alternatively, you can use the &dashboard; to deploy the SNMP gateway
-   service for SNMPv2c and SNMPv3.
+   service for SNMPv2c and SNMPv3. For more details, refer to <xref linkend="dashboard-cluster-services"/>.
   </para>
  </sect1>
 </chapter>

--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -477,13 +477,13 @@
   </para>
  </sect1>
  <sect1 xml:id="prometheus-webhook-snmp">
-  <title>&prometheus; &alertmanager; SNMP webhook</title>
+  <title>&prometheus; &alertmanager; SNMP Gateway</title>
 
   <para>
    If you want to get notified about &prometheus; alerts via SNMP traps, then
-   you can install the &prometheus; &alertmanager; SNMP webhook via &cephadm;.
-   To do so, you need to create a service and placement specification file with
-   the following content:
+   you can install the &prometheus; &alertmanager; SNMP Gateway via &cephadm;
+   or the Ceph Dashboard. To do so for SNMPv2c for example, you need to create a service and
+   placement specification file with the following content:
   </para>
 
   <note>
@@ -494,129 +494,20 @@
   </note>
 
 <screen>
-service_type: container
-service_id: prometheus-webhook-snmp
+service_type: snmp-gateway
+service_name: snmp-gateway
 placement:
     <replaceable>ADD_PLACEMENT_HERE</replaceable>
-image: registry.suse.com/ses/7/prometheus-webhook-snmp:latest
-args:
-    - "--publish 9099:9099"
-envs:
-    - ARGS="--debug --snmp-host=<replaceable>ADD_HOST_GATEWAY_HERE</replaceable>"
-    - RUN_ARGS="--metrics"
-EOF
+spec:
+  credentials:
+    snmp_community: <replaceable>ADD_COMMUNITY_STRING_HERE</replaceable>
+  snmp_destination: <replaceable>ADD_FQDN_HERE</replaceable>:<replaceable>ADD_PORT_HERE</replaceable>
+  snmp_version: V2c
 </screen>
 
   <para>
-   Use this service specification to get the service running using its default
-   settings.
+   Alternatively you can use the Ceph Dashboard to deploy the SNMP Gateway
+   service for SNMPv2c and SNMPv3.
   </para>
-
-  <para>
-   You need to publish the port the &prometheus; receiver is listening on by
-   using the command line argument <literal>--publish
-   <replaceable>HOST_PORT</replaceable>:<replaceable>CONTAINER_PORT</replaceable></literal>
-   when running the service, because the port is not exposed automatically by
-   the container. This can be done by adding the following lines to the
-   specification:
-  </para>
-
-<screen>
-args:
-    - "--publish 9099:9099"
-</screen>
-
-  <para>
-   Alternatively, connect the container to the host network by using the
-   command line argument <literal>--network=host</literal>.
-  </para>
-
-<screen>
-args:
-    - "--network=host"
-</screen>
-
-  <para>
-   If the SNMP trap receiver is not installed on the same host as the
-   container, then you must also specify the FQDN of the SNMP host. Use the
-   container's network gateway to be able to receive SNMP traps outside the
-   container/host:
-  </para>
-
-<screen>
-envs:
-    - ARGS="--debug --snmp-host=<replaceable>CONTAINER_GATEWAY</replaceable>"
-</screen>
-
-  <sect2 xml:id="configure-prometheus-webhook-snmp">
-   <title>Configuring the <literal>prometheus-webhook-snmp</literal> service</title>
-   <para>
-    The container can be configured by environment variables or by using a
-    configuration file.
-   </para>
-   <para>
-    For the environment variables, use <literal>ARGS</literal> to set global
-    options and <literal>RUN_ARGS</literal> for the <command>run</command>
-    command options. You need to adapt the service specification the following
-    way:
-   </para>
-<screen>
-envs:
-    - ARGS="--debug --snmp-host=<replaceable>CONTAINER_GATEWAY</replaceable>"
-    - RUN_ARGS="--metrics --port=9101"
-</screen>
-   <para>
-    To use a configuration file, the service specification must be adapted the
-    following way:
-   </para>
-<screen>
-files:
-    etc/prometheus-webhook-snmp.conf:
-        - "debug: True"
-        - "snmp_host: <replaceable>ADD_HOST_GATEWAY_HERE</replaceable>"
-        - "metrics: True"
-volume_mounts:
-    etc/prometheus-webhook-snmp.conf: /etc/prometheus-webhook-snmp.conf
-</screen>
-   <para>
-    To deploy, run the following command:
-   </para>
-<screen>&prompt.cephuser;ceph orch apply -i <replaceable>SERVICE_SPEC_FILE</replaceable></screen>
-   <para>
-    See <xref linkend="deploy-cephadm-day2-services"/> for more information.
-   </para>
-  </sect2>
-
-  <sect2 xml:id="configure-prometheus-alertmanager-for-snmp">
-   <title>Configuring the &prometheus; &alertmanager; for SNMP</title>
-   <para>
-    Finally, the &prometheus; &alertmanager; needs to be configured
-    specifically for SNMP traps. If this service has not been deployed already,
-    create a service specification file. You need to replace
-    <literal>IP_OR_FQDN</literal> with the IP address or FQDN of the host where
-    the &prometheus; &alertmanager; SNMP webhook has been installed. For
-    example:
-   </para>
-   <note>
-    <para>
-     If you have already deployed this service, then to ensure the
-     &alertmanager; is set up correctly for SNMP, re-deploy with the following
-     settings.
-    </para>
-   </note>
-<screen>
-  service_type: alertmanager
-  placement:
-    hosts:
-    - <replaceable>HOSTNAME</replaceable>
-  user_data:
-    default_webhook_urls:
-    - 'http://<replaceable>IP_OR_FQDN</replaceable>:9099/'
-</screen>
-   <para>
-    Apply the service specification with the following command:
-   </para>
-<screen>&prompt.cephuser;ceph orch apply -i <replaceable>SERVICE_SPEC_FILE</replaceable></screen>
-  </sect2>
  </sect1>
 </chapter>


### PR DESCRIPTION
Adapt Prometheus Alertmanager SNMP Gateway setup to new upstream solution in SES7.1 (Pacific). This should give us less support effort.

@tbazant Please feel free to cherry-pick this PR/commit to add your changes in a separate PR.

Maybe it is possible to add those screenshots to the documentation, too.
![snmp_v2](https://user-images.githubusercontent.com/1897962/157064917-33ae9bb1-bcae-4722-9afb-83904c9e7e08.png)
![snmp_v3](https://user-images.githubusercontent.com/1897962/157064925-5fe74391-7930-4197-8e3c-095f73c6348c.png)

