### PR TITLE
Add a note to 'Debugging the Ceph Dashboard flag'

### DIFF
--- a/xml/bp_troubleshooting_dashboard.xml
+++ b/xml/bp_troubleshooting_dashboard.xml
@@ -247,6 +247,11 @@ Error ENOENT: User <replaceable>USERNAME</replaceable> does not exist
 <screen>
 &prompt.cephuser;ceph dashboard debug enable
 </screen>
+   <note>
+    <para>
+     Activating the debug flag temporarily causes a <literal>HEALTH_WARN</literal> cluster state.
+    </para>
+   </note>
   </sect2>
 
   <sect2 xml:id="setting-log-level-dashboard-module">

--- a/xml/bp_troubleshooting_dashboard.xml
+++ b/xml/bp_troubleshooting_dashboard.xml
@@ -249,7 +249,8 @@ Error ENOENT: User <replaceable>USERNAME</replaceable> does not exist
 </screen>
    <note>
     <para>
-     Activating the debug flag temporarily causes a <literal>HEALTH_WARN</literal> cluster state.
+     Activating the debug flag temporarily causes a
+     <literal>HEALTH_WARN</literal> cluster state.
     </para>
    </note>
   </sect2>


### PR DESCRIPTION
Activating the debug flag temporarily causes a HEALTH_WARN cluster state.

Signed-off-by: Volker Theile <vtheile@suse.com>