### PR TITLE
Update container image paths to point to `ceph` instead of `prometheus`

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -357,17 +357,17 @@
      </listitem>
      <listitem>
       <para>
-       registry.suse.com/ses/7/prometheus/prometheus-server
+       registry.suse.com/ses/7/ceph/prometheus-server
       </para>
      </listitem>
      <listitem>
       <para>
-       registry.suse.com/ses/7/prometheus/prometheus-node-exporter
+       registry.suse.com/ses/7/ceph/prometheus-node-exporter
       </para>
      </listitem>
      <listitem>
       <para>
-       registry.suse.com/ses/7/prometheus/prometheus-alertmanager
+       registry.suse.com/ses/7/ceph/prometheus-alertmanager
       </para>
      </listitem>
     </itemizedlist>
@@ -781,9 +781,9 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
       to specify the image to use on each command, for example:
      </para>
 <screen>
-&prompt.cephuser;cephadm --image 192.168.121.1:5000/ses/7/prometheus/prometheus-server:2.27.1 \
+&prompt.cephuser;cephadm --image 192.168.121.1:5000/ses/7/ceph/prometheus-server:2.27.1 \
   adopt --style=legacy --name prometheus.$(hostname)
-&prompt.cephuser;cephadm --image 192.168.121.1:5000/ses/7/prometheus/prometheus-alertmanager:0.21.0 \
+&prompt.cephuser;cephadm --image 192.168.121.1:5000/ses/7/ceph/prometheus-alertmanager:0.21.0 \
   adopt --style=legacy --name alertmanager.$(hostname)
 &prompt.cephuser;cephadm --image 192.168.121.1:5000/ses/7/ceph/grafana:7.3.1 \
  adopt --style=legacy --name grafana.$(hostname)

--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -172,17 +172,17 @@
   <itemizedlist>
    <listitem>
     <para>
-     registry.suse.com/ses/7/prometheus/prometheus-server:2.27.1
+     registry.suse.com/ses/7/ceph/prometheus-server:2.27.1
     </para>
    </listitem>
    <listitem>
     <para>
-     registry.suse.com/ses/7/prometheus/prometheus-node-exporter:1.1.2
+     registry.suse.com/ses/7/ceph/prometheus-node-exporter:1.1.2
     </para>
    </listitem>
    <listitem>
     <para>
-     registry.suse.com/ses/7/prometheus/prometheus-alertmanager:0.21.0
+     registry.suse.com/ses/7/ceph/prometheus-alertmanager:0.21.0
     </para>
    </listitem>
    <listitem>

--- a/xml/bp_troubleshooting_cephadm.xml
+++ b/xml/bp_troubleshooting_cephadm.xml
@@ -90,7 +90,7 @@
 <screen>
 &prompt.cephuser;ceph orch ps --daemon-type prometheus
 NAME               HOST    STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                                                   IMAGE ID      CONTAINER ID
-prometheus.master  master  running (65m)  7m ago     2h   2.27.1   registry.suse.com/ses/7/prometheus/prometheus-server:2.27.1  e77db6e75e78  7b11062150ab
+prometheus.master  master  running (65m)  7m ago     2h   2.27.1   registry.suse.com/ses/7/ceph/prometheus-server:2.27.1  e77db6e75e78  7b11062150ab
 </screen>
     <para>
      In this example, <literal>prometheus.master</literal> is the name and the

--- a/xml/deploy_bootstrap.xml
+++ b/xml/deploy_bootstrap.xml
@@ -667,9 +667,9 @@ podman run --name myregistry -p <option>REG_HOST_PORT</option>:5000 \
 <screen>
 skopeo inspect docker://registry.suse.com/ses/7/ceph/ceph | jq .RepoTags
 skopeo inspect docker://registry.suse.com/ses/7/ceph/grafana | jq .RepoTags
-skopeo inspect docker://registry.suse.com/ses/7/prometheus/prometheus-server:2.27.1 | jq .RepoTags
-skopeo inspect docker://registry.suse.com/ses/7/prometheus/prometheus-node-exporter:1.1.2 | jq .RepoTags
-skopeo inspect docker://registry.suse.com/ses/7/prometheus/prometheus-alertmanager:0.21.0 | jq .RepoTags
+skopeo inspect docker://registry.suse.com/ses/7/ceph/prometheus-server:2.27.1 | jq .RepoTags
+skopeo inspect docker://registry.suse.com/ses/7/ceph/prometheus-node-exporter:1.1.2 | jq .RepoTags
+skopeo inspect docker://registry.suse.com/ses/7/ceph/prometheus-alertmanager:0.21.0 | jq .RepoTags
 </screen>
       </example>
       <example>
@@ -694,9 +694,9 @@ skopeo inspect docker://registry.suse.com/ses/7/prometheus/prometheus-alertmanag
       <example>
        <title>Synchronize latest &prometheus; images</title>
 <screen>
-skopeo sync --src docker --dest dir registry.suse.com/ses/7/prometheus/prometheus-server:2.27.1 /root/images/
-skopeo sync --src docker --dest dir registry.suse.com/ses/7/prometheus/prometheus-node-exporter:1.1.2 /root/images/
-skopeo sync --src docker --dest dir registry.suse.com/ses/7/prometheus/prometheus-alertmanager:0.21.0 /root/images/
+skopeo sync --src docker --dest dir registry.suse.com/ses/7/ceph/prometheus-server:2.27.1 /root/images/
+skopeo sync --src docker --dest dir registry.suse.com/ses/7/ceph/prometheus-node-exporter:1.1.2 /root/images/
+skopeo sync --src docker --dest dir registry.suse.com/ses/7/ceph/prometheus-alertmanager:0.21.0 /root/images/
 </screen>
       </example>
      </step>


### PR DESCRIPTION
Signed-off-by: Patrick Seidensal <pseidensal@suse.com>