### PR TITLE
NFS Ganesha mgr module mandatory (re-)enable after installation/upgrade to Pacific

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -958,6 +958,7 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
   <sect2 xml:id="upgrade-ganesha">
    <title>Upgrading &ganesha;</title>
    &ganesha_support;
+   &ganesha_mgr_module;
    <para>
     The following demonstrates how to migrate an existing &ganesha; service
     running &ceph; Nautilus to an &ganesha; container running &ceph; Octopus.

--- a/xml/deploy_core.xml
+++ b/xml/deploy_core.xml
@@ -776,6 +776,12 @@ spec:
      </para>
     </listitem>
    </itemizedlist>
+
+    <para>
+     Enable the <literal>nfs</literal> module in the &mgr; daemon. This allows to define NFS exports 
+     through the NFS section in the &dashboard;:
+    </para>
+    <screen>&prompt.cephuser;ceph mgr module enable nfs</screen>
   </sect2>
 
   <sect2 xml:id="deploy-cephadm-day2-service-rbdmirror">

--- a/xml/deploy_core.xml
+++ b/xml/deploy_core.xml
@@ -778,7 +778,7 @@ spec:
    </itemizedlist>
 
     <para>
-     Enable the <literal>nfs</literal> module in the &mgr; daemon. This allows to define NFS exports 
+     Enable the <literal>nfs</literal> module in the &mgr; daemon. This allows defining NFS exports 
      through the NFS section in the &dashboard;:
     </para>
     <screen>&prompt.cephuser;ceph mgr module enable nfs</screen>

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -121,7 +121,7 @@
  <para>
   The upgrade process disables the <literal>nfs</literal> module in the &mgr; daemon. 
   You can re-enable it by executing the following command from the &adm;:
-  <screen>&prompt.cephuser;ceph mgr module enable nfs</screen>
+<screen>&prompt.cephuser;ceph mgr module enable nfs</screen>
  </para>
 </important>
 '>

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -115,3 +115,13 @@
  </para>
 </important>
 '>
+
+<!ENTITY ganesha_mgr_module  '
+<important xmlns="http://docbook.org/ns/docbook">
+ <para>
+  The upgrade process disables the <literal>nfs</literal> module in the &mgr; daemon. 
+  You can re-enable it by executing the following command from the &adm;:
+  <screen>&prompt.cephuser;ceph mgr module enable nfs</screen>
+ </para>
+</important>
+'>

--- a/xml/upgrade-to-pacific.xml
+++ b/xml/upgrade-to-pacific.xml
@@ -233,4 +233,14 @@
 
 <screen>&prompt.cephuser;ceph orch upgrade start --image registry.suse.com/ses/7.1/ceph/ceph</screen>
  </sect1>
+
+ <sect1 xml:id="upgrade-gateways-7p">
+  <title>Gateway service upgrade</title>
+
+  <sect2 xml:id="upgrade-ganesha-7p">
+   <title>Upgrading &ganesha;</title>
+      &ganesha_mgr_module;
+  </sect2>
+ </sect1>
+
 </chapter>


### PR DESCRIPTION
Hi @tbazant,
This is my proposal for bz#1197250.
There are 3 changes that cover 3 different scenarios when dealing with 7.1 and NFS mgr module:

1. clean installation of 7.1
2. upgrade from 6
3. upgrade from 7

For the 1. the modification is simply a normal step one must do after he completed the Ganesha service installation.
For cases 2. and 3. otherwise, this note has been rendered as an _Important_ box; this choice has been done to remark the fact that the upgrading process has actually broken something and you need to do an action to restore it.

I have also a note by @l-mb:
_This overlaps with bz#1197667 which is a section we can reference in the release notes then._


Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>