### PR TITLE
Use suse2022-ns stylesheets for SES en-us

### DIFF
--- a/DC-ses-admin
+++ b/DC-ses-admin
@@ -12,7 +12,7 @@ PROFOS="sles"
 PROFCONDITION="suse-product"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 
 ### Sort the glossary
 XSLTPARAM="--param glossary.sort=1"

--- a/DC-ses-all
+++ b/DC-ses-all
@@ -11,7 +11,7 @@ PROFOS="sles"
 PROFCONDITION="suse-product"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 
 ### Sort the glossary
 XSLTPARAM="--param glossary.sort=1"

--- a/DC-ses-deployment
+++ b/DC-ses-deployment
@@ -12,7 +12,7 @@ PROFOS="sles"
 PROFCONDITION="suse-product"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 
 ### Sort the glossary
 XSLTPARAM="--param glossary.sort=1"

--- a/DC-ses-man
+++ b/DC-ses-man
@@ -12,7 +12,7 @@ PROFOS="sles"
 PROFCONDITION="suse-product"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 
 ### Sort the glossary
 XSLTPARAM="--param glossary.sort=1"

--- a/DC-ses-rook
+++ b/DC-ses-rook
@@ -12,7 +12,7 @@ PROFOS="sles"
 PROFCONDITION="suse-product"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 
 ### Sort the glossary
 XSLTPARAM="--param glossary.sort=1"

--- a/DC-ses-security
+++ b/DC-ses-security
@@ -12,7 +12,7 @@ PROFOS="sles"
 PROFCONDITION="suse-product"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 
 ### Sort the glossary
 XSLTPARAM="--param glossary.sort=1"

--- a/DC-ses-troubleshooting
+++ b/DC-ses-troubleshooting
@@ -12,7 +12,7 @@ PROFOS="sles"
 PROFCONDITION="suse-product"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 
 ### Sort the glossary
 XSLTPARAM="--param glossary.sort=1"

--- a/DC-ses-windows
+++ b/DC-ses-windows
@@ -12,7 +12,7 @@ PROFOS="sles"
 PROFCONDITION="suse-product"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 
 ### Sort the glossary
 #XSLTPARAM="--param glossary.sort=1"


### PR DESCRIPTION
### Description

We want to switch to the new 3-column layout. This PR uses the new stylesheets.


### Which product versions do the changes apply to?

* [x] `main` (main): 
* [x] `maintenance/ses7`: 
* [x] `maintenance/ses6`: 
* [x] `maintenance/ses5`: 
