### PR TITLE
rgw_frontend_ssl_key is removed after upgrade to Pacific (bsc#0120319)

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -629,19 +629,6 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
    </listitem>
   </itemizedlist>
 
-  <important>
-   <para>
-    To successfully upgrade the &mds;, ensure you reduce the &mds; to 1.
-   </para>
-   <para>
-    Run <command>salt-run upgrade.status</command> to ensure that all &mds;s on
-    standby are stopped.
-   </para>
-   <para>
-    Ensure you stop the &mds; before upgrading the &mon; nodes as it may
-    otherwise result in a failed quorum.
-   </para>
-  </important>
 
   <para>
    This step also applies to any nodes that are part of the cluster, but do not
@@ -657,10 +644,37 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
    mode at the end of the upgrade procedure.
   </para>
 
+  <important>
+   <para>
+    To successfully upgrade the &mds;, ensure you reduce the &mds; to 1.
+   </para>
+   <para>
+    Run <command>salt-run upgrade.status</command> to ensure that all &mds;s on
+    standby are stopped.
+   </para>
+   <para>
+    Ensure you stop the &mds; before upgrading the &mon; nodes as it may
+    otherwise result in a failed quorum.
+   </para>
+  </important>
+
   <note>
    <para>
     &mds; and &ogw; services are unavailable from the time of upgrading to
     &cephos; until they are redeployed at the end of the upgrade procedure.
+   </para>
+  </note>
+
+  <note>
+   <para>
+    &productname; &productnumber; does not use the
+    <option>rgw_frontend_ssl_key</option> option. Instead, both the SSL key and
+    certificate are concatenated under the
+    <option>rgw_frontend_ssl_certificate</option> option.  If the &ogw;
+    deployment uses the <option>rgw_frontend_ssl_key</option> option, it will
+    not be available after the upgrade to &productname; &productnumber;.  Refer
+    to <xref linkend="cephadm-deploy-using-secure-ssl-access"/> for more
+    details.
    </para>
   </note>
  </sect1>

--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -672,7 +672,7 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
     certificate are concatenated under the
     <option>rgw_frontend_ssl_certificate</option> option. If the &ogw;
     deployment uses the <option>rgw_frontend_ssl_key</option> option, it will
-    not be available after the upgrade to &productname; &productnumber;.  Refer
+    not be available after the upgrade to &productname; &productnumber;. Refer
     to <xref linkend="cephadm-deploy-using-secure-ssl-access"/> for more
     details.
    </para>

--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -670,7 +670,7 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
     &productname; &productnumber; does not use the
     <option>rgw_frontend_ssl_key</option> option. Instead, both the SSL key and
     certificate are concatenated under the
-    <option>rgw_frontend_ssl_certificate</option> option.  If the &ogw;
+    <option>rgw_frontend_ssl_certificate</option> option. If the &ogw;
     deployment uses the <option>rgw_frontend_ssl_key</option> option, it will
     not be available after the upgrade to &productname; &productnumber;.  Refer
     to <xref linkend="cephadm-deploy-using-secure-ssl-access"/> for more


### PR DESCRIPTION
`rgw_frontend_ssl_key` is obsolete in SES 7.1, both SSL strings are now part of `rgw_frontend_ssl_certificate`

fixes https://bugzilla.suse.com/show_bug.cgi?id=1200319