### PR TITLE
rgw_frontend_ssl_key is removed after upgrade to Pacific (bsc#1200319)

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -665,7 +665,7 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
    </para>
   </note>
 
-  <important xmlns="http://docbook.org/ns/docbook">
+  <important>
     <para>
     &productname; &productnumber; does not use the
     <option>rgw_frontend_ssl_key</option> option. Instead, both the SSL key and

--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -665,18 +665,21 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
    </para>
   </note>
 
-  <note>
-   <para>
+  <important xmlns="http://docbook.org/ns/docbook">
+    <para>
     &productname; &productnumber; does not use the
     <option>rgw_frontend_ssl_key</option> option. Instead, both the SSL key and
     certificate are concatenated under the
     <option>rgw_frontend_ssl_certificate</option> option. If the &ogw;
     deployment uses the <option>rgw_frontend_ssl_key</option> option, it will
-    not be available after the upgrade to &productname; &productnumber;. Refer
-    to <xref linkend="cephadm-deploy-using-secure-ssl-access"/> for more
+    not be available after the upgrade to &productname; &productnumber;.
+    In this case, the &ogw; must be redeployed with the
+    <option>rgw_frontend_ssl_certificate</option> option.
+    Refer to <xref linkend="cephadm-deploy-using-secure-ssl-access"/> for more
     details.
    </para>
-  </note>
+  </important>
+
  </sect1>
  <sect1 xml:id="upgrade-cephsalt">
   <title>Installing &cephsalt; and applying the cluster configuration</title>

--- a/xml/upgrade-to-pacific.xml
+++ b/xml/upgrade-to-pacific.xml
@@ -252,6 +252,24 @@
  <sect1 xml:id="upgrade-gateways-7p">
   <title>Gateway service upgrade</title>
 
+ <sect2 xml:id="upgrade-object-gateway-7p">
+ <title>Upgrading Object Gateway</title>
+   <important xmlns="http://docbook.org/ns/docbook">
+    <para>
+     &productname; &productnumber; does not use the
+     <option>rgw_frontend_ssl_key</option> option. Instead, both the SSL key and
+     certificate are concatenated under the
+     <option>rgw_frontend_ssl_certificate</option> option. If the &ogw;
+     deployment uses the <option>rgw_frontend_ssl_key</option> option, it will
+     not be available after the upgrade to &productname; &productnumber;.
+     In this case, the &ogw; must be redeployed with the
+     <option>rgw_frontend_ssl_certificate</option> option.
+     Refer to <xref linkend="cephadm-deploy-using-secure-ssl-access"/> for more
+     details.
+    </para>
+   </important>
+  </sect2>
+
   <sect2 xml:id="upgrade-ganesha-7p">
    <title>Upgrading &ganesha;</title>
       &ganesha_mgr_module;

--- a/xml/upgrade-to-pacific.xml
+++ b/xml/upgrade-to-pacific.xml
@@ -253,7 +253,7 @@
   <title>Gateway service upgrade</title>
 
  <sect2 xml:id="upgrade-object-gateway-7p">
- <title>Upgrading Object Gateway</title>
+ <title>Upgrading the &ogw;</title>
    <important xmlns="http://docbook.org/ns/docbook">
     <para>
      &productname; &productnumber; does not use the

--- a/xml/upgrade-to-pacific.xml
+++ b/xml/upgrade-to-pacific.xml
@@ -254,7 +254,7 @@
 
  <sect2 xml:id="upgrade-object-gateway-7p">
  <title>Upgrading the &ogw;</title>
-   <important xmlns="http://docbook.org/ns/docbook">
+   <important>
     <para>
      &productname; &productnumber; does not use the
      <option>rgw_frontend_ssl_key</option> option. Instead, both the SSL key and


### PR DESCRIPTION
- Changed format from Note to Important
- Information added also in upgrade-to-pacific.xml

Fixes: bsc#1200319
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>