### PR TITLE
Revert "Removed dangerous option during upgrade (bsc#1200883)"

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -516,7 +516,6 @@ Nodes running older software versions must be upgraded in the following order:
   </para>
 
   <procedure>
-   <!-- 2022-06-27 tbazant: not valid yet, see bsc#1200883
    <step>
     <para>
      Before adopting any OSD node, you need to perform a format conversion of
@@ -537,7 +536,6 @@ Nodes running older software versions must be upgraded in the following order:
      </para>
     </note>
    </step>
-   -->
    <step>
     <para>
      If the node you are upgrading is an OSD node, avoid having the OSD marked


### PR DESCRIPTION
Setting bluestore_fsck_quick_fix_on_mount true in 16.2.7 has been okayed by @tserong 