### PR TITLE
Update monitoring container images

### DIFF
--- a/xml/admin_ceph_upgrade.xml
+++ b/xml/admin_ceph_upgrade.xml
@@ -390,10 +390,10 @@
 
   <important>
     <para>
-      Before continuing, ensure the steps have been followed 
-      from <xref linkend="deploy-cephadm-configure-imagepath"/>. 
+      Before continuing, ensure the steps have been followed
+      from <xref linkend="deploy-cephadm-configure-imagepath"/>.
       Without this configuration, the podman image pull fails in
-      &cephadm;, but will succeed in the terminal if the customer 
+      &cephadm;, but will succeed in the terminal if the customer
       sets the following variables:
     </para>
 <screen>
@@ -906,9 +906,9 @@ ID   CLASS  WEIGHT   TYPE NAME       STATUS  REWEIGHT  PRI-AFF
 <screen>
 &prompt.cephuser;cephadm --image 192.168.121.1:5000/ses/7.1/ceph/prometheus-server:2.32.1 \
   adopt --style=legacy --name prometheus.$(hostname)
-&prompt.cephuser;cephadm --image 192.168.121.1:5000/ses/7.1/ceph/prometheus-alertmanager:0.21.0 \
+&prompt.cephuser;cephadm --image 192.168.121.1:5000/ses/7.1/ceph/prometheus-alertmanager:0.23.0 \
   adopt --style=legacy --name alertmanager.$(hostname)
-&prompt.cephuser;cephadm --image 192.168.121.1:5000/ses/7.1/ceph/grafana:7.5.12 \
+&prompt.cephuser;cephadm --image 192.168.121.1:5000/ses/7.1/ceph/grafana:8.3.10 \
  adopt --style=legacy --name grafana.$(hostname)
 </screen>
      <para>

--- a/xml/admin_monitoring_alerting.xml
+++ b/xml/admin_monitoring_alerting.xml
@@ -177,17 +177,17 @@
    </listitem>
    <listitem>
     <para>
-     registry.suse.com/ses/7.1/ceph/prometheus-node-exporter:1.1.2
+     registry.suse.com/ses/7.1/ceph/prometheus-node-exporter:1.3.0
     </para>
    </listitem>
    <listitem>
     <para>
-     registry.suse.com/ses/7.1/ceph/prometheus-alertmanager:0.21.0
+     registry.suse.com/ses/7.1/ceph/prometheus-alertmanager:0.23.0
     </para>
    </listitem>
    <listitem>
     <para>
-     registry.suse.com/ses/7.1/ceph/grafana:7.5.12
+     registry.suse.com/ses/7.1/ceph/grafana:8.3.10
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/deploy_bootstrap.xml
+++ b/xml/deploy_bootstrap.xml
@@ -913,10 +913,10 @@ env = ["https_proxy=http://some.url.example.com:8080",
   docker://registry.suse.com/ses/7.1/ceph/prometheus-server:2.32.1 | \
   jq .RepoTags
 &prompt.user;skopeo inspect \
-  docker://registry.suse.com/ses/7.1/ceph/prometheus-node-exporter:1.1.2 | \
+  docker://registry.suse.com/ses/7.1/ceph/prometheus-node-exporter:1.3.0 | \
   jq .RepoTags
 &prompt.user;skopeo inspect \
-  docker://registry.suse.com/ses/7.1/ceph/prometheus-alertmanager:0.21.0 | \
+  docker://registry.suse.com/ses/7.1/ceph/prometheus-alertmanager:0.23.0 | \
   jq .RepoTags
 &prompt.user;skopeo inspect \
   docker://registry.suse.com/ses/7.1/ceph/haproxy:2.0.14 | jq .RepoTags
@@ -957,25 +957,25 @@ env = ["https_proxy=http://some.url.example.com:8080",
   REG_HOST_FQDN:5000/ses/7.1/ceph/ceph:latest
 &prompt.root;podman push REG_HOST_FQDN:5000/ses/7.1/ceph/ceph:latest
 
-&prompt.root;podman pull registry.suse.com/ses/7.1/ceph/grafana:7.5.12
-&prompt.root;podman tag registry.suse.com/ses/7.1/ceph/grafana:7.5.12 \
-  REG_HOST_FQDN:5000/ses/7.1/ceph/grafana:7.5.12
-&prompt.root;podman push REG_HOST_FQDN:5000/ses/7.1/ceph/grafana:7.5.12
+&prompt.root;podman pull registry.suse.com/ses/7.1/ceph/grafana:8.3.10
+&prompt.root;podman tag registry.suse.com/ses/7.1/ceph/grafana:8.3.10 \
+  REG_HOST_FQDN:5000/ses/7.1/ceph/grafana:8.3.10
+&prompt.root;podman push REG_HOST_FQDN:5000/ses/7.1/ceph/grafana:8.3.10
 
 &prompt.root;podman pull registry.suse.com/ses/7.1/ceph/prometheus-server:2.32.1
 &prompt.root;podman tag registry.suse.com/ses/7.1/ceph/prometheus-server:2.32.1 \
   REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-server:2.32.1
 &prompt.root;podman push REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-server:2.32.1
 
-&prompt.root;podman pull registry.suse.com/ses/7.1/ceph/prometheus-alertmanager:0.21.0
-&prompt.root;podman tag registry.suse.com/ses/7.1/ceph/prometheus-alertmanager:0.21.0 \
-  REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-alertmanager:0.21.0
-&prompt.root;podman push REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-alertmanager:0.21.0
+&prompt.root;podman pull registry.suse.com/ses/7.1/ceph/prometheus-alertmanager:0.23.0
+&prompt.root;podman tag registry.suse.com/ses/7.1/ceph/prometheus-alertmanager:0.23.0 \
+  REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-alertmanager:0.23.0
+&prompt.root;podman push REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-alertmanager:0.23.0
 
-&prompt.root;podman pull registry.suse.com/ses/7.1/ceph/prometheus-node-exporter:1.1.2
-&prompt.root;podman tag registry.suse.com/ses/7.1/ceph/prometheus-node-exporter:1.1.2 \
-  REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-node-exporter:1.1.2
-&prompt.root;podman push REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-node-exporter:1.1.2
+&prompt.root;podman pull registry.suse.com/ses/7.1/ceph/prometheus-node-exporter:1.3.0
+&prompt.root;podman tag registry.suse.com/ses/7.1/ceph/prometheus-node-exporter:1.3.0 \
+  REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-node-exporter:1.3.0
+&prompt.root;podman push REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-node-exporter:1.3.0
 
 &prompt.root;podman pull registry.suse.com/ses/7.1/ceph/haproxy:2.0.14
 &prompt.root;podman tag registry.suse.com/ses/7.1/ceph/haproxy:2.0.14 \
@@ -1024,15 +1024,15 @@ env = ["https_proxy=http://some.url.example.com:8080",
 &prompt.user;skopeo inspect \
   docker://REG_HOST_FQDN:5000/ses/7.1/ceph/ceph | jq .RepoTags
 &prompt.user;skopeo inspect \
-  docker://REG_HOST_FQDN:5000/ses/7.1/ceph/grafana:7.5.12 | jq .RepoTags
+  docker://REG_HOST_FQDN:5000/ses/7.1/ceph/grafana:8.3.10 | jq .RepoTags
 &prompt.user;skopeo inspect \
   docker://REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-server:2.32.1 | \
   jq .RepoTags
 &prompt.user;skopeo inspect \
-  docker://REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-alertmanager:0.21.0 | \
+  docker://REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-alertmanager:0.23.0 | \
   jq .RepoTags
 &prompt.user;skopeo inspect \
-  docker://REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-node-exporter:1.1.2 | \
+  docker://REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-node-exporter:1.3.0 | \
   jq .RepoTags
 &prompt.user;skopeo inspect \
   docker://REG_HOST_FQDN:5000/ses/7.1/ceph/haproxy:2.0.14 | jq .RepoTags
@@ -1133,15 +1133,15 @@ ceph config set global container_image
               </para>
 <screen>
 &prompt.cephuser;ceph config set mgr mgr/cephadm/container_image_alertmanager \
-  REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-alertmanager:0.21.0
+  REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-alertmanager:0.23.0
 &prompt.cephuser;ceph config set mgr mgr/cephadm/container_image_grafana \
-  REG_HOST_FQDN:5000/ses/7.1/ceph/grafana:7.5.12
+  REG_HOST_FQDN:5000/ses/7.1/ceph/grafana:8.3.10
 &prompt.cephuser;ceph config set mgr mgr/cephadm/container_image_haproxy \
   REG_HOST_FQDN:5000/ses/7.1/ceph/haproxy:2.0.14
 &prompt.cephuser;ceph config set mgr mgr/cephadm/container_image_keepalived \
   REG_HOST_FQDN:5000/ses/7.1/ceph/keepalived:2.0.19
 &prompt.cephuser;ceph config set mgr mgr/cephadm/container_image_node_exporter \
-  REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-node-exporter:1.1.2
+  REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-node-exporter:1.3.0
 &prompt.cephuser;ceph config set mgr mgr/cephadm/container_image_prometheus \
   REG_HOST_FQDN:5000/ses/7.1/ceph/prometheus-server:2.32.1
 &prompt.cephuser;ceph config set mgr mgr/cephadm/container_image_snmp_gateway \


### PR DESCRIPTION
This is a draft PR. I'll change this as soon as https://github.com/SUSE/ceph/pull/493 has been merged.

In order to reflect changes in https://github.com/SUSE/ceph/pull/493

Node exporter: registry.suse.com/ses/7.1/ceph/prometheus-node-exporter:1.3.0 Alertmanager: registry.suse.com/ses/7.1/ceph/prometheus-alertmanager:0.23.0 Grafana: registry.suse.com/ses/7.1/ceph/grafana:8.3.10

Signed-off-by: Tatjana Dehler <tdehler@suse.com>